### PR TITLE
Patch to compile spine on Openbsd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ The Cacti Group | spine
 
 1.2.13
 -issue#156: Compile on Cygwin is failing due to icmp6 headers missing
+-issue: Fix a number of compiler warnings
 
 1.2.12
 -issue#155: Failed host lookup causes spine to crash

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+1.2.14
+-issue#162: Spine not updating rrd_next_step
+
 1.2.13
 -issue#156: Compile on Cygwin is failing due to icmp6 headers missing
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+1.2.13
+-issue#156: Compile on Cygwin is failing due to icmp6 headers missing
+
 1.2.12
 -issue#155: Failed host lookup causes spine to crash
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+1.2.12
+-issue#155: Failed host lookup causes spine to crash
+
 1.2.11
 -issue#122: Unable to compile spine on OpenBSD
 -issue#129: Repeated warnings due to 'Recache Event Detected for Device'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,13 @@
 The Cacti Group | spine
 
 1.2.11
--issue#122: Can't compile spine on Openbsd
--issue#129: PCOMMAND Device[XXXX] WARNING: Recache Event Detected for Device
--issue#134: Feature request: Loop Waiting on 2 of 2 pollers when database name is incorrect
--issue#144: Improve MySQL Retry Logic
--issue#149: Segmentation fault in spine 1.2.10 due to IPv6 address using IPv4 ICMP ping
--issue#150: FATAL: Spine Encountered a Segmentation Fault [4, Interrupted system call] (Spine thread)
--issue#151: Spine no longer stripping alpha characters from output
+-issue#122: Unable to compile spine on OpenBSD
+-issue#129: Repeated warnings due to 'Recache Event Detected for Device'
+-issue#134: No error is recorded to log file when database is incorrect
+-issue#144: MySQL retry logic is not working as expected
+-issue#149: When using IPv6 address, segmentation fault can occur due to incorrectly using IPv4 ping
+-issue#150: When polling results are null, segmentation errors may occur
+-issue#151: When collecting data, spine should be stripping alpha characters from output
 
 1.2.10
 -feature: release to match Cacti release
@@ -428,7 +428,7 @@ The Cacti Group | spine
 -feature: enabled signal handling in cactid
 
 0.8.6h
-Not released.  Syncing with Cacti distribution again.
+-feature: Not released.  Syncing with Cacti distribution again.
 
 0.8.6g
 -bug#0000609: console "error" messages should go to stderr instead of stdout

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,6 @@ The Cacti Group | spine
 
 1.2.13
 -issue#156: Compile on Cygwin is failing due to icmp6 headers missing
--issue: Fix a number of compiler warnings
 
 1.2.12
 -issue#155: Failed host lookup causes spine to crash

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ chmod +s /usr/local/spine/bin/spine
    * gcc-core
    * gzip
    * help2man
+   * inetutils-src
    * libmysqlclient
    * libmariadb-devel
    * libssl-devel

--- a/common.h
+++ b/common.h
@@ -104,7 +104,9 @@
 #  include <netinet/in.h>
 #  include <netinet/ip.h>
 #  include <netinet/ip6.h>
+#ifndef __CYGWIN__
 #  include <netinet/icmp6.h>
