### PR TITLE
avoid MySQL queries returning data out of the expected order

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ The Cacti Group | spine
 -issue#178: Fix build for Percona (Server database client library)
 -issue#184: Warning during make process related to backtrace symbols
 -issue#186: Spine having random segfaults when attempting to connect
+-issue#187: With large installations spine can create too many connections causing routers to detect DOS
 
 1.2.16
 -issue: Some developer debug log messages falsely labeled as WARNINGS

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ The Cacti Group | spine
 -issue#164: Remove the need of the dos2unix program
 -issue#171: Spine experiencing MySQL socket error 2002 under load
 -issue#175: Under heavy load MySQL/MariaDB return 2006 and 2013 errors on query
+-issue: Some developer debug log messages falsely labeled as WARNINGS
 -feature#176: Add Data Source turnaround time to debug output
 
 1.2.15

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ The Cacti Group | spine
 
 1.2.13
 -issue#156: Compile on Cygwin is failing due to icmp6 headers missing
+-issue: Fix a number of compiler warnings
 
 1.2.12
 -issue#155: Failed host lookup causes spine to crash

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+1.2.13
+-issue#156: Compile on Cygwin is failing due to icmp6 headers missing
+
 1.2.12
 -issue#155: Failed host lookup causes spine to crash
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+1.2.12
+-issue#155: Failed host lookup causes spine to crash
+
 1.2.11
 -issue#122: Unable to compile spine on OpenBSD
 -issue#129: Repeated warnings due to 'Recache Event Detected for Device'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+1.2.17
+-issue#178: Fix build for Percona (Server database client library)
+
 1.2.16
 -issue: Some developer debug log messages falsely labeled as WARNINGS
 -issue#164: Remove the need of the dos2unix program

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 The Cacti Group | spine
 
 1.2.16
+-issue#164: Remove the need of the dos2unix program
 -issue#175: Under heavy load MySQL/MariaDB return 2006 and 2013 errors on query
 -feature#176: Add Data Source turnaround time to debug output
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ The Cacti Group | spine
 
 1.2.15
 -issue#166: Spine error with new versions 1.2.x when the access to temperature SNMP data (worked by changing to a previous versions)
+-issue#168: Patch to compile spine on Openbsd
 
 1.2.14
 -issue#162: Spine not updating rrd_next_step

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,13 @@
 The Cacti Group | spine
 
 1.2.11
--issue#122: Can't compile spine on Openbsd
--issue#129: PCOMMAND Device[XXXX] WARNING: Recache Event Detected for Device
--issue#134: Feature request: Loop Waiting on 2 of 2 pollers when database name is incorrect
--issue#144: Improve MySQL Retry Logic
--issue#149: Segmentation fault in spine 1.2.10 due to IPv6 address using IPv4 ICMP ping
--issue#150: FATAL: Spine Encountered a Segmentation Fault [4, Interrupted system call] (Spine thread)
--issue#151: Spine no longer stripping alpha characters from output
+-issue#122: Unable to compile spine on OpenBSD
+-issue#129: Repeated warnings due to 'Recache Event Detected for Device'
+-issue#134: No error is recorded to log file when database is incorrect
+-issue#144: MySQL retry logic is not working as expected
+-issue#149: When using IPv6 address, segmentation fault can occur due to incorrectly using IPv4 ping
+-issue#150: When polling results are null, segmentation errors may occur
+-issue#151: When collecting data, spine should be stripping alpha characters from output
 
 1.2.10
 -feature: release to match Cacti release
@@ -428,7 +428,7 @@ The Cacti Group | spine
 -feature: enabled signal handling in cactid
 
 0.8.6h
-Not released.  Syncing with Cacti distribution again.
+-feature: Not released.  Syncing with Cacti distribution again.
 
 0.8.6g
 -bug#0000609: console "error" messages should go to stderr instead of stdout

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,6 @@ The Cacti Group | spine
 
 1.2.13
 -issue#156: Compile on Cygwin is failing due to icmp6 headers missing
--issue: Fix a number of compiler warnings
 
 1.2.12
 -issue#155: Failed host lookup causes spine to crash

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 The Cacti Group | spine
 
 1.2.15
--issue#166: Spine error with new versions 1.2.x when the access to temperature SNMP data (worked by changing to a previous versions)
--issue#168: Patch to compile spine on Openbsd
+-issue#166: Special characters may not always be ignored properly
+-issue#168: Correct issues with linking under OpenBSD
 
 1.2.14
 -issue#162: Spine not updating rrd_next_step

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+1.2.15
+-issue#166: Spine error with new versions 1.2.x when the access to temperature SNMP data (worked by changing to a previous versions)
+
 1.2.13
 -issue#156: Compile on Cygwin is failing due to icmp6 headers missing
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ The Cacti Group | spine
 
 1.2.17
 -issue#178: Fix build for Percona (Server database client library)
+-issue#184: Warning during make process related to backtrace symbols
 
 1.2.16
 -issue: Some developer debug log messages falsely labeled as WARNINGS

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ The Cacti Group | spine
 -issue#175: Under heavy load MySQL/MariaDB return 2006 and 2013 errors on query
 -issue: Some developer debug log messages falsely labeled as WARNINGS
 -feature#176: Add Data Source turnaround time to debug output
+-feature: Add backtrace output to stderr for signals
 
 1.2.15
 -issue#166: Special characters may not always be ignored properly

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ The Cacti Group | spine
 -issue#184: Warning during make process related to backtrace symbols
 -issue#186: Spine having random segfaults when attempting to connect
 -issue#187: With large installations spine can create too many connections causing routers to detect DOS
+-feature#188: More concurrent script servers needed for large installs
 
 1.2.16
 -issue: Some developer debug log messages falsely labeled as WARNINGS

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ The Cacti Group | spine
 1.2.17
 -issue#178: Fix build for Percona (Server database client library)
 -issue#184: Warning during make process related to backtrace symbols
+-issue#186: Spine having random segfaults when attempting to connect
 
 1.2.16
 -issue: Some developer debug log messages falsely labeled as WARNINGS

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ The Cacti Group | spine
 
 1.2.11
 -issue#122: Can't compile spine on Openbsd
+-issue#129: PCOMMAND Device[XXXX] WARNING: Recache Event Detected for Device
 -issue#134: Feature request: Loop Waiting on 2 of 2 pollers when database name is incorrect
 -issue#144: Improve MySQL Retry Logic
 -issue#149: Segmentation fault in spine 1.2.10 due to IPv6 address using IPv4 ICMP ping

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ The Cacti Group | spine
 
 1.2.16
 -issue#164: Remove the need of the dos2unix program
+-issue#171: Spine experiencing MySQL socket error 2002 under load
 -issue#175: Under heavy load MySQL/MariaDB return 2006 and 2013 errors on query
 -feature#176: Add Data Source turnaround time to debug output
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 The Cacti Group | spine
 
+1.2.16
+-issue#175: Under heavy load MySQL/MariaDB return 2006 and 2013 errors on query
+-feature#176: Add Data Source turnaround time to debug output
+
 1.2.15
 -issue#166: Special characters may not always be ignored properly
 -issue#168: Correct issues with linking under OpenBSD

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,12 @@
 The Cacti Group | spine
 
 1.2.16
+-issue: Some developer debug log messages falsely labeled as WARNINGS
 -issue#164: Remove the need of the dos2unix program
 -issue#171: Spine experiencing MySQL socket error 2002 under load
 -issue#175: Under heavy load MySQL/MariaDB return 2006 and 2013 errors on query
--issue: Some developer debug log messages falsely labeled as WARNINGS
--feature#176: Add Data Source turnaround time to debug output
 -feature: Add backtrace output to stderr for signals
+-feature#176: Add Data Source turnaround time to debug output
 
 1.2.15
 -issue#166: Special characters may not always be ignored properly

--- a/INSTALL
+++ b/INSTALL
@@ -69,6 +69,7 @@ CYGWIN Prerequisite
       * automake
       * dos2unix
       * gcc-core
+      * gcc-debuginfo
       * gzip
       * help2man
       * libmysqlclient

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ chmod +s /usr/local/spine/bin/spine
    * gcc-core
    * gzip
    * help2man
+   * inetutils-src
    * libmysqlclient
    * libmariadb-devel
    * libssl-devel

--- a/bootstrap
+++ b/bootstrap
@@ -28,14 +28,10 @@ display_help () {
 }
 
 # Check for parameters
-if [ "${1}x" = "--helpx" -o "${1}x" = "-hx" ]; then
+if [ "${1}" = "--help" -o "${1}" = "-h" ]; then
   display_help
   exit 0
 fi
-
-# Check for dos2unix
-which dos2unix > /dev/null 2>&1
-[ $? -gt 0 ] && echo "FATAL: Unable to locate dos2unix utility" && exit -1
 
 echo "INFO: Starting Spine build process"
 
@@ -44,7 +40,10 @@ echo "INFO: Removing cache directories"
 rm -rf autom4te.cache .deps
 
 # Make sure all files are unix formatted files 
-find . -type f -exec dos2unix --d2u \{\} \; > /dev/null 2>&1
+which dos2unix > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  find . -type f -exec dos2unix --d2u \{\} \; > /dev/null 2>&1
+fi
 
 # Prepare a build state
 echo "INFO: Running auto-tools to verify buildability"

--- a/common.h
+++ b/common.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/common.h
+++ b/common.h
@@ -104,7 +104,9 @@
 #  include <netinet/in.h>
 #  include <netinet/ip.h>
 #  include <netinet/ip6.h>
+#ifndef __CYGWIN__
 #  include <netinet/icmp6.h>
