### PR TITLE
Spine-Error with "Wrong-Type" SNMP-Answer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+1.2.7
+-issue#113: spine1.2.6 couldn't open directory `m4'
+
 1.2.6
 -issue#101: MySQL 8 has retired 'my_bool' type
 -issue#104: Spine should report which threads are outstanding

--- a/bootstrap
+++ b/bootstrap
@@ -48,10 +48,12 @@ find . -type f -exec dos2unix --d2u \{\} \; > /dev/null 2>&1
 
 # Prepare a build state
 echo "INFO: Running auto-tools to verify buildability"
+aclocal --install
 libtoolize
 automake --add-missing
 autoreconf --force --install
 [ $? -ne 0 ] && echo "ERROR: 'autoreconf' exited with errors" && exit -1
+
 
 # Provide some meaningful notes
 echo "INFO: Spine bootstrap process completed"

--- a/bootstrap
+++ b/bootstrap
@@ -48,6 +48,8 @@ find . -type f -exec dos2unix --d2u \{\} \; > /dev/null 2>&1
 
 # Prepare a build state
 echo "INFO: Running auto-tools to verify buildability"
+libtoolize
+automake --add-missing
 autoreconf --force --install
 [ $? -ne 0 ] && echo "ERROR: 'autoreconf' exited with errors" && exit -1
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@ AC_INIT(Spine Poller, 1.2.6, http://www.cacti.net/issues.php)
 
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)
+AM_INIT_AUTOMAKE
 
 AC_CANONICAL_HOST
 AC_CONFIG_SRCDIR(spine.c)

--- a/configure.ac
+++ b/configure.ac
@@ -3,8 +3,6 @@ AC_INIT(Spine Poller, 1.2.6, http://www.cacti.net/issues.php)
 
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)
-AM_INIT_AUTOMAKE
-AC_PROG_CC
 
 AC_CANONICAL_HOST
 AC_CONFIG_SRCDIR(spine.c)

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,7 @@ AC_INIT(Spine Poller, 1.2.6, http://www.cacti.net/issues.php)
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)
 AM_INIT_AUTOMAKE
+AC_PROG_CC
 
 AC_CANONICAL_HOST
 AC_CONFIG_SRCDIR(spine.c)


### PR DESCRIPTION
If you have a SNMP-Device that gives you a "WRONG Type" Answer for a SNMP-Query. Spine removes trailing characters from the answer.

To Reproduce
Steps to reproduce the behavior:

do SNMP-Query on Host: (Answer should look like that):
IF-MIB::ifHCInOctets.167862272 = Wrong Type (should be Counter64): Hex-STRING: 00 00 00 02 41 CF B4 DC

debug answer in snmp.c from spine ~line 700

debug answer after
snprintf(snmp_oids[i].result, RESULTS_BUFFER, "%s", trim(strip_alpha(temp_result)));

compare values in temp_result <-> snmp_oids[i].result

in snmp_oids[i].result the DC (last two characters) are removed in strip_alpha

Server-OS is FreeBSD 12.1-RELEASE-p1
Cacti / Spine-Release 1.2.7