+#endif
 #  include <netinet/ip_icmp.h>
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.53)
-AC_INIT(Spine Poller, 1.2.13, http://www.cacti.net/issues.php)
+AC_INIT(Spine Poller, 1.2.14, http://www.cacti.net/issues.php)
 
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.53)
-AC_INIT(Spine Poller, 1.2.12, http://www.cacti.net/issues.php)
+AC_INIT(Spine Poller, 1.2.13, http://www.cacti.net/issues.php)
 
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_CANONICAL_HOST
 AC_CONFIG_SRCDIR(spine.c)
 AC_PREFIX_DEFAULT(/usr/local/spine)
 AC_LANG(C)
+AC_PROG_CC
 
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_HEADERS(config/config.h)

--- a/ping.c
+++ b/ping.c
@@ -868,9 +868,6 @@ int get_address_type(host_t *host) {
 
 	if ((error = getaddrinfo(host->hostname, NULL, &hints, &res_list)) != 0) {
 		SPINE_LOG(("WARNING: Unable to determine address info for %s (%s)", host->hostname, gai_strerror(error)));
-		if (res_list != NULL) {
-			freeaddrinfo(res_list);
-		}
 		return SPINE_NONE;
 	}
 

--- a/poller.c
+++ b/poller.c
@@ -1517,7 +1517,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			die("ERROR: Fatal malloc error: poller.c query3 output buffer!");
 		}
 		query3[0] = '\0';
-		strncat(query3, query8, strlen(query3));
+		strncat(query3, query8, strlen(query8));
 
 		out_buffer = strlen(query3);
 
@@ -1527,7 +1527,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 				die("ERROR: Fatal malloc error: poller.c query12 boost output buffer!");
 			}
 			query12[0] = '\0';
-			strncat(query12, query11, strlen(query12));
+			strncat(query12, query11, strlen(query11));
 		}
 
 		int mode;
@@ -1552,24 +1552,24 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			/* if the next element to the buffer will overflow it, write to the database */
 			if ((out_buffer + result_length) >= MAX_MYSQL_BUF_SIZE) {
 				/* append the suffix */
-				strncat(query3, posuffix, strlen(query3));
+				strncat(query3, posuffix, strlen(posuffix));
 
 				/* insert the record */
 				db_insert(&mysqlt, mode, query3);
 
 				/* re-initialize the query buffer */
 				query3[0] = '\0';
-				strncat(query3, query8, strlen(query3));
+				strncat(query3, query8, strlen(query8));
 
 				/* insert the record for boost */
 				if (set.boost_redirect && set.boost_enabled) {
 					/* append the suffix */
-					strncat(query12, posuffix, strlen(query12));
+					strncat(query12, posuffix, strlen(posuffix));
 
 					db_insert(&mysqlt, mode, query12);
 
 					query12[0] = '\0';
-					strncat(query12, query11, strlen(query12));
+					strncat(query12, query11, strlen(query11));
 				}
 
 				/* reset the output buffer length */
@@ -1586,10 +1586,10 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 				result_string[0] = ',';
 			}
 
-			strncat(query3, result_string, strlen(query3));
+			strncat(query3, result_string, strlen(result_string));
 
 			if (set.boost_redirect && set.boost_enabled) {
-				strncat(query12, result_string, strlen(query12));
+				strncat(query12, result_string, strlen(result_string));
 			}
 
 			out_buffer = out_buffer + strlen(result_string);
@@ -1600,7 +1600,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 		/* perform the last insert if there is data to process */
 		if (out_buffer > strlen(query8)) {
 			/* append the suffix */
-			strncat(query3, posuffix, strlen(query3));
+			strncat(query3, posuffix, strlen(posuffix));
 
 			/* insert records into database */
 			db_insert(&mysqlt, mode, query3);
@@ -1608,7 +1608,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			/* insert the record for boost */
 			if (set.boost_redirect && set.boost_enabled) {
 				/* append the suffix */
-				strncat(query12, posuffix, strlen(query12));
+				strncat(query12, posuffix, strlen(posuffix));
 
 				db_insert(&mysqlt, mode, query12);
 			}

--- a/poller.c
+++ b/poller.c
@@ -1517,7 +1517,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			die("ERROR: Fatal malloc error: poller.c query3 output buffer!");
 		}
 		query3[0] = '\0';
-		strncat(query3, query8, strlen(query8));
+		strncat(query3, query8, strlen(query3));
 
 		out_buffer = strlen(query3);
 
@@ -1527,7 +1527,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 				die("ERROR: Fatal malloc error: poller.c query12 boost output buffer!");
 			}
 			query12[0] = '\0';
-			strncat(query12, query11, strlen(query11));
+			strncat(query12, query11, strlen(query12));
 		}
 
 		int mode;
@@ -1552,24 +1552,24 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			/* if the next element to the buffer will overflow it, write to the database */
 			if ((out_buffer + result_length) >= MAX_MYSQL_BUF_SIZE) {
 				/* append the suffix */
-				strncat(query3, posuffix, strlen(posuffix));
+				strncat(query3, posuffix, strlen(query3));
 
 				/* insert the record */
 				db_insert(&mysqlt, mode, query3);
 
 				/* re-initialize the query buffer */
 				query3[0] = '\0';
-				strncat(query3, query8, strlen(query8));
+				strncat(query3, query8, strlen(query3));
 
 				/* insert the record for boost */
 				if (set.boost_redirect && set.boost_enabled) {
 					/* append the suffix */
-					strncat(query12, posuffix, strlen(posuffix));
+					strncat(query12, posuffix, strlen(query12));
 
 					db_insert(&mysqlt, mode, query12);
 
 					query12[0] = '\0';
-					strncat(query12, query11, strlen(query11));
+					strncat(query12, query11, strlen(query12));
 				}
 
 				/* reset the output buffer length */
@@ -1586,10 +1586,10 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 				result_string[0] = ',';
 			}
 
-			strncat(query3, result_string, strlen(result_string));
+			strncat(query3, result_string, strlen(query3));
 
 			if (set.boost_redirect && set.boost_enabled) {
-				strncat(query12, result_string, strlen(result_string));
+				strncat(query12, result_string, strlen(query12));
 			}
 
 			out_buffer = out_buffer + strlen(result_string);
