### PR TITLE
Spine should always report if failing back from ICMP to UDP

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ The Cacti Group | spine
 
 1.2.0
 -feature: Allow threads to be set a Data Collector level
+-issue#54: Spine should always report if ICMP fails
 
 1.1.38
 -feature: release to match Cacti release

--- a/ping.c
+++ b/ping.c
@@ -59,11 +59,7 @@ int ping_host(host_t *host, ping_t *ping) {
 
 		if (host->ping_method == PING_ICMP) {
 			if (set.icmp_avail == FALSE) {
-				if (is_debug_device(host->id)) {
-					SPINE_LOG(("Device[%i] DEBUG Falling back to UDP Ping Due to SetUID Issues", host->id));
-				} else {
-					SPINE_LOG_DEBUG(("Device[%i] DEBUG Falling back to UDP Ping Due to SetUID Issues", host->id));
-				}
+				SPINE_LOG(("Device[%i] DEBUG Falling back to UDP Ping Due to SetUID Issues", host->id));
 				host->ping_method = PING_UDP;
 			}
 		}


### PR DESCRIPTION
This is a fix for issue #54 