+#endif
 #  include <netinet/ip_icmp.h>
 #endif
 

--- a/common.h
+++ b/common.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.53)
-AC_INIT(Spine Poller, 1.2.15, http://www.cacti.net/issues.php)
+AC_INIT(Spine Poller, 1.2.16, http://www.cacti.net/issues.php)
 
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)

--- a/configure.ac
+++ b/configure.ac
@@ -257,12 +257,22 @@ if test -n "$MYSQL_LIB_DIR" ; then
 fi
   CFLAGS="-I$MYSQL_INC_DIR $CFLAGS"
 
-AC_CHECK_LIB(mysqlclient, mysql_init,
-  [ LIBS="-lmysqlclient -lm -ldl $LIBS"
-    AC_DEFINE(HAVE_MYSQL, 1, MySQL Client API)
-    HAVE_MYSQL=yes ],
-  [ HAVE_MYSQL=no ]
-)
+unamestr=$(uname)
+if test $unamestr == 'OpenBSD'; then
+  AC_CHECK_LIB(mysqlclient, mysql_init,
+    [ LIBS="-lmysqlclient -lm $LIBS"
+      AC_DEFINE(HAVE_MYSQL, 1, MySQL Client API)
+      HAVE_MYSQL=yes ],
+    [ HAVE_MYSQL=no ]
+  )
+else
+  AC_CHECK_LIB(mysqlclient, mysql_init,
+    [ LIBS="-lmysqlclient -lm -ldl $LIBS"
+      AC_DEFINE(HAVE_MYSQL, 1, MySQL Client API)
+      HAVE_MYSQL=yes ],
+    [ HAVE_MYSQL=no ]
+  )
+fi
 
 if test $MYSQL_REENTRANT = 1 ; then
   LIBS="-lmysqlclient_r -lm -ldl $LIBS"
@@ -274,7 +284,11 @@ else
       LIBS="-lmysqlclient_r -lm -ldl $LIBS"
     else
       if test "$HAVE_MYSQL" == "yes"; then
-        LIBS="-lmysqlclient -lm -ldl $LIBS"
+        if test $unamestr == 'OpenBSD'; then
+          LIBS="-lmysqlclient -lm $LIBS"
+        else
+          LIBS="-lmysqlclient -lm -ldl $LIBS"
+        fi
       else
         LIBS="-lmariadbclient -lm -ldl $LIBS"
       fi

--- a/configure.ac
+++ b/configure.ac
@@ -456,7 +456,7 @@ AC_TRY_LINK(
     }
   ],
   [  AC_MSG_RESULT(yes)
-     AC_DEFINE(HAS_EXECINFO_H,1,[Do we have backtracing capabilities?])
+     AC_DEFINE(HAVE_EXECINFO_H,1,[Do we have backtracing capabilities?])
   ],
   AC_MSG_RESULT(no)
 )

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.53)
-AC_INIT(Spine Poller, 1.2.12, http://www.cacti.net/issues.php)
+AC_INIT(Spine Poller, 1.2.13, http://www.cacti.net/issues.php)
 
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_CANONICAL_HOST
 AC_CONFIG_SRCDIR(spine.c)
 AC_PREFIX_DEFAULT(/usr/local/spine)
 AC_LANG(C)
+AC_PROG_CC
 
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_HEADERS(config/config.h)

--- a/configure.ac
+++ b/configure.ac
@@ -248,6 +248,8 @@ fi
 for i in $MYSQL_DIR /usr /usr/local /opt /opt/mysql /usr/pkg /usr/local/mysql; do
   MYSQL_LIB_CHK($i/lib64)
   MYSQL_LIB_CHK($i/lib64/mysql)
+  MYSQL_LIB_CHK($i/lib/x86_64-linux-gnu)
+  MYSQL_LIB_CHK($i/lib/x86_64-linux-gnu/mysql)
   MYSQL_LIB_CHK($i/lib)
   MYSQL_LIB_CHK($i/lib/mysql)
 done
@@ -290,7 +292,11 @@ else
           LIBS="-lmysqlclient -lm -ldl $LIBS"
         fi
       else
-        LIBS="-lmariadbclient -lm -ldl $LIBS"
+        if test -f $MYSQL_LIB_DIR/libperconaserverclient.a -o -f $MYSQL_LIB_DIR/libperconaserverclient.$ShLib; then
+          LIBS="-lperconaserverclient -lm -ldl $LIBS"
+        else
+          LIBS="-lmariadbclient -lm -ldl $LIBS"
+        fi
       fi
     fi
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.53)
-AC_INIT(Spine Poller, 1.2.10, http://www.cacti.net/issues.php)
+AC_INIT(Spine Poller, 1.2.11, http://www.cacti.net/issues.php)
 
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.53)
-AC_INIT(Spine Poller, 1.2.16, http://www.cacti.net/issues.php)
+AC_INIT(Spine Poller, 1.2.17, http://www.cacti.net/issues.php)
 
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.53)
-AC_INIT(Spine Poller, 1.2.14, http://www.cacti.net/issues.php)
+AC_INIT(Spine Poller, 1.2.15, http://www.cacti.net/issues.php)
 
 AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)

--- a/error.c
+++ b/error.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/error.c
+++ b/error.c
@@ -46,73 +46,34 @@
 static void spine_signal_handler(int spine_signal) {
 	signal(spine_signal, SIG_DFL);
 
-#if HAS_EXECINFO_H
-	// get void*'s for all entries on the stack
-	set.exit_size = backtrace(set.exit_stack, 10);
-#endif
-
 	set.exit_code = spine_signal;
 
 	switch (spine_signal) {
 		case SIGABRT:
-			spine_print_backtrace();
 			die("FATAL: Spine Interrupted by Abort Signal");
 			break;
 		case SIGINT:
-			spine_print_backtrace();
 			die("FATAL: Spine Interrupted by Console Operator");
 			break;
 		case SIGSEGV:
-			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Segmentation Fault");
 			break;
 		case SIGBUS:
-			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Bus Error");
 			break;
 		case SIGFPE:
-			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Floating Point Exception");
 			break;
 		case SIGQUIT:
-			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Keyboard Quit Command");
 			break;
 		case SIGPIPE:
-			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Broken Pipe");
 			break;
 		default:
-			spine_print_backtrace();
 			die("FATAL: Spine Encountered An Unhandled Exception Signal Number: '%d'", spine_signal);
 			break;
 	}
-}
-
-void spine_print_backtrace() {
-	int nptrs;
-	int bt_buf_size = 100;
-	void *buffer[bt_buf_size];
-	char **strings;
-	int j;
-
-	nptrs = backtrace(buffer, bt_buf_size);
-	fprintf(stderr, "backtrace() returned %d addresses\n", nptrs);
-
-	/* The call backtrace_symbols_fd(buffer, nptrs, STDOUT_FILENO)
-	 * would produce similar output to the following: */
-
-	strings = backtrace_symbols(buffer, nptrs);
-	if (strings == NULL) {
-		perror("Spine backtrace symbols follow");
-		exit(EXIT_FAILURE);
-	}
-
-	for (j = 0; j < nptrs; j++) {
-		fprintf(stderr, "%s\n", strings[j]);
-	}
-
-	free(strings);
 }
 
 static int spine_fatal_signals[] = {

--- a/error.c
+++ b/error.c
@@ -56,7 +56,29 @@ static void spine_signal_handler(int spine_signal) {
 			die("FATAL: Spine Interrupted by Console Operator");
 			break;
 		case SIGSEGV:
-			die("FATAL: Spine Encountered a Segmentation Fault");
+			printf("FATAL: Spine Encountered a Segmentation Fault\n");
+
+			#ifdef HAVE_EXECINFO_H
+				int row = 0;
+				char **exit_strings = NULL;
+
+				fprintf(stderr, "Generating backtrace...%ld line(s)...\n", set.exit_size);
+
+				if (set.exit_size) {
+					set.exit_size = backtrace(set.exit_stack, set.exit_size);
+					exit_strings  = backtrace_symbols(set.exit_stack, set.exit_size);
+
+					if (exit_strings) {
+						for (row = 0; row < set.exit_size; row++) {
+							fprintf(stderr, "%3d: %s\n", row, exit_strings[row]);
+						}
+
+						free(exit_strings);
+					}
+				}
+			#endif
+			exit(1);
+
 			break;
 		case SIGBUS:
 			die("FATAL: Spine Encountered a Bus Error");

--- a/error.c
+++ b/error.c
@@ -54,28 +54,65 @@ static void spine_signal_handler(int spine_signal) {
 	set.exit_code = spine_signal;
 
 	switch (spine_signal) {
+		case SIGABRT:
+			spine_print_backtrace();
+			die("FATAL: Spine Interrupted by Abort Signal");
+			break;
 		case SIGINT:
+			spine_print_backtrace();
 			die("FATAL: Spine Interrupted by Console Operator");
 			break;
 		case SIGSEGV:
+			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Segmentation Fault");
 			break;
 		case SIGBUS:
+			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Bus Error");
 			break;
 		case SIGFPE:
+			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Floating Point Exception");
 			break;
 		case SIGQUIT:
+			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Keyboard Quit Command");
 			break;
 		case SIGPIPE:
+			spine_print_backtrace();
 			die("FATAL: Spine Encountered a Broken Pipe");
 			break;
 		default:
+			spine_print_backtrace();
 			die("FATAL: Spine Encountered An Unhandled Exception Signal Number: '%d'", spine_signal);
 			break;
 	}
+}
+
+void spine_print_backtrace() {
+	int nptrs;
+	int bt_buf_size = 100;
+	void *buffer[bt_buf_size];
+	char **strings;
+	int j;
+
+	nptrs = backtrace(buffer, bt_buf_size);
+	fprintf(stderr, "backtrace() returned %d addresses\n", nptrs);
+
+	/* The call backtrace_symbols_fd(buffer, nptrs, STDOUT_FILENO)
+	 * would produce similar output to the following: */
+
+	strings = backtrace_symbols(buffer, nptrs);
+	if (strings == NULL) {
+		perror("Spine backtrace symbols follow");
+		exit(EXIT_FAILURE);
+	}
+
+	for (j = 0; j < nptrs; j++) {
+		fprintf(stderr, "%s\n", strings[j]);
+	}
+
+	free(strings);
 }
 
 static int spine_fatal_signals[] = {

--- a/error.c
+++ b/error.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/error.h
+++ b/error.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/error.h
+++ b/error.h
@@ -31,5 +31,6 @@
  +-------------------------------------------------------------------------+
 */
 
+extern void spine_print_backtrace(void);
 extern void install_spine_signal_handler(void);
 extern void uninstall_spine_signal_handler(void);

--- a/error.h
+++ b/error.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/error.h
+++ b/error.h
@@ -31,6 +31,5 @@
  +-------------------------------------------------------------------------+
 */
 
-extern void spine_print_backtrace(void);
 extern void install_spine_signal_handler(void);
 extern void uninstall_spine_signal_handler(void);

--- a/keywords.c
+++ b/keywords.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/keywords.c
+++ b/keywords.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/keywords.h
+++ b/keywords.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/keywords.h
+++ b/keywords.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/locks.c
+++ b/locks.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/locks.c
+++ b/locks.c
@@ -65,48 +65,63 @@ DEFINE_SPINE_LOCK(php_proc_6)
 DEFINE_SPINE_LOCK(php_proc_7)
 DEFINE_SPINE_LOCK(php_proc_8)
 DEFINE_SPINE_LOCK(php_proc_9)
+DEFINE_SPINE_LOCK(php_proc_10)
+DEFINE_SPINE_LOCK(php_proc_11)
+DEFINE_SPINE_LOCK(php_proc_12)
+DEFINE_SPINE_LOCK(php_proc_13)
+DEFINE_SPINE_LOCK(php_proc_14)
 
 void init_mutexes() {
-	pthread_once((pthread_once_t*) get_attr(LOCK_SNMP_O),       init_snmp_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_SETEUID_O),    init_seteuid_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_GHBN_O),       init_ghbn_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_POOL_O),       init_pool_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_SYSLOG_O),     init_syslog_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_O),        init_php_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PEND_O),       init_pend_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_0_O), init_php_proc_0_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_1_O), init_php_proc_1_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_2_O), init_php_proc_2_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_3_O), init_php_proc_3_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_4_O), init_php_proc_4_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_5_O), init_php_proc_5_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_6_O), init_php_proc_6_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_7_O), init_php_proc_7_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_8_O), init_php_proc_8_lock);
-	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_9_O), init_php_proc_9_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_SNMP_O),        init_snmp_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_SETEUID_O),     init_seteuid_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_GHBN_O),        init_ghbn_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_POOL_O),        init_pool_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_SYSLOG_O),      init_syslog_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_O),         init_php_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PEND_O),        init_pend_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_0_O),  init_php_proc_0_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_1_O),  init_php_proc_1_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_2_O),  init_php_proc_2_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_3_O),  init_php_proc_3_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_4_O),  init_php_proc_4_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_5_O),  init_php_proc_5_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_6_O),  init_php_proc_6_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_7_O),  init_php_proc_7_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_8_O),  init_php_proc_8_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_9_O),  init_php_proc_9_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_10_O), init_php_proc_10_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_11_O), init_php_proc_11_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_12_O), init_php_proc_12_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_13_O), init_php_proc_13_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_14_O), init_php_proc_14_lock);
 }
 
 pthread_mutex_t* get_lock(int lock) {
 	pthread_mutex_t *ret_val = NULL;
 
 	switch (lock) {
-	case LOCK_SNMP:       ret_val = &snmp_lock;       break;
-	case LOCK_SETEUID:    ret_val = &seteuid_lock;    break;
-	case LOCK_GHBN:       ret_val = &ghbn_lock;       break;
-	case LOCK_POOL:       ret_val = &pool_lock;       break;
-	case LOCK_SYSLOG:     ret_val = &syslog_lock;     break;
-	case LOCK_PHP:        ret_val = &php_lock;        break;
-	case LOCK_PHP_PROC_0: ret_val = &php_proc_0_lock; break;
-	case LOCK_PHP_PROC_1: ret_val = &php_proc_1_lock; break;
-	case LOCK_PHP_PROC_2: ret_val = &php_proc_2_lock; break;
-	case LOCK_PHP_PROC_3: ret_val = &php_proc_3_lock; break;
-	case LOCK_PHP_PROC_4: ret_val = &php_proc_4_lock; break;
-	case LOCK_PHP_PROC_5: ret_val = &php_proc_5_lock; break;
-	case LOCK_PHP_PROC_6: ret_val = &php_proc_6_lock; break;
-	case LOCK_PHP_PROC_7: ret_val = &php_proc_7_lock; break;
-	case LOCK_PHP_PROC_8: ret_val = &php_proc_8_lock; break;
-	case LOCK_PHP_PROC_9: ret_val = &php_proc_9_lock; break;
-	case LOCK_PEND:       ret_val = &pend_lock;       break;
+	case LOCK_SNMP:        ret_val = &snmp_lock;        break;
+	case LOCK_SETEUID:     ret_val = &seteuid_lock;     break;
+	case LOCK_GHBN:        ret_val = &ghbn_lock;        break;
+	case LOCK_POOL:        ret_val = &pool_lock;        break;
+	case LOCK_SYSLOG:      ret_val = &syslog_lock;      break;
+	case LOCK_PHP:         ret_val = &php_lock;         break;
+	case LOCK_PHP_PROC_0:  ret_val = &php_proc_0_lock;  break;
+	case LOCK_PHP_PROC_1:  ret_val = &php_proc_1_lock;  break;
+	case LOCK_PHP_PROC_2:  ret_val = &php_proc_2_lock;  break;
+	case LOCK_PHP_PROC_3:  ret_val = &php_proc_3_lock;  break;
+	case LOCK_PHP_PROC_4:  ret_val = &php_proc_4_lock;  break;
+	case LOCK_PHP_PROC_5:  ret_val = &php_proc_5_lock;  break;
+	case LOCK_PHP_PROC_6:  ret_val = &php_proc_6_lock;  break;
+	case LOCK_PHP_PROC_7:  ret_val = &php_proc_7_lock;  break;
+	case LOCK_PHP_PROC_8:  ret_val = &php_proc_8_lock;  break;
+	case LOCK_PHP_PROC_9:  ret_val = &php_proc_9_lock;  break;
+	case LOCK_PHP_PROC_10: ret_val = &php_proc_10_lock; break;
+	case LOCK_PHP_PROC_11: ret_val = &php_proc_11_lock; break;
+	case LOCK_PHP_PROC_12: ret_val = &php_proc_12_lock; break;
+	case LOCK_PHP_PROC_13: ret_val = &php_proc_13_lock; break;
+	case LOCK_PHP_PROC_14: ret_val = &php_proc_14_lock; break;
+	case LOCK_PEND:        ret_val = &pend_lock;        break;
 	}
 
 	return ret_val;
@@ -116,23 +131,28 @@ pthread_once_t* get_attr(int locko) {
 	pthread_once_t *ret_val = NULL;
 
 	switch (locko) {
-	case LOCK_SNMP_O:       ret_val = &snmp_lock_o;       break;
-	case LOCK_SETEUID_O:    ret_val = &seteuid_lock_o;    break;
-	case LOCK_GHBN_O:       ret_val = &ghbn_lock_o;       break;
-	case LOCK_POOL_O:       ret_val = &pool_lock_o;       break;
-	case LOCK_SYSLOG_O:     ret_val = &syslog_lock_o;     break;
-	case LOCK_PHP_O:        ret_val = &php_lock_o;        break;
-	case LOCK_PHP_PROC_0_O: ret_val = &php_proc_0_lock_o; break;
-	case LOCK_PHP_PROC_1_O: ret_val = &php_proc_1_lock_o; break;
-	case LOCK_PHP_PROC_2_O: ret_val = &php_proc_2_lock_o; break;
-	case LOCK_PHP_PROC_3_O: ret_val = &php_proc_3_lock_o; break;
-	case LOCK_PHP_PROC_4_O: ret_val = &php_proc_4_lock_o; break;
-	case LOCK_PHP_PROC_5_O: ret_val = &php_proc_5_lock_o; break;
-	case LOCK_PHP_PROC_6_O: ret_val = &php_proc_6_lock_o; break;
-	case LOCK_PHP_PROC_7_O: ret_val = &php_proc_7_lock_o; break;
-	case LOCK_PHP_PROC_8_O: ret_val = &php_proc_8_lock_o; break;
-	case LOCK_PHP_PROC_9_O: ret_val = &php_proc_9_lock_o; break;
-	case LOCK_PEND_O:       ret_val = &pend_lock_o;       break;
+	case LOCK_SNMP_O:        ret_val = &snmp_lock_o;        break;
+	case LOCK_SETEUID_O:     ret_val = &seteuid_lock_o;     break;
+	case LOCK_GHBN_O:        ret_val = &ghbn_lock_o;        break;
+	case LOCK_POOL_O:        ret_val = &pool_lock_o;        break;
+	case LOCK_SYSLOG_O:      ret_val = &syslog_lock_o;      break;
+	case LOCK_PHP_O:         ret_val = &php_lock_o;         break;
+	case LOCK_PHP_PROC_0_O:  ret_val = &php_proc_0_lock_o;  break;
+	case LOCK_PHP_PROC_1_O:  ret_val = &php_proc_1_lock_o;  break;
+	case LOCK_PHP_PROC_2_O:  ret_val = &php_proc_2_lock_o;  break;
+	case LOCK_PHP_PROC_3_O:  ret_val = &php_proc_3_lock_o;  break;
+	case LOCK_PHP_PROC_4_O:  ret_val = &php_proc_4_lock_o;  break;
+	case LOCK_PHP_PROC_5_O:  ret_val = &php_proc_5_lock_o;  break;
+	case LOCK_PHP_PROC_6_O:  ret_val = &php_proc_6_lock_o;  break;
+	case LOCK_PHP_PROC_7_O:  ret_val = &php_proc_7_lock_o;  break;
+	case LOCK_PHP_PROC_8_O:  ret_val = &php_proc_8_lock_o;  break;
+	case LOCK_PHP_PROC_9_O:  ret_val = &php_proc_9_lock_o;  break;
+	case LOCK_PHP_PROC_10_O: ret_val = &php_proc_10_lock_o; break;
+	case LOCK_PHP_PROC_11_O: ret_val = &php_proc_11_lock_o; break;
+	case LOCK_PHP_PROC_12_O: ret_val = &php_proc_12_lock_o; break;
+	case LOCK_PHP_PROC_13_O: ret_val = &php_proc_13_lock_o; break;
+	case LOCK_PHP_PROC_14_O: ret_val = &php_proc_14_lock_o; break;
+	case LOCK_PEND_O:        ret_val = &pend_lock_o;        break;
 	}
 
 	return ret_val;

--- a/locks.c
+++ b/locks.c
@@ -51,6 +51,7 @@
 DEFINE_SPINE_LOCK(snmp)
 DEFINE_SPINE_LOCK(seteuid)
 DEFINE_SPINE_LOCK(ghbn)
+DEFINE_SPINE_LOCK(pool)
 DEFINE_SPINE_LOCK(syslog)
 DEFINE_SPINE_LOCK(php)
 DEFINE_SPINE_LOCK(pend)
@@ -69,6 +70,7 @@ void init_mutexes() {
 	pthread_once((pthread_once_t*) get_attr(LOCK_SNMP_O),       init_snmp_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_SETEUID_O),    init_seteuid_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_GHBN_O),       init_ghbn_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_POOL_O),       init_pool_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_SYSLOG_O),     init_syslog_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_O),        init_php_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_PEND_O),       init_pend_lock);