@@ -1600,7 +1600,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 		/* perform the last insert if there is data to process */
 		if (out_buffer > strlen(query8)) {
 			/* append the suffix */
-			strncat(query3, posuffix, strlen(posuffix));
+			strncat(query3, posuffix, strlen(query3));
 
 			/* insert records into database */
 			db_insert(&mysqlt, mode, query3);
@@ -1608,7 +1608,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			/* insert the record for boost */
 			if (set.boost_redirect && set.boost_enabled) {
 				/* append the suffix */
-				strncat(query12, posuffix, strlen(posuffix));
+				strncat(query12, posuffix, strlen(query12));
 
 				db_insert(&mysqlt, mode, query12);
 			}

--- a/poller.c
+++ b/poller.c
@@ -1175,7 +1175,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 								/* is valid output, continue */
 							} else {
 								/* remove double or single quotes from string */
-								snprintf(temp_result, RESULTS_BUFFER, "%s", snmp_oids[j].result);
+								snprintf(temp_result, RESULTS_BUFFER, "%s", strip_alpha(trim(snmp_oids[j].result)));
 								snprintf(snmp_oids[j].result , RESULTS_BUFFER, "%s", temp_result);
 
 								/* detect erroneous non-numeric result */

--- a/snmp.c
+++ b/snmp.c
@@ -186,7 +186,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 	snprintf(hostnameport, BUFSIZE, "%s:%i", hostname, snmp_port);
 	session.peername    = hostnameport;
 	session.retries     = set.snmp_retries;
-	session.remote_port = snmp_port;
 	session.timeout     = (snmp_timeout * 1000); /* net-snmp likes microseconds */
 
 	SPINE_LOG_MEDIUM(("Device[%i] INFO: SNMP Device '%s' has timeout %ld (%d), retries %d", host_id, hostname, session.timeout, snmp_timeout, session.retries));

--- a/spine.c
+++ b/spine.c
@@ -695,7 +695,7 @@ int main(int argc, char *argv[]) {
 		total_items = atoi(mysql_row[0]);
 		db_free_result(tresult);
 
-		if (total_items < device_threads) {
+		if (total_items && total_items < device_threads) {
 			device_threads = total_items;
 		}
 

--- a/util.c
+++ b/util.c
@@ -1171,7 +1171,7 @@ int spine_log(const char *format, ...) {
 
 	/* append a line feed to the log message if needed */
 	if (!strstr(flogmessage, "\n")) {
-		strncat(flogmessage, "\n", 1);
+		strcat(flogmessage, "\n");
 	}
 
 	if ((IS_LOGGING_TO_FILE() &&
@@ -1471,7 +1471,7 @@ char *strncopy(char *dst, const char *src, size_t obuf) {
 	if (!len) {
 		dst[0] = '\0';
 	} else if (len < obuf) {
-		strncpy(dst, src, len);
+		strncpy(dst, src, sizeof(dst));
 		dst[len] = '\0';
 	} else {
 		strncpy(dst, src, --obuf);

--- a/util.c
+++ b/util.c
@@ -1471,7 +1471,7 @@ char *strncopy(char *dst, const char *src, size_t obuf) {
 	if (!len) {
 		dst[0] = '\0';
 	} else if (len < obuf) {
-		strncpy(dst, src, sizeof(dst));
+		strncpy(dst, src, len);
 		dst[len] = '\0';
 	} else {
 		strncpy(dst, src, --obuf);


### PR DESCRIPTION
Following the issue I openbsd for openbsd
https://github.com/Cacti/spine/issues/163

Changelog = Switch to remove -ldl option for Openbsd compilation in configure.ac

Here's the patch
```
# cat patch163_Openbsd
--- configure.ac.orig   Thu Aug 27 02:01:47 2020
+++ configure.ac        Thu Aug 27 01:48:22 2020
@@ -257,12 +257,22 @@
 fi
   CFLAGS="-I$MYSQL_INC_DIR $CFLAGS"

-AC_CHECK_LIB(mysqlclient, mysql_init,
-  [ LIBS="-lmysqlclient -lm -ldl $LIBS"
-    AC_DEFINE(HAVE_MYSQL, 1, MySQL Client API)
-    HAVE_MYSQL=yes ],
-  [ HAVE_MYSQL=no ]
-)
+unamestr=$(uname)
+if test $unamestr == 'OpenBSD'; then
+  AC_CHECK_LIB(mysqlclient, mysql_init,
+    [ LIBS="-lmysqlclient -lm $LIBS"
+      AC_DEFINE(HAVE_MYSQL, 1, MySQL Client API)
+      HAVE_MYSQL=yes ],
+    [ HAVE_MYSQL=no ]
+  )
+else
+  AC_CHECK_LIB(mysqlclient, mysql_init,
+    [ LIBS="-lmysqlclient -lm -ldl $LIBS"
+      AC_DEFINE(HAVE_MYSQL, 1, MySQL Client API)
+      HAVE_MYSQL=yes ],
+    [ HAVE_MYSQL=no ]
+  )
+fi

 if test $MYSQL_REENTRANT = 1 ; then
   LIBS="-lmysqlclient_r -lm -ldl $LIBS"
@@ -274,7 +284,11 @@
       LIBS="-lmysqlclient_r -lm -ldl $LIBS"
     else
       if test "$HAVE_MYSQL" == "yes"; then
-        LIBS="-lmysqlclient -lm -ldl $LIBS"
+        if test $unamestr == 'OpenBSD'; then
+          LIBS="-lmysqlclient -lm $LIBS"
+        else
+          LIBS="-lmysqlclient -lm -ldl $LIBS"
+        fi
       else
         LIBS="-lmariadbclient -lm -ldl $LIBS"
       fi

```