### PR TITLE
Fix build for Percona (Server database client library)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -248,6 +248,8 @@ fi
 for i in $MYSQL_DIR /usr /usr/local /opt /opt/mysql /usr/pkg /usr/local/mysql; do
   MYSQL_LIB_CHK($i/lib64)
   MYSQL_LIB_CHK($i/lib64/mysql)
+  MYSQL_LIB_CHK($i/lib/x86_64-linux-gnu)
+  MYSQL_LIB_CHK($i/lib/x86_64-linux-gnu/mysql)
   MYSQL_LIB_CHK($i/lib)
   MYSQL_LIB_CHK($i/lib/mysql)
 done
@@ -290,7 +292,11 @@ else
           LIBS="-lmysqlclient -lm -ldl $LIBS"
         fi
       else
-        LIBS="-lmariadbclient -lm -ldl $LIBS"
+        if test -f $MYSQL_LIB_DIR/libperconaserverclient.a -o -f $MYSQL_LIB_DIR/libperconaserverclient.$ShLib; then
+          LIBS="-lperconaserverclient -lm -ldl $LIBS"
+        else
+          LIBS="-lmariadbclient -lm -ldl $LIBS"
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
We're trying to compile Spine against the Percona Server database client library (on Ubuntu). This does not seem to be supported at the moment. The suggested changes below add that support.

There might be a "prettier" or "better" way to do this, but I'm not aware of one.