### PR TITLE
Add help2man prerequisite to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ chmod +s /usr/local/spine/bin/spine
       * dos2unix
       * gcc-core
       * gzip
+      * help2man
       * libmysqlclient
       * libmysqlclient-devel
       * libtool


### PR DESCRIPTION
- help2man is a CYGWIN prerequisite for Windows installation