### PR TITLE
Locking optimization / performance improvement

### DIFF
--- a/common.h
+++ b/common.h
@@ -87,6 +87,7 @@
 #include <math.h>
 #include <mysql.h>
 #include <netdb.h>
+#include <semaphore.h>
 #include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/locks.c
+++ b/locks.c
@@ -52,7 +52,6 @@ DEFINE_SPINE_LOCK(snmp)
 DEFINE_SPINE_LOCK(thread)
 DEFINE_SPINE_LOCK(seteuid)
 DEFINE_SPINE_LOCK(ghbn)
-DEFINE_SPINE_LOCK(pipe)
 DEFINE_SPINE_LOCK(syslog)
 DEFINE_SPINE_LOCK(php)
 DEFINE_SPINE_LOCK(php_proc_0)
@@ -71,7 +70,6 @@ void init_mutexes() {
 	pthread_once((pthread_once_t*) get_attr(LOCK_THREAD_O),     init_thread_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_SETEUID_O),    init_seteuid_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_GHBN_O),       init_ghbn_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PIPE_O),       init_pipe_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_SYSLOG_O),     init_syslog_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_O),        init_php_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_0_O), init_php_proc_0_lock);
@@ -94,7 +92,6 @@ pthread_mutex_t* get_lock(int lock) {
 	case LOCK_THREAD:     ret_val = &thread_lock;     break;
 	case LOCK_SETEUID:    ret_val = &seteuid_lock;    break;
 	case LOCK_GHBN:       ret_val = &ghbn_lock;       break;
-	case LOCK_PIPE:       ret_val = &pipe_lock;       break;
 	case LOCK_SYSLOG:     ret_val = &syslog_lock;     break;
 	case LOCK_PHP:        ret_val = &php_lock;        break;
 	case LOCK_PHP_PROC_0: ret_val = &php_proc_0_lock; break;
@@ -120,7 +117,6 @@ pthread_once_t* get_attr(int locko) {
 	case LOCK_THREAD_O:     ret_val = &thread_lock_o;     break;
 	case LOCK_SETEUID_O:    ret_val = &seteuid_lock_o;    break;
 	case LOCK_GHBN_O:       ret_val = &ghbn_lock_o;       break;
-	case LOCK_PIPE_O:       ret_val = &pipe_lock_o;       break;
 	case LOCK_SYSLOG_O:     ret_val = &syslog_lock_o;     break;
 	case LOCK_PHP_O:        ret_val = &php_lock_o;        break;
 	case LOCK_PHP_PROC_0_O: ret_val = &php_proc_0_lock_o; break;

--- a/locks.c
+++ b/locks.c
@@ -49,7 +49,6 @@
 	}
 
 DEFINE_SPINE_LOCK(snmp)
-DEFINE_SPINE_LOCK(thread)
 DEFINE_SPINE_LOCK(seteuid)
 DEFINE_SPINE_LOCK(ghbn)
 DEFINE_SPINE_LOCK(syslog)
@@ -67,7 +66,6 @@ DEFINE_SPINE_LOCK(php_proc_9)
 
 void init_mutexes() {
 	pthread_once((pthread_once_t*) get_attr(LOCK_SNMP_O),       init_snmp_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_THREAD_O),     init_thread_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_SETEUID_O),    init_seteuid_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_GHBN_O),       init_ghbn_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_SYSLOG_O),     init_syslog_lock);