@@ -91,6 +93,7 @@ pthread_mutex_t* get_lock(int lock) {
 	case LOCK_SNMP:       ret_val = &snmp_lock;       break;
 	case LOCK_SETEUID:    ret_val = &seteuid_lock;    break;
 	case LOCK_GHBN:       ret_val = &ghbn_lock;       break;
+	case LOCK_POOL:       ret_val = &pool_lock;       break;
 	case LOCK_SYSLOG:     ret_val = &syslog_lock;     break;
 	case LOCK_PHP:        ret_val = &php_lock;        break;
 	case LOCK_PHP_PROC_0: ret_val = &php_proc_0_lock; break;
@@ -116,6 +119,7 @@ pthread_once_t* get_attr(int locko) {
 	case LOCK_SNMP_O:       ret_val = &snmp_lock_o;       break;
 	case LOCK_SETEUID_O:    ret_val = &seteuid_lock_o;    break;
 	case LOCK_GHBN_O:       ret_val = &ghbn_lock_o;       break;
+	case LOCK_POOL_O:       ret_val = &pool_lock_o;       break;
 	case LOCK_SYSLOG_O:     ret_val = &syslog_lock_o;     break;
 	case LOCK_PHP_O:        ret_val = &php_lock_o;        break;
 	case LOCK_PHP_PROC_0_O: ret_val = &php_proc_0_lock_o; break;

--- a/locks.c
+++ b/locks.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/locks.h
+++ b/locks.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/locks.h
+++ b/locks.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/php.c
+++ b/php.c
@@ -60,16 +60,21 @@ char *php_cmd(const char *php_command, int php_process) {
 
 	/* place lock around mutex */
 	switch (php_process) {
-	case 0: thread_mutex_lock(LOCK_PHP_PROC_0);	break;
-	case 1: thread_mutex_lock(LOCK_PHP_PROC_1);	break;
-	case 2: thread_mutex_lock(LOCK_PHP_PROC_2);	break;
-	case 3: thread_mutex_lock(LOCK_PHP_PROC_3);	break;
-	case 4: thread_mutex_lock(LOCK_PHP_PROC_4);	break;
-	case 5: thread_mutex_lock(LOCK_PHP_PROC_5);	break;
-	case 6: thread_mutex_lock(LOCK_PHP_PROC_6);	break;
-	case 7: thread_mutex_lock(LOCK_PHP_PROC_7);	break;
-	case 8: thread_mutex_lock(LOCK_PHP_PROC_8);	break;
-	case 9: thread_mutex_lock(LOCK_PHP_PROC_9);	break;
+	case 0:  thread_mutex_lock(LOCK_PHP_PROC_0);  break;
+	case 1:  thread_mutex_lock(LOCK_PHP_PROC_1);  break;
+	case 2:  thread_mutex_lock(LOCK_PHP_PROC_2);  break;
+	case 3:  thread_mutex_lock(LOCK_PHP_PROC_3);  break;
+	case 4:  thread_mutex_lock(LOCK_PHP_PROC_4);  break;
+	case 5:  thread_mutex_lock(LOCK_PHP_PROC_5);  break;
+	case 6:  thread_mutex_lock(LOCK_PHP_PROC_6);  break;
+	case 7:  thread_mutex_lock(LOCK_PHP_PROC_7);  break;
+	case 8:  thread_mutex_lock(LOCK_PHP_PROC_8);  break;
+	case 9:  thread_mutex_lock(LOCK_PHP_PROC_9);  break;
+	case 10: thread_mutex_lock(LOCK_PHP_PROC_10); break;
+	case 11: thread_mutex_lock(LOCK_PHP_PROC_11); break;
+	case 12: thread_mutex_lock(LOCK_PHP_PROC_12); break;
+	case 13: thread_mutex_lock(LOCK_PHP_PROC_13); break;
+	case 14: thread_mutex_lock(LOCK_PHP_PROC_14); break;
 	}
 
 	/* send command to the script server */
@@ -100,16 +105,21 @@ char *php_cmd(const char *php_command, int php_process) {
 
 	/* unlock around php process */
 	switch (php_process) {
-	case 0: thread_mutex_unlock(LOCK_PHP_PROC_0); break;
-	case 1: thread_mutex_unlock(LOCK_PHP_PROC_1); break;
-	case 2: thread_mutex_unlock(LOCK_PHP_PROC_2); break;
-	case 3: thread_mutex_unlock(LOCK_PHP_PROC_3); break;
-	case 4: thread_mutex_unlock(LOCK_PHP_PROC_4); break;
-	case 5: thread_mutex_unlock(LOCK_PHP_PROC_5); break;
-	case 6: thread_mutex_unlock(LOCK_PHP_PROC_6); break;
-	case 7: thread_mutex_unlock(LOCK_PHP_PROC_7); break;
-	case 8: thread_mutex_unlock(LOCK_PHP_PROC_8); break;
-	case 9: thread_mutex_unlock(LOCK_PHP_PROC_9); break;
+	case 0:  thread_mutex_unlock(LOCK_PHP_PROC_0);  break;
+	case 1:  thread_mutex_unlock(LOCK_PHP_PROC_1);  break;
+	case 2:  thread_mutex_unlock(LOCK_PHP_PROC_2);  break;
+	case 3:  thread_mutex_unlock(LOCK_PHP_PROC_3);  break;
+	case 4:  thread_mutex_unlock(LOCK_PHP_PROC_4);  break;
+	case 5:  thread_mutex_unlock(LOCK_PHP_PROC_5);  break;
+	case 6:  thread_mutex_unlock(LOCK_PHP_PROC_6);  break;
+	case 7:  thread_mutex_unlock(LOCK_PHP_PROC_7);  break;
+	case 8:  thread_mutex_unlock(LOCK_PHP_PROC_8);  break;
+	case 9:  thread_mutex_unlock(LOCK_PHP_PROC_9);  break;
+	case 10: thread_mutex_unlock(LOCK_PHP_PROC_10); break;
+	case 11: thread_mutex_unlock(LOCK_PHP_PROC_11); break;
+	case 12: thread_mutex_unlock(LOCK_PHP_PROC_12); break;
+	case 13: thread_mutex_unlock(LOCK_PHP_PROC_13); break;
+	case 14: thread_mutex_unlock(LOCK_PHP_PROC_14); break;
 	}
 
 	return result_string;

--- a/php.c
+++ b/php.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/php.c
+++ b/php.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |
@@ -233,22 +233,22 @@ char *php_readpipe(int php_process) {
 	default:
 		if (FD_ISSET(php_processes[php_process].php_read_fd, &fds)) {
 			bptr = result_string;
-	
+
 			while (1) {
 				i = read(php_processes[php_process].php_read_fd, bptr, RESULTS_BUFFER-(bptr-result_string));
-	
+
 				if (i <= 0) {
 					SET_UNDEFINED(result_string);
 					break;
 				}
-	
+
 				bptr += i;
 				*bptr = '\0';	/* make what we've got into a string */
-	
+
 				if ((cp = strstr(result_string,"\n")) != 0) {
 					break;
 				}
-	
+
 				if (bptr >= result_string+BUFSIZE) {
 					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
 					SET_UNDEFINED(result_string);

--- a/php.h
+++ b/php.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/php.h
+++ b/php.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/ping.c
+++ b/ping.c
@@ -160,7 +160,7 @@ int ping_host(host_t *host, ping_t *ping) {
  *
  */
 int ping_snmp(host_t *host, ping_t *ping) {
-	char *poll_result;
+	char *poll_result = NULL;
 	char *oid;
 	double begin_time, end_time, total_time;
 	double one_thousand = 1000.00;

--- a/ping.c
+++ b/ping.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/ping.c
+++ b/ping.c
@@ -868,9 +868,6 @@ int get_address_type(host_t *host) {
 
 	if ((error = getaddrinfo(host->hostname, NULL, &hints, &res_list)) != 0) {
 		SPINE_LOG(("WARNING: Unable to determine address info for %s (%s)", host->hostname, gai_strerror(error)));
-		if (res_list != NULL) {
-			freeaddrinfo(res_list);
-		}
 		return SPINE_NONE;
 	}
 

--- a/ping.c
+++ b/ping.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/ping.h
+++ b/ping.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/ping.h
+++ b/ping.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/poller.c
+++ b/poller.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/poller.c
+++ b/poller.c
@@ -1517,7 +1517,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			die("ERROR: Fatal malloc error: poller.c query3 output buffer!");
 		}
 		query3[0] = '\0';
-		strncat(query3, query8, strlen(query3));
+		strncat(query3, query8, strlen(query8));
 
 		out_buffer = strlen(query3);
 
@@ -1527,7 +1527,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 				die("ERROR: Fatal malloc error: poller.c query12 boost output buffer!");
 			}
 			query12[0] = '\0';
-			strncat(query12, query11, strlen(query12));
+			strncat(query12, query11, strlen(query11));
 		}
 
 		int mode;
@@ -1552,24 +1552,24 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			/* if the next element to the buffer will overflow it, write to the database */
 			if ((out_buffer + result_length) >= MAX_MYSQL_BUF_SIZE) {
 				/* append the suffix */
-				strncat(query3, posuffix, strlen(query3));
+				strncat(query3, posuffix, strlen(posuffix));
 
 				/* insert the record */
 				db_insert(&mysqlt, mode, query3);
 
 				/* re-initialize the query buffer */
 				query3[0] = '\0';
-				strncat(query3, query8, strlen(query3));
+				strncat(query3, query8, strlen(query8));
 
 				/* insert the record for boost */
 				if (set.boost_redirect && set.boost_enabled) {
 					/* append the suffix */
-					strncat(query12, posuffix, strlen(query12));
+					strncat(query12, posuffix, strlen(posuffix));
 
 					db_insert(&mysqlt, mode, query12);
 
 					query12[0] = '\0';
-					strncat(query12, query11, strlen(query12));
+					strncat(query12, query11, strlen(query11));
 				}
 
 				/* reset the output buffer length */
@@ -1586,10 +1586,10 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 				result_string[0] = ',';
 			}
 
-			strncat(query3, result_string, strlen(query3));
+			strncat(query3, result_string, strlen(result_string));
 
 			if (set.boost_redirect && set.boost_enabled) {
-				strncat(query12, result_string, strlen(query12));
+				strncat(query12, result_string, strlen(result_string));
 			}
 
 			out_buffer = out_buffer + strlen(result_string);
@@ -1600,7 +1600,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 		/* perform the last insert if there is data to process */
 		if (out_buffer > strlen(query8)) {
 			/* append the suffix */
-			strncat(query3, posuffix, strlen(query3));
+			strncat(query3, posuffix, strlen(posuffix));
 
 			/* insert records into database */
 			db_insert(&mysqlt, mode, query3);
@@ -1608,7 +1608,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			/* insert the record for boost */
 			if (set.boost_redirect && set.boost_enabled) {
 				/* append the suffix */
-				strncat(query12, posuffix, strlen(query12));
+				strncat(query12, posuffix, strlen(posuffix));
 
 				db_insert(&mysqlt, mode, query12);
 			}

--- a/poller.c
+++ b/poller.c
@@ -1517,7 +1517,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			die("ERROR: Fatal malloc error: poller.c query3 output buffer!");
 		}
 		query3[0] = '\0';
-		strncat(query3, query8, strlen(query8));
+		strncat(query3, query8, strlen(query3));
 
 		out_buffer = strlen(query3);
 
@@ -1527,7 +1527,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 				die("ERROR: Fatal malloc error: poller.c query12 boost output buffer!");
 			}
 			query12[0] = '\0';
-			strncat(query12, query11, strlen(query11));
+			strncat(query12, query11, strlen(query12));
 		}
 
 		int mode;
@@ -1552,24 +1552,24 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			/* if the next element to the buffer will overflow it, write to the database */
 			if ((out_buffer + result_length) >= MAX_MYSQL_BUF_SIZE) {
 				/* append the suffix */
-				strncat(query3, posuffix, strlen(posuffix));
+				strncat(query3, posuffix, strlen(query3));
 
 				/* insert the record */
 				db_insert(&mysqlt, mode, query3);
 
 				/* re-initialize the query buffer */
 				query3[0] = '\0';
-				strncat(query3, query8, strlen(query8));
+				strncat(query3, query8, strlen(query3));
 
 				/* insert the record for boost */
 				if (set.boost_redirect && set.boost_enabled) {
 					/* append the suffix */
-					strncat(query12, posuffix, strlen(posuffix));
+					strncat(query12, posuffix, strlen(query12));
 
 					db_insert(&mysqlt, mode, query12);
 
 					query12[0] = '\0';
-					strncat(query12, query11, strlen(query11));
+					strncat(query12, query11, strlen(query12));
 				}
 
 				/* reset the output buffer length */
@@ -1586,10 +1586,10 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 				result_string[0] = ',';
 			}
 
-			strncat(query3, result_string, strlen(result_string));
+			strncat(query3, result_string, strlen(query3));
 
 			if (set.boost_redirect && set.boost_enabled) {
-				strncat(query12, result_string, strlen(result_string));
+				strncat(query12, result_string, strlen(query12));
 			}
 
 			out_buffer = out_buffer + strlen(result_string);
@@ -1600,7 +1600,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 		/* perform the last insert if there is data to process */
 		if (out_buffer > strlen(query8)) {
 			/* append the suffix */
-			strncat(query3, posuffix, strlen(posuffix));
+			strncat(query3, posuffix, strlen(query3));
 
 			/* insert records into database */
 			db_insert(&mysqlt, mode, query3);
@@ -1608,7 +1608,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 			/* insert the record for boost */
 			if (set.boost_redirect && set.boost_enabled) {
 				/* append the suffix */
-				strncat(query12, posuffix, strlen(posuffix));
+				strncat(query12, posuffix, strlen(query12));
 
 				db_insert(&mysqlt, mode, query12);
 			}

--- a/poller.c
+++ b/poller.c
@@ -175,6 +175,8 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 	char last_snmp_context[65];
 	char last_snmp_engine_id[30];
 	double poll_time = get_time_as_double();
+	double thread_start = 0;
+	double thread_end = 0;
 
 	/* reindex shortcuts to speed polling */
 	int previous_assert_failure = FALSE;
@@ -1090,6 +1092,8 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 
 		i = 0; k = 0;
 		while ((i < num_rows) && (!host->ignore_host)) {
+			thread_start = get_time_as_double();
+
 			switch(poller_items[i].action) {
 			case POLLER_ACTION_SNMP: /* raw SNMP poll */
 				/* initialize or reinitialize snmp as required */
@@ -1196,10 +1200,12 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 
 							snprintf(poller_items[snmp_oids[j].array_position].result, RESULTS_BUFFER, "%s", snmp_oids[j].result);
 
+							thread_end = get_time_as_double();
+
 							if (is_debug_device(host_id)) {
-								SPINE_LOG(("Device[%i] HT[%i] DS[%i] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
+								SPINE_LOG(("Device[%i] HT[%i] DS[%i] TT[%.2f] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, (thread_end - thread_start) * 1000, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
 							} else {
-								SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
+								SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] TT[%.2f] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, (thread_end - thread_start) * 1000, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
 							}
 						}
 
@@ -1291,10 +1297,12 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 
 						snprintf(poller_items[snmp_oids[j].array_position].result, RESULTS_BUFFER, "%s", snmp_oids[j].result);
 
+						thread_end = get_time_as_double();
+
 						if (is_debug_device(host_id)) {
-							SPINE_LOG(("Device[%i] HT[%i] DS[%i] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
+							SPINE_LOG(("Device[%i] HT[%i] DS[%i] TT[%.2f] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, (thread_end - thread_start) * 1000, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
 						} else {
-							SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
+							SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] TT[%.2f] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, (thread_end - thread_start) * 1000, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
 						}
 
 						if (!IS_UNDEFINED(poller_items[snmp_oids[j].array_position].result)) {
@@ -1357,10 +1365,12 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 
 				if (poll_result) free(poll_result);
 
+				thread_end = get_time_as_double();
+
 				if (is_debug_device(host_id)) {
-					SPINE_LOG(("Device[%i] HT[%i] DS[%i] SCRIPT: %s, output: %s", host_id, host_thread, poller_items[i].local_data_id, poller_items[i].arg1, poller_items[i].result));
+					SPINE_LOG(("Device[%i] HT[%i] DS[%i] TT[%.2f] SCRIPT: %s, output: %s", host_id, host_thread, poller_items[i].local_data_id, (thread_end - thread_start) * 1000, poller_items[i].arg1, poller_items[i].result));
 				} else {
-					SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] SCRIPT: %s, output: %s", host_id, host_thread, poller_items[i].local_data_id, poller_items[i].arg1, poller_items[i].result));
+					SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] TT[%.2f] SCRIPT: %s, output: %s", host_id, host_thread, poller_items[i].local_data_id, (thread_end - thread_start) * 1000, poller_items[i].arg1, poller_items[i].result));
 				}
 
 				if (!IS_UNDEFINED(poller_items[i].result)) {
@@ -1413,10 +1423,12 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 
 				if (poll_result) free(poll_result);
 
+				thread_end = get_time_as_double();
+
 				if (is_debug_device(host_id)) {
-					SPINE_LOG(("Device[%i] HT[%i] DS[%i] SS[%i] SERVER: %s, output: %s", host_id, host_thread, poller_items[i].local_data_id, php_process, poller_items[i].arg1, poller_items[i].result));
+					SPINE_LOG(("Device[%i] HT[%i] DS[%i] SS[%i] TT[%.2f] SERVER: %s, output: %s", host_id, host_thread, poller_items[i].local_data_id, php_process, (thread_end - thread_start) * 1000, poller_items[i].arg1, poller_items[i].result));
 				} else {
-					SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] SS[%i] SERVER: %s, output: %s", host_id, host_thread, poller_items[i].local_data_id, php_process, poller_items[i].arg1, poller_items[i].result));
+					SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] SS[%i] TT[%.2f] SERVER: %s, output: %s", host_id, host_thread, poller_items[i].local_data_id, php_process, (thread_end - thread_start) * 1000, poller_items[i].arg1, poller_items[i].result));
 				}
 
 				if (IS_UNDEFINED(poller_items[i].result)) {
@@ -1497,10 +1509,12 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 
 				snprintf(poller_items[snmp_oids[j].array_position].result, RESULTS_BUFFER, "%s", snmp_oids[j].result);
 
+				thread_end = get_time_as_double();
+
 				if (is_debug_device(host_id)) {
-					SPINE_LOG(("Device[%i] HT[%i] DS[%i] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
+					SPINE_LOG(("Device[%i] HT[%i] DS[%i] TT[%.2f] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, (thread_end - thread_start) * 1000, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
 				} else {
-					SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
+					SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] TT[%.2f] SNMP: v%i: %s, dsname: %s, oid: %s, value: %s", host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, (thread_end - thread_start) * 1000, host->snmp_version, host->hostname, poller_items[snmp_oids[j].array_position].rrd_name, poller_items[snmp_oids[j].array_position].arg1, poller_items[snmp_oids[j].array_position].result));
 				}
 
 				if (!IS_UNDEFINED(poller_items[snmp_oids[j].array_position].result)) {

--- a/poller.c
+++ b/poller.c
@@ -1175,7 +1175,7 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 								/* is valid output, continue */
 							} else {
 								/* remove double or single quotes from string */
-								snprintf(temp_result, RESULTS_BUFFER, "%s", snmp_oids[j].result);
+								snprintf(temp_result, RESULTS_BUFFER, "%s", strip_alpha(trim(snmp_oids[j].result)));
 								snprintf(snmp_oids[j].result , RESULTS_BUFFER, "%s", temp_result);
 
 								/* detect erroneous non-numeric result */

--- a/poller.c
+++ b/poller.c
@@ -745,9 +745,11 @@ void poll_host(int host_id, int host_thread, int last_host_thread, int host_data
 									}
 									poll_result[0] = '\0';
 									snprintf(poll_result, BUFSIZE, "%s", sysUptime);
-								} else {
+								} else if (strstr(reindex->arg1, ".1.3.6.1.2.1.1.3.0")) {
 									poll_result = snmp_get(host, reindex->arg1);
 									snprintf(sysUptime, BUFSIZE, "%s", poll_result);
+								} else {
+									poll_result = snmp_get(host, reindex->arg1);
 								}
 
 								if (is_debug_device(host->id)) {

--- a/poller.c
+++ b/poller.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/poller.h
+++ b/poller.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/poller.h
+++ b/poller.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/snmp.c
+++ b/snmp.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/snmp.c
+++ b/snmp.c
@@ -186,7 +186,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 	snprintf(hostnameport, BUFSIZE, "%s:%i", hostname, snmp_port);
 	session.peername    = hostnameport;
 	session.retries     = set.snmp_retries;
-	session.remote_port = snmp_port;
 	session.timeout     = (snmp_timeout * 1000); /* net-snmp likes microseconds */
 
 	SPINE_LOG_MEDIUM(("Device[%i] INFO: SNMP Device '%s' has timeout %ld (%d), retries %d", host_id, hostname, session.timeout, snmp_timeout, session.retries));

--- a/snmp.c
+++ b/snmp.c
@@ -383,7 +383,7 @@ char *snmp_get(host_t *current_host, char *snmp_oid) {
 
 					snprint_value(temp_result, RESULTS_BUFFER, vars->name, vars->name_length, vars);
 
-					snprint_asciistring(result_string, RESULTS_BUFFER, temp_result, strlen(temp_result));
+					snprintf(result_string, RESULTS_BUFFER, "%s", trim(temp_result));
 				} else {
 					SPINE_LOG_HIGH(("ERROR: Failed to get oid '%s' for Device[%d]",  snmp_oid, current_host->id));
 				}

--- a/snmp.c
+++ b/snmp.c
@@ -2,6 +2,7 @@
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
  | Copyright (C) 2004-2021 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |
@@ -384,11 +385,11 @@ char *snmp_get(host_t *current_host, char *snmp_oid) {
 
 					snprintf(result_string, RESULTS_BUFFER, "%s", trim(temp_result));
 				} else {
-					SPINE_LOG_HIGH(("ERROR: Failed to get oid '%s' for Device[%d]",  snmp_oid, current_host->id));
+					SPINE_LOG_HIGH(("ERROR: Failed to get oid '%s' for Device[%d] with Response[%d]",  snmp_oid, current_host->id, response->errstat));
 				}
 			}
 		} else {
-			SPINE_LOG_HIGH(("ERROR: Failed to get oid '%s' for Device[%d]",  snmp_oid, current_host->id));
+			SPINE_LOG_HIGH(("ERROR: Failed to get oid '%s' for Device[%d] with Status[%d]",  snmp_oid, current_host->id, status));
 		}
 
 		if (response) {

--- a/snmp.c
+++ b/snmp.c
@@ -344,27 +344,27 @@ char *snmp_get(host_t *current_host, char *snmp_oid) {
 	if (current_host->snmp_session != NULL) {
 		anOID_len = MAX_OID_LEN;
 
-		SPINE_LOG_DEVDBG(("Device[%i] WARNING: snmp_pdu_create(%s)", current_host->id, snmp_oid));
+		SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_pdu_create(%s)", current_host->id, snmp_oid));
 		pdu = snmp_pdu_create(SNMP_MSG_GET);
-		SPINE_LOG_DEVDBG(("Device[%i] WARNING: snmp_pdu_create(%s) [complete]", current_host->id, snmp_oid));
+		SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_pdu_create(%s) [complete]", current_host->id, snmp_oid));
 
-		SPINE_LOG_DEVDBG(("Device[%i] WARNING: snmp_parse_oid(%s)", current_host->id, snmp_oid));
+		SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_parse_oid(%s)", current_host->id, snmp_oid));
 		if (!snmp_parse_oid(snmp_oid, anOID, &anOID_len)) {
-			SPINE_LOG_DEVDBG(("Device[%i] WARNING: snmp_parse_oid(%s) [complete]", current_host->id, snmp_oid));
+			SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_parse_oid(%s) [complete]", current_host->id, snmp_oid));
 			SPINE_LOG(("Device[%i] ERROR: SNMP Get Problems parsing SNMP OID %s", current_host->id, snmp_oid));
 			SET_UNDEFINED(result_string);
 			return result_string;
 		} else {
-			SPINE_LOG_DEVDBG(("Device[%i] WARNING: snmp_parse_oid(%s) [complete]", current_host->id, snmp_oid));
-			SPINE_LOG_DEVDBG(("Device[%i] WARNING: snmp_add_null_var(%s)", current_host->id, snmp_oid));
+			SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_parse_oid(%s) [complete]", current_host->id, snmp_oid));
+			SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_add_null_var(%s)", current_host->id, snmp_oid));
 			snmp_add_null_var(pdu, anOID, anOID_len);
-			SPINE_LOG_DEVDBG(("Device[%i] WARNING: snmp_add_null_var(%s) [complete]", current_host->id, snmp_oid));
+			SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_add_null_var(%s) [complete]", current_host->id, snmp_oid));
 		}
 
 		/* poll host */
-		SPINE_LOG_DEVDBG(("Device[%i] WARNING: snmp_sess_sync_response(%s)", current_host->id, snmp_oid));
+		SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_sess_sync_response(%s)", current_host->id, snmp_oid));
 		status = snmp_sess_synch_response(current_host->snmp_session, pdu, &response);
-		SPINE_LOG_DEVDBG(("Device[%i] WARNING: snmp_sess_sync_response(%s) [complete]", current_host->id, snmp_oid));
+		SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_sess_sync_response(%s) [complete]", current_host->id, snmp_oid));
 
 		/* add status to host structure */
 		current_host->snmp_status = status;

--- a/snmp.c
+++ b/snmp.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/snmp.h
+++ b/snmp.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/snmp.h
+++ b/snmp.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/spine.c
+++ b/spine.c
@@ -699,7 +699,7 @@ int main(int argc, char *argv[]) {
 		}
 
 		/* adjust device threads in cases where the host does not have sufficient data sources */
-		snprintf(querybuf, BIG_BUFSIZE, "SELECT COUNT(*) FROM poller_item WHERE host_id=%i AND rrd_next_step <=0", host_id);
+		snprintf(querybuf, BIG_BUFSIZE, "SELECT COUNT(local_data_id) FROM poller_item WHERE host_id=%i AND rrd_next_step <=0", host_id);
 		tresult   = db_query(&mysql, LOCAL, querybuf);
 		mysql_row = mysql_fetch_row(tresult);
 
@@ -715,7 +715,7 @@ int main(int argc, char *argv[]) {
 		/* determine how many items will be polled per thread */
 		if (device_threads > 1) {
 			if (current_thread == 1) {
-				snprintf(querybuf, BIG_BUFSIZE, "SELECT CEIL(COUNT(*)/%i) FROM poller_item WHERE host_id=%i AND rrd_next_step <=0", device_threads, host_id);
+				snprintf(querybuf, BIG_BUFSIZE, "SELECT CEIL(COUNT(local_data_id)/%i) FROM poller_item WHERE host_id=%i AND rrd_next_step <=0", device_threads, host_id);
 				tresult   = db_query(&mysql, LOCAL, querybuf);
 				mysql_row = mysql_fetch_row(tresult);
 

--- a/spine.c
+++ b/spine.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |
@@ -1000,7 +1000,7 @@ static void display_help(int only_version) {
 		0 /* ENDMARKER */
 	};
 
-	printf("SPINE %s  Copyright 2004-2019 by The Cacti Group\n", VERSION);
+	printf("SPINE %s  Copyright 2004-2020 by The Cacti Group\n", VERSION);
 
 	if (only_version == FALSE) {
 		printf("\n");

--- a/spine.c
+++ b/spine.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/spine.h
+++ b/spine.h
@@ -58,7 +58,7 @@
 #define DISABLE_STDERR
 #endif
 
-#ifdef HAS_EXECINFO_H
+#ifdef HAVE_EXECINFO_H
 #include <execinfo.h>
 #endif
 

--- a/spine.h
+++ b/spine.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/spine.h
+++ b/spine.h
@@ -183,7 +183,12 @@
 #define LOCK_PHP_PROC_7 14
 #define LOCK_PHP_PROC_8 15
 #define LOCK_PHP_PROC_9 16
-#define LOCK_PEND 17
+#define LOCK_PHP_PROC_10 17
+#define LOCK_PHP_PROC_11 18
+#define LOCK_PHP_PROC_12 19
+#define LOCK_PHP_PROC_13 20
+#define LOCK_PHP_PROC_14 21
+#define LOCK_PEND 30
 
 #define LOCK_SNMP_O 0
 #define LOCK_SETEUID_O 2
@@ -201,7 +206,12 @@
 #define LOCK_PHP_PROC_7_O 14
 #define LOCK_PHP_PROC_8_O 15
 #define LOCK_PHP_PROC_9_O 16
-#define LOCK_PEND_O 17
+#define LOCK_PHP_PROC_10_O 17
+#define LOCK_PHP_PROC_11_O 18
+#define LOCK_PHP_PROC_12_O 19
+#define LOCK_PHP_PROC_13_O 20
+#define LOCK_PHP_PROC_14_O 21
+#define LOCK_PEND_O 30
 
 /* poller actions */
 #define POLLER_ACTION_SNMP 0
@@ -275,7 +285,7 @@
 #define ICMP_HDR_SIZE 8
 
 /* required for PHP Script Server */
-#define MAX_PHP_SERVERS 10
+#define MAX_PHP_SERVERS 15
 #define PHP_READY 0
 #define PHP_BUSY 1
 #define PHP_INIT 999

--- a/spine.h
+++ b/spine.h
@@ -58,7 +58,7 @@
 #define DISABLE_STDERR
 #endif
 
-#ifdef HAVE_EXECINFO_H
+#ifdef HAS_EXECINFO_H
 #include <execinfo.h>
 #endif
 
@@ -170,6 +170,7 @@
 #define LOCK_SNMP 0
 #define LOCK_SETEUID 2
 #define LOCK_GHBN 3
+#define LOCK_POOL 4
 #define LOCK_SYSLOG 5
 #define LOCK_PHP 6
 #define LOCK_PHP_PROC_0 7
@@ -187,6 +188,7 @@
 #define LOCK_SNMP_O 0
 #define LOCK_SETEUID_O 2
 #define LOCK_GHBN_O 3
+#define LOCK_POOL_O 4
 #define LOCK_SYSLOG_O 5
 #define LOCK_PHP_O 6
 #define LOCK_PHP_PROC_0_O 7
@@ -552,7 +554,7 @@ typedef struct host_reindex_struct {
 	int    action;
 } reindex_t;
 
-/*! Ping Result Struction
+/*! Ping Result Structure
  *
  * This structure holds the results of a host ping.
  *
@@ -564,6 +566,16 @@ typedef struct ping_results {
 	char   snmp_status[50];
 	char   snmp_response[SMALL_BUFSIZE];
 } ping_t;
+
+/*! MySQL Connection Pool Structure
+ *
+ * This structure holds the mysql connetion pool object.
+ */
+typedef struct db_connection {
+	int   id;
+	int   free;
+	MYSQL mysql;
+} pool_t;
 
 /* Include all Standard Spine Headers */
 #include "poller.h"
@@ -583,5 +595,7 @@ extern php_t  *php_processes;
 extern char   start_datetime[20];
 extern char   config_paths[CONFIG_PATHS][BUFSIZE];
 extern sem_t  active_threads;
+extern pool_t *db_pool_remote;
+extern pool_t *db_pool_local;
 
 #endif /* not _SPINE_H_ */

--- a/spine.h
+++ b/spine.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/sql.c
+++ b/sql.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |
@@ -291,7 +291,7 @@ void db_connect(int type, MYSQL *mysql) {
 			error = mysql_errno(mysql);
 			db_disconnect(mysql);
 
-			if (error == 2013 && errno == EINTR) {
+			if ((error == 2003 || error == 2013) && errno == EINTR) {
 				usleep(50000);
 				tries++;
 				success = FALSE;

--- a/sql.c
+++ b/sql.c
@@ -289,7 +289,7 @@ void db_connect(int type, MYSQL *mysql) {
 			error = mysql_errno(mysql);
 			db_disconnect(mysql);
 
-			if ((error == 2003 || error == 2013) && errno == EINTR) {
+			if ((error == 2002 || error == 2003 || error == 2006 || error == 2013) && errno == EINTR) {
 				usleep(50000);
 				tries++;
 				success = FALSE;

--- a/sql.c
+++ b/sql.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/sql.h
+++ b/sql.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/sql.h
+++ b/sql.h
@@ -37,6 +37,10 @@ extern void db_connect(int type, MYSQL *mysql);
 extern void db_disconnect(MYSQL *mysql);
 extern void db_escape(MYSQL *mysql, char *output, int max_size, const char *input);
 extern void db_free_result(MYSQL_RES *result);
+extern void db_create_connection_pool(int type);
+extern void db_close_connection_pool(int type);
+extern pool_t db_get_connection(int type);
+extern void db_release_connection(int type, int id);
 
 extern int append_hostrange(char *obuf, const char *colname);
 

--- a/sql.h
+++ b/sql.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/util.c
+++ b/util.c
@@ -1005,13 +1005,13 @@ void die(const char *format, ...) {
 
 	set.exit_size = 10;
 
-	fprintf(stderr, "Generating backtrace...%ld line(s)...\n", set.exit_size);
-
 	if (set.exit_size) {
 		set.exit_size = backtrace(set.exit_stack, set.exit_size);
 		exit_strings  = backtrace_symbols(set.exit_stack, set.exit_size);
 
 		if (exit_strings) {
+			fprintf(stderr, "Generating backtrace...%ld line(s)...\n", set.exit_size);
+
 			for (row = 0; row < set.exit_size; row++) {
 				fprintf(stderr, "%3d: %s\n", row, exit_strings[row]);
 			}

--- a/util.c
+++ b/util.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/util.c
+++ b/util.c
@@ -1001,7 +1001,7 @@ void die(const char *format, ...) {
 
 #ifdef HAVE_EXECINFO_H
 	int row = 0;
-	char **exit_strings = NULL;
+	char **exit_strings = (char **)NULL;
 
 	fprintf(stderr, "Generating backtrace...%ld line(s)...\n", set.exit_size);
 

--- a/util.c
+++ b/util.c
@@ -999,38 +999,6 @@ void die(const char *format, ...) {
 
 	SPINE_LOG(("%s", flogmessage));
 
-#ifdef HAVE_EXECINFO_H
-	int row = 0;
-	char **exit_strings = (char **) NULL;
-
-	set.exit_size = 10;
-
-	if (set.exit_size) {
-		set.exit_size = backtrace(set.exit_stack, set.exit_size);
-		exit_strings  = backtrace_symbols(set.exit_stack, set.exit_size);
-
-		if (exit_strings) {
-			fprintf(stderr, "Generating backtrace...%ld line(s)...\n", set.exit_size);
-
-			for (row = 0; row < set.exit_size; row++) {
-				fprintf(stderr, "%3d: %s\n", row, exit_strings[row]);
-			}
-
-			free(exit_strings);
-		}
-	}
-#endif
-
-	// Close the local connection pool
-	if (db_pool_local) {
-		db_close_connection_pool(LOCAL);
-	}
-
-	// Close the remote connection pool
-	if (db_pool_remote) {
-		db_close_connection_pool(REMOTE);
-	}
-
 	if (set.parent_fork == SPINE_PARENT) {
 		if (set.php_initialized) {
 			php_close(PHP_INIT);

--- a/util.c
+++ b/util.c
@@ -1001,7 +1001,9 @@ void die(const char *format, ...) {
 
 #ifdef HAVE_EXECINFO_H
 	int row = 0;
-	char **exit_strings = (char **)NULL;
+	char **exit_strings = (char **) NULL;
+
+	set.exit_size = 10;
 
 	fprintf(stderr, "Generating backtrace...%ld line(s)...\n", set.exit_size);
 
@@ -1011,7 +1013,7 @@ void die(const char *format, ...) {
 
 		if (exit_strings) {
 			for (row = 0; row < set.exit_size; row++) {
-			        fprintf(stderr, "%3d: %s\n", row, exit_strings[row]);
+				fprintf(stderr, "%3d: %s\n", row, exit_strings[row]);
 			}
 
 			free(exit_strings);

--- a/util.c
+++ b/util.c
@@ -1021,6 +1021,16 @@ void die(const char *format, ...) {
 	}
 #endif
 
+	// Close the local connection pool
+	if (db_pool_local) {
+		db_close_connection_pool(LOCAL);
+	}
+
+	// Close the remote connection pool
+	if (db_pool_remote) {
+		db_close_connection_pool(REMOTE);
+	}
+
 	if (set.parent_fork == SPINE_PARENT) {
 		if (set.php_initialized) {
 			php_close(PHP_INIT);

--- a/util.c
+++ b/util.c
@@ -1171,7 +1171,7 @@ int spine_log(const char *format, ...) {
 
 	/* append a line feed to the log message if needed */
 	if (!strstr(flogmessage, "\n")) {
-		strncat(flogmessage, "\n", 1);
+		strcat(flogmessage, "\n");
 	}
 
 	if ((IS_LOGGING_TO_FILE() &&
@@ -1471,7 +1471,7 @@ char *strncopy(char *dst, const char *src, size_t obuf) {
 	if (!len) {
 		dst[0] = '\0';
 	} else if (len < obuf) {
-		strncpy(dst, src, len);
+		strncpy(dst, src, sizeof(dst));
 		dst[len] = '\0';
 	} else {
 		strncpy(dst, src, --obuf);

--- a/util.c
+++ b/util.c
@@ -1001,7 +1001,7 @@ void die(const char *format, ...) {
 
 #ifdef HAVE_EXECINFO_H
 	int row = 0;
-	char **exit_strings = null;
+	char **exit_strings = NULL;
 
 	fprintf(stderr, "Generating backtrace...%ld line(s)...\n", set.exit_size);
 

--- a/util.c
+++ b/util.c
@@ -1345,32 +1345,44 @@ int is_numeric(char *string) {
  *
  *  \return TRUE if the string is valid hex, FALSE otherwise
  *
+ *  The function is modified where the string needs to include
+ *  at least one of the following string ' ', '-', or ':'
+ *
  */
-int is_hexadecimal(const char * str, const short ignore_space) {
+int is_hexadecimal(const char * str, const short ignore_special) {
 	int i = 0;
+	int delim_found = FALSE;
 
 	if (!str) return FALSE;
 
 	while (*str) {
 		switch (*str) {
-		case '0': case '1': case '2': case '3':
-		case '4': case '5': case '6': case '7':
-		case '8': case '9':
-		case 'a': case 'A': case 'b': case 'B':
-		case 'c': case 'C': case 'd': case 'D':
-		case 'e': case 'E': case 'f': case 'F':
-		case '"':
-			break;
-		case ' ': case '\t':
-			if (ignore_space) break;
-		default:
-			return FALSE;
+			case '0': case '1': case '2': case '3':
+			case '4': case '5': case '6': case '7':
+			case '8': case '9':
+			case 'a': case 'A': case 'b': case 'B':
+			case 'c': case 'C': case 'd': case 'D':
+			case 'e': case 'E': case 'f': case 'F':
+			case '"':
+				break;
+			case '-': case ':': case ' ':
+				delim_found = TRUE;
+				break;
+			case '\t':
+				if (ignore_special) {
+					break;
+				}
+			default:
+				return FALSE;
 		}
+
 		str++;
 		i++;
 	}
 
-	if (i < 3) return FALSE;
+	if ((i < 3) || delim_found == FALSE) {
+		return FALSE;
+	}
 
 	return TRUE;
 }

--- a/util.c
+++ b/util.c
@@ -999,14 +999,20 @@ void die(const char *format, ...) {
 
 	SPINE_LOG(("%s", flogmessage));
 
-#ifdef HAS_EXECINFO_H
-	printf("Generating backtrace...%ld line(s)...\n", set.exit_size);
+#ifdef HAVE_EXECINFO_H
+	int row = 0;
+	char **exit_strings = null;
+
+	fprintf(stderr, "Generating backtrace...%ld line(s)...\n", set.exit_size);
+
 	if (set.exit_size) {
-		char **exit_strings = backtrace_symbols(set.exit_stack, set.exit_size);
+		set.exit_size = backtrace(set.exit_stack, set.exit_size);
+		exit_strings  = backtrace_symbols(set.exit_stack, set.exit_size);
+
 		if (exit_strings) {
-			int row = 0;
-			for (row = 0; row < set.exit_size; row++)
-			        printf("%3d: %s\n", row, exit_strings[row]);
+			for (row = 0; row < set.exit_size; row++) {
+			        fprintf(stderr, "%3d: %s\n", row, exit_strings[row]);
+			}
 
 			free(exit_strings);
 		}

--- a/util.c
+++ b/util.c
@@ -1471,7 +1471,7 @@ char *strncopy(char *dst, const char *src, size_t obuf) {
 	if (!len) {
 		dst[0] = '\0';
 	} else if (len < obuf) {
-		strncpy(dst, src, sizeof(dst));
+		strncpy(dst, src, len);
 		dst[len] = '\0';
 	} else {
 		strncpy(dst, src, --obuf);

--- a/util.c
+++ b/util.c
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/util.h
+++ b/util.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:*
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2019 The Cacti Group                                 |
+ | Copyright (C) 2004-2020 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/util.h
+++ b/util.h
@@ -1,7 +1,7 @@
 /*
  ex: set tabstop=4 shiftwidth=4 autoindent:*
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2020 The Cacti Group                                 |
+ | Copyright (C) 2004-2021 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU Lesser General Public              |

--- a/util.h
+++ b/util.h
@@ -51,7 +51,7 @@ extern void set_option(const char *setting, const char *value);
 extern int is_numeric(char *string);
 extern int is_ipaddress(const char *string);
 extern int all_digits(const char *str);
-extern int is_hexadecimal(const char * str, const short ignore_space);
+extern int is_hexadecimal(const char * str, const short ignore_special);
 
 /* determine if a device is a debug device */
 extern int is_debug_device(int device_id);


### PR DESCRIPTION
proposed patch to solve the problem reported and discussed on #172 , in which MySQL queries with LIMIT could return data out of the expected order and, thus, some data sources would be simply skipped by the spine polling process

```
--- poller.c.orig       2020-11-30 15:21:59.000000000 -0300
+++ poller.c    2021-02-17 11:33:32.595176927 -0300
@@ -260,7 +260,7 @@
                        " FROM poller_item"
                        " WHERE host_id = %i"
                        " AND deleted = ''"
-                       " ORDER BY snmp_port %s", host_id, limits);
+                       " ORDER BY local_data_id,snmp_port %s", host_id, limits);

                /* host structure for uptime checks */
                snprintf(query2, BIG_BUFSIZE,
@@ -292,7 +292,7 @@
                                "snmp_auth_protocol, snmp_priv_passphrase, snmp_priv_protocol, snmp_context, snmp_engine_id "
                        " FROM poller_item"
                        " WHERE host_id=%i AND rrd_next_step <=0"
-                       " ORDER by snmp_port %s", host_id, limits);
+                       " ORDER BY local_data_id,snmp_port %s", host_id, limits);

                /* query to setup the next polling interval in cacti */
                snprintf(query6, BUFSIZE,
@@ -332,7 +332,7 @@
                                "snmp_auth_protocol, snmp_priv_passphrase, snmp_priv_protocol, snmp_context, snmp_engine_id "
                        " FROM poller_item"
                        " WHERE host_id=%i AND poller_id=%i"
-                       " ORDER BY snmp_port %s", host_id, set.poller_id, limits);
+                       " ORDER BY local_data_id,snmp_port %s", host_id, set.poller_id, limits);

                /* host structure for uptime checks */
                snprintf(query2, BIG_BUFSIZE,
@@ -364,7 +364,7 @@
                                "snmp_auth_protocol, snmp_priv_passphrase, snmp_priv_protocol, snmp_context, snmp_engine_id "
                        " FROM poller_item"
                        " WHERE host_id=%i AND rrd_next_step <=0 AND poller_id=%i"
-                       " ORDER by snmp_port %s", host_id, set.poller_id, limits);
+                       " ORDER BY local_data_id,snmp_port %s", host_id, set.poller_id, limits);

                /* query to setup the next polling interval in cacti */
                snprintf(query6, BUFSIZE,

```