### PR TITLE
issue #7: Remote poller db settings not translating correctly

### DIFF
--- a/sql.c
+++ b/sql.c
@@ -277,7 +277,7 @@ void db_connect(const char *database, MYSQL *mysql) {
 			if (set.mode == REMOTE_OFFLINE || set.mode == REMOTE_RECOVERY) {
 				connect_error = mysql_real_connect(mysql, hostname, set.dbuser, set.dbpass, database, set.dbport, socket, 0);
 			}else{
-				connect_error = mysql_real_connect(mysql, hostname, set.rdbuser, set.rdbpass, database, set.rdbport, socket, 0);
+				connect_error = mysql_real_connect(mysql, hostname, set.rdbuser, set.rdbpass, set.rdbdb, set.rdbport, socket, 0);
 			}
 		}else{
 			connect_error = mysql_real_connect(mysql, hostname, set.dbuser, set.dbpass, database, set.dbport, socket, 0);


### PR DESCRIPTION
Updating sql.c when remote poller is online to use proper "RDB_Name" variable.