@@ -89,7 +87,6 @@ pthread_mutex_t* get_lock(int lock) {
 
 	switch (lock) {
 	case LOCK_SNMP:       ret_val = &snmp_lock;       break;
-	case LOCK_THREAD:     ret_val = &thread_lock;     break;
 	case LOCK_SETEUID:    ret_val = &seteuid_lock;    break;
 	case LOCK_GHBN:       ret_val = &ghbn_lock;       break;
 	case LOCK_SYSLOG:     ret_val = &syslog_lock;     break;
@@ -114,7 +111,6 @@ pthread_once_t* get_attr(int locko) {
 
 	switch (locko) {
 	case LOCK_SNMP_O:       ret_val = &snmp_lock_o;       break;
-	case LOCK_THREAD_O:     ret_val = &thread_lock_o;     break;
 	case LOCK_SETEUID_O:    ret_val = &seteuid_lock_o;    break;
 	case LOCK_GHBN_O:       ret_val = &ghbn_lock_o;       break;
 	case LOCK_SYSLOG_O:     ret_val = &syslog_lock_o;     break;

--- a/poller.c
+++ b/poller.c
@@ -59,9 +59,10 @@ void *child(void *arg) {
 	host_time_double = poller_details.host_time_double;
 	snprintf(host_time, SMALL_BUFSIZE, "%s", poller_details.host_time);
 
-	free(arg);
+	/* Allows main thread to proceed with creation of other threads */
+	sem_post(poller_details.thread_init_sem);
 
-	thread_ready = TRUE;
+	free(arg);
 
 	SPINE_LOG_DEBUG(("DEBUG: In Poller, About to Start Polling of Host"));
 

--- a/poller.c
+++ b/poller.c
@@ -50,6 +50,7 @@ void *child(void *arg) {
 	int host_data_ids;
 	double host_time_double;
 	char host_time[SMALL_BUFSIZE];
+	int a_threads_value;
 
 	poller_thread_t poller_details = *(poller_thread_t*) arg;
 	host_id          = poller_details.host_id;
@@ -68,18 +69,10 @@ void *child(void *arg) {
 
 	poll_host(host_id, host_thread, last_host_thread, host_data_ids, host_time, host_time_double);
 
-	while (TRUE) {
-		if (thread_mutex_trylock(LOCK_THREAD) == 0) {
-			active_threads--;
-			thread_mutex_unlock(LOCK_THREAD);
+	sem_post(&active_threads);
 
-			break;
-		}
-		
-		usleep(100);
-	}
-
-	SPINE_LOG_DEBUG(("DEBUG: The Value of Active Threads is %i" ,active_threads));
+	sem_getvalue(&active_threads, &a_threads_value);
+	SPINE_LOG_DEBUG(("DEBUG: The Value of Active Threads is %i", set.threads - a_threads_value));
 
 	/* end the thread */
 	pthread_exit(0);

--- a/spine.c
+++ b/spine.c
@@ -212,7 +212,6 @@ int main(int argc, char *argv[]) {
 	int canexit = FALSE;
 	int host_id = 0;
 	int i;
-	int mutex_status  = 0;
 	int thread_status = 0;
 	int change_host   = TRUE;
 	int current_thread;

--- a/spine.c
+++ b/spine.c
@@ -185,7 +185,6 @@ int main(int argc, char *argv[]) {
 	int num_rows = 0;
 	int device_counter = 0;
 	int poller_counter = 0;
-	int last_active_threads = 0;
 	int valid_conf_file = FALSE;
 	char querybuf[BIG_BUFSIZE], *qp = querybuf;
 	char *host_time = NULL;
@@ -615,9 +614,6 @@ int main(int argc, char *argv[]) {
 
 	/* loop through devices until done */
 	while (canexit == FALSE && device_counter < num_rows) {
-		sem_getvalue(&active_threads, &last_active_threads);
-		last_active_threads = set.threads - last_active_threads;
-
 		if (change_host) {
 			mysql_row       = mysql_fetch_row(result);
 			host_id         = atoi(mysql_row[0]);

--- a/spine.c
+++ b/spine.c
@@ -97,7 +97,7 @@
 int entries = 0;
 int num_hosts = 0;
 int active_threads = 0;
-int active_scripts = 0;
+sem_t active_scripts;
 
 config_t set;
 php_t	*php_processes = 0;
@@ -601,6 +601,9 @@ int main(int argc, char *argv[]) {
 	}else{
 		change_host = TRUE;
 	}
+
+	/* initialize active_scripts semaphore */
+	sem_init(&active_scripts, 0, MAX_SIMULTANEOUS_SCRIPTS);
 
 	/* initialize thread initialization semaphore */
 	sem_init(&thread_init_sem, 0, 1);

--- a/spine.c
+++ b/spine.c
@@ -580,6 +580,19 @@ int main(int argc, char *argv[]) {
 
 	init_mutexes();
 
+	/* initialize active_threads semaphore */
+	sem_init(&active_threads, 0, set.threads);
+
+	/* initialize active_scripts semaphore */
+	sem_init(&active_scripts, 0, MAX_SIMULTANEOUS_SCRIPTS);
+
+	/* initialize thread initialization semaphore */
+	sem_init(&thread_init_sem, 0, 1);
+
+	/* specify the point of timeout for timedwait semaphores */
+	until.tv_sec = (time_t)(set.poller_interval + begin_time - 0.2);
+	until.tv_nsec = 0;
+
 	sem_getvalue(&active_threads, &a_threads_value);
 	SPINE_LOG_DEBUG(("DEBUG: Initial Value of Active Threads is %i", set.threads - a_threads_value));
 
@@ -597,19 +610,6 @@ int main(int argc, char *argv[]) {
 	}else{
 		change_host = TRUE;
 	}
-
-	/* initialize active_threads semaphore */
-	sem_init(&active_threads, 0, set.threads);
-
-	/* initialize active_scripts semaphore */
-	sem_init(&active_scripts, 0, MAX_SIMULTANEOUS_SCRIPTS);
-
-	/* initialize thread initialization semaphore */
-	sem_init(&thread_init_sem, 0, 1);
-
-	/* specify the point of timeout for timedwait semaphores */
-	until.tv_sec = (time_t)(set.poller_interval + begin_time - 0.2);
-	until.tv_nsec = 0;
 
 	/* loop through devices until done */
 	while (canexit == FALSE && device_counter < num_rows) {

--- a/spine.c
+++ b/spine.c
@@ -181,7 +181,7 @@ void drop_root(uid_t server_uid, gid_t server_gid) {
 int main(int argc, char *argv[]) {
 	struct timeval now;
 	char *conf_file = NULL;
-	double begin_time, end_time, current_time;
+	double begin_time, end_time;
 	int num_rows = 0;
 	int device_counter = 0;
 	int poller_counter = 0;

--- a/spine.c
+++ b/spine.c
@@ -96,7 +96,7 @@
 /* Global Variables */
 int entries = 0;
 int num_hosts = 0;
-int active_threads = 0;
+sem_t active_threads;
 sem_t active_scripts;
 
 config_t set;
@@ -187,14 +187,14 @@ int main(int argc, char *argv[]) {
 	int poller_counter = 0;
 	int last_active_threads = 0;
 	int valid_conf_file = FALSE;
-	long int EXTERNAL_THREAD_SLEEP = 50;
-	long int internal_thread_sleep;
 	char querybuf[BIG_BUFSIZE], *qp = querybuf;
 	char *host_time = NULL;
 	double host_time_double = 0;
 	int itemsPT = 0;
 	int device_threads;
 	sem_t thread_init_sem;
+	int a_threads_value;
+	struct timespec until;
 
 	#ifdef HAVE_LCAP
 	if (geteuid() == 0)
@@ -472,9 +472,6 @@ int main(int argc, char *argv[]) {
 		set.poller_interval = 300;
 	}
 
-	/* calculate the external_tread_sleep value */
-	internal_thread_sleep = EXTERNAL_THREAD_SLEEP * set.num_parent_processes / 50;
-
 	/* connect to database */
 	db_connect(set.dbdb, &mysql);
 
@@ -585,7 +582,8 @@ int main(int argc, char *argv[]) {
 
 	init_mutexes();
 
-	SPINE_LOG_DEBUG(("DEBUG: Initial Value of Active Threads is %i", active_threads));
+	sem_getvalue(&active_threads, &a_threads_value);
+	SPINE_LOG_DEBUG(("DEBUG: Initial Value of Active Threads is %i", set.threads - a_threads_value));
 
 	/* tell fork processes that they are now active */
 	set.parent_fork = SPINE_FORK;
@@ -602,187 +600,118 @@ int main(int argc, char *argv[]) {
 		change_host = TRUE;
 	}
 
+	/* initialize active_threads semaphore */
+	sem_init(&active_threads, 0, set.threads);
+
 	/* initialize active_scripts semaphore */
 	sem_init(&active_scripts, 0, MAX_SIMULTANEOUS_SCRIPTS);
 
 	/* initialize thread initialization semaphore */
 	sem_init(&thread_init_sem, 0, 1);
 
+	/* specify the point of timeout for timedwait semaphores */
+	until.tv_sec = (time_t)(set.poller_interval + begin_time - 0.2);
+	until.tv_nsec = 0;
+
 	/* loop through devices until done */
-	while ((device_counter < num_rows) && (canexit == FALSE)) {
-		while ((active_threads < set.threads) && (device_counter < num_rows) && (canexit == FALSE)) {
-			mutex_status = thread_mutex_trylock(LOCK_THREAD);
-	
-			switch (mutex_status) {
-			case 0:
-				last_active_threads = active_threads;
-	
-				if (change_host) {
-					mysql_row       = mysql_fetch_row(result);
-					host_id         = atoi(mysql_row[0]);
-					device_threads  = atoi(mysql_row[1]);
-					current_thread  = 1;
-				}else{
-					current_thread++;
-				}
+	while (canexit == FALSE && device_counter < num_rows) {
+		sem_getvalue(&active_threads, &last_active_threads);
+		last_active_threads = set.threads - last_active_threads;
 
-				if (current_thread >= device_threads) {
-					change_host = TRUE;
-				}else{
-					change_host = FALSE;
-				}
-
-				/* determine how many items will be polled per thread */
-				if (device_threads > 1) {
-					if (current_thread == 1) {
-						snprintf(querybuf, BIG_BUFSIZE, "SELECT CEIL(COUNT(*)/%i) FROM poller_item WHERE host_id=%i", device_threads, host_id);
-						tresult   = db_query(&mysql, querybuf);
-						mysql_row = mysql_fetch_row(tresult);
-
-						itemsPT   = atoi(mysql_row[0]);
-						db_free_result(tresult);
-
-						if (host_time) free(host_time);
-						host_time = get_host_poll_time();
-						host_time_double = get_time_as_double();
-					}
-				}else{
-					itemsPT   = 0;
-					if (host_time) free(host_time);
-					host_time = get_host_poll_time();
-					host_time_double = get_time_as_double();
-				}
-
-				/* populate the thread structure */
-				if (!(poller_details = (poller_thread_t *)malloc(sizeof(poller_thread_t)))) {
-					die("ERROR: Fatal malloc error: spine.c poller_details!");
-				}
-
-				poller_details->host_id          = host_id;
-				poller_details->host_thread      = current_thread;
-				poller_details->last_host_thread = device_threads;
-				poller_details->host_data_ids    = itemsPT;
-				poller_details->host_time        = host_time;
-				poller_details->host_time_double = host_time_double;
-				poller_details->thread_init_sem  = &thread_init_sem;
-
-				/* create child process */
-				sem_wait(&thread_init_sem);
-				thread_status = pthread_create(&threads[device_counter], &attr, child, poller_details);
-
-				switch (thread_status) {
-					case 0:
-						SPINE_LOG_DEBUG(("DEBUG: Valid Thread to be Created"));
-
-						if (change_host) {
-							device_counter++;
-						}
-						active_threads++;
-
-						/* wait for the child to read and process the structure */
-						sem_wait(&thread_init_sem);
-						sem_post(&thread_init_sem);
-
-						SPINE_LOG_DEBUG(("DEBUG: The Value of Active Threads is %i", active_threads));
-
-						break;
-					case EAGAIN:
-						SPINE_LOG(("ERROR: The System Lacked the Resources to Create a Thread"));
-						break;
-					case EFAULT:
-						SPINE_LOG(("ERROR: The Thread or Attribute were Invalid"));
-						break;
-					case EINVAL:
-						SPINE_LOG(("ERROR: The Thread Attribute is Not Initialized"));
-						break;
-					default:
-						SPINE_LOG(("ERROR: Unknown Thread Creation Error"));
-						break;
-				}
-				/* Restore thread initialization semaphore if thread creation failed */
-				if (thread_status)
-				    sem_post(&thread_init_sem);
-
-				thread_mutex_unlock(LOCK_THREAD);
-
-				/* get current time and exit program if time limit exceeded */
-				if (poller_counter >= 20) {
-					current_time = get_time_as_double();
-
-					if ((current_time - begin_time + .2) > set.poller_interval) {
-						SPINE_LOG(("ERROR: Spine Timed Out While Processing Hosts Internal"));
-						canexit = TRUE;
-						break;
-					}
-
-					poller_counter = 0;
-				}else{
-					poller_counter++;
-				}
-	
-				break;
-			case EDEADLK:
-				SPINE_LOG(("ERROR: Deadlock Occured"));
-				break;
-			case EBUSY:
-				break;
-			case EINVAL:
-				SPINE_LOG(("ERROR: Attempt to Unlock an Uninitialized Mutex"));
-				break;
-			case EFAULT:
-				SPINE_LOG(("ERROR: Attempt to Unlock an Invalid Mutex"));
-				break;
-			default:
-				SPINE_LOG(("ERROR: Unknown Mutex Lock Error Code Returned"));
-				break;
-			}
-	
-			/* get current time and exit program if time limit exceeded */
-			if (poller_counter >= 20) {
-				current_time = get_time_as_double();
-	
-				if ((current_time - begin_time + .2) > set.poller_interval) {
-					SPINE_LOG(("ERROR: Spine Timed Out While Processing Hosts Internal"));
-					canexit = TRUE;
-					break;
-				}
-	
-				poller_counter = 0;
-			}else{
-				poller_counter++;
-			}
+		if (change_host) {
+			mysql_row       = mysql_fetch_row(result);
+			host_id         = atoi(mysql_row[0]);
+			device_threads  = atoi(mysql_row[1]);
+			current_thread  = 1;
+		}else{
+			current_thread++;
 		}
 
-		usleep(internal_thread_sleep);
+		change_host = (current_thread >= device_threads) ? TRUE : FALSE;
+
+		/* determine how many items will be polled per thread */
+		if (device_threads > 1) {
+			if (current_thread == 1) {
+				snprintf(querybuf, BIG_BUFSIZE, "SELECT CEIL(COUNT(*)/%i) FROM poller_item WHERE host_id=%i", device_threads, host_id);
+				tresult   = db_query(&mysql, querybuf);
+				mysql_row = mysql_fetch_row(tresult);
+
+				itemsPT   = atoi(mysql_row[0]);
+				db_free_result(tresult);
+
+				if (host_time) free(host_time);
+				host_time = get_host_poll_time();
+				host_time_double = get_time_as_double();
+			}
+		}else{
+			itemsPT   = 0;
+			if (host_time) free(host_time);
+			host_time = get_host_poll_time();
+			host_time_double = get_time_as_double();
+		}
+
+		/* populate the thread structure */
+		if (!(poller_details = (poller_thread_t *)malloc(sizeof(poller_thread_t)))) {
+			die("ERROR: Fatal malloc error: spine.c poller_details!");
+		}
+
+		poller_details->host_id          = host_id;
+		poller_details->host_thread      = current_thread;
+		poller_details->last_host_thread = device_threads;
+		poller_details->host_data_ids    = itemsPT;
+		poller_details->host_time        = host_time;
+		poller_details->host_time_double = host_time_double;
+		poller_details->thread_init_sem  = &thread_init_sem;
+
+		if (sem_timedwait(&active_threads, &until)) {
+			SPINE_LOG(("ERROR: Spine Timed Out While Processing Hosts Internal"));
+			canexit = TRUE;
+			break;
+		}
+
+		/* create child process */
+		sem_wait(&thread_init_sem);
+		thread_status = pthread_create(&threads[device_counter], &attr, child, poller_details);
+
+		switch (thread_status) {
+			case 0:
+				SPINE_LOG_DEBUG(("DEBUG: Valid Thread to be Created"));
+
+				if (change_host) {
+					device_counter++;
+				}
+
+				/* wait for the child to read and process the structure */
+				sem_wait(&thread_init_sem);
+				sem_post(&thread_init_sem);
+
+				sem_getvalue(&active_threads, &a_threads_value);
+				SPINE_LOG_DEBUG(("DEBUG: The Value of Active Threads is %i", set.threads - a_threads_value));
+
+				break;
+			case EAGAIN:
+				SPINE_LOG(("ERROR: The System Lacked the Resources to Create a Thread"));
+				break;
+			case EFAULT:
+				SPINE_LOG(("ERROR: The Thread or Attribute were Invalid"));
+				break;
+			case EINVAL:
+				SPINE_LOG(("ERROR: The Thread Attribute is Not Initialized"));
+				break;
+			default:
+				SPINE_LOG(("ERROR: Unknown Thread Creation Error"));
+				break;
+		}
+		/* Restore thread initialization semaphore if thread creation failed */
+		if (thread_status)
+			sem_post(&thread_init_sem);
 	}
 
 	/* wait for all threads to complete */
-	while (canexit == FALSE) {
-		if (thread_mutex_trylock(LOCK_THREAD) == 0) {
-			last_active_threads = active_threads;
-
-			if (active_threads == 0) {
-				canexit = TRUE;
-			}
-
-			thread_mutex_unlock(LOCK_THREAD);
-		}
-
-		usleep(EXTERNAL_THREAD_SLEEP);
-
-		/* get current time and exit program if time limit exceeded */
-		if (poller_counter >= 20) {
-			current_time = get_time_as_double();
-
-			if ((current_time - begin_time + .2) > set.poller_interval) {
-				SPINE_LOG(("ERROR: Spine Timed Out While Processing Hosts Internal"));
-				canexit = TRUE;
-				break;
-			}
-
-			poller_counter = 0;
-		}else{
-			poller_counter++;
+	for (i = 0; i < set.threads; i++) {
+		if (sem_timedwait(&active_threads, &until)) {
+			SPINE_LOG(("ERROR: Spine Timed Out While Processing Hosts Internal"));
+			canexit = TRUE;
 		}
 	}
 

--- a/spine.h
+++ b/spine.h
@@ -158,7 +158,6 @@
 #define LOCK_THREAD 1
 #define LOCK_SETEUID 2
 #define LOCK_GHBN 3
-#define LOCK_PIPE 4
 #define LOCK_SYSLOG 5
 #define LOCK_PHP 6
 #define LOCK_PHP_PROC_0 7
@@ -176,7 +175,6 @@
 #define LOCK_THREAD_O 1
 #define LOCK_SETEUID_O 2
 #define LOCK_GHBN_O 3
-#define LOCK_PIPE_O 4
 #define LOCK_SYSLOG_O 5
 #define LOCK_PHP_O 6
 #define LOCK_PHP_PROC_0_O 7

--- a/spine.h
+++ b/spine.h
@@ -155,7 +155,6 @@
 
 /* threads constants */
 #define LOCK_SNMP 0
-#define LOCK_THREAD 1
 #define LOCK_SETEUID 2
 #define LOCK_GHBN 3
 #define LOCK_SYSLOG 5
@@ -172,7 +171,6 @@
 #define LOCK_PHP_PROC_9 16
 
 #define LOCK_SNMP_O 0
-#define LOCK_THREAD_O 1
 #define LOCK_SETEUID_O 2
 #define LOCK_GHBN_O 3
 #define LOCK_SYSLOG_O 5
@@ -515,6 +513,6 @@ extern config_t set;
 extern php_t  *php_processes;
 extern char   start_datetime[20];
 extern char   config_paths[CONFIG_PATHS][BUFSIZE];
-extern int    active_threads;
+extern sem_t  active_threads;
 
 #endif /* not _SPINE_H_ */

--- a/spine.h
+++ b/spine.h
@@ -409,6 +409,7 @@ typedef struct poller_thread {
 	int host_data_ids;
 	char *host_time;
 	double host_time_double;
+	sem_t *thread_init_sem;
 } poller_thread_t;
 
 /*! PHP Script Server Structure
@@ -517,6 +518,5 @@ extern php_t  *php_processes;
 extern char   start_datetime[20];
 extern char   config_paths[CONFIG_PATHS][BUFSIZE];
 extern int    active_threads;
-extern int    thread_ready;
 
 #endif /* not _SPINE_H_ */


### PR DESCRIPTION
Replace multiple cases of suboptimal use of locking (mutexes + sleep loops) with POSIX semaphores.
This change (mostly commits 9343666 and 6055fa0) significantly reduce load caused by spine process to operating system.
Some comparison numbers available in commit message of 9343666.