### PR TITLE
Use sem_wait() instead of sem_trywait()

### DIFF
--- a/spine.c
+++ b/spine.c
@@ -774,6 +774,7 @@ int main(int argc, char *argv[]) {
 				die("ERROR: Invalid sempaphore in call to sem_wait()");
 			} else if (errno = EINTR) {
 				SPINE_LOG_DEVDBG(("WARNING: Interrupted by signal while processing Available Thread Lock"));
+				break;
 			}
 		}
 
@@ -784,6 +785,7 @@ int main(int argc, char *argv[]) {
                                 die("ERROR: Invalid sempaphore in call to sem_wait()");
                         } else if (errno = EINTR) {
                                 SPINE_LOG_DEVDBG(("WARNING: Interrupted by signal while processing Thread Initialization Lock"));
+				break;
                         }
                 }
 


### PR DESCRIPTION
I think what is going on here is that once spine has spawned the maximum number of threads allowed by the semaphore it only waits 10000 microseconds * 100 retries (1 second) for a thread to complete so it can spawn another. This results in devices/hosts getting skipped and timeout errors appearing in the log if all active threads take longer then 1 second to run. In my environment this happens often and causes spine to not properly poll all hosts. I changed the error handling based on my comments in #208 as the Linux semaphore implementation does not seem to match the way the error handling is done, nor does it seem to ever return some of the errno's that are being checked for in the code. This could be different for a different OS with a different implementation though.

I'd argue that breaking a loop immediately on a successful sem_trywait() is more or less the same thing anyway but concurrency in C is not really my thing. You could also setup a timeout with a signal handler and SIGALRM.

Another option here would be to use sem_timedwait() but this does not really solve the problem, it's just a different way of effectively doing the same thing.

I don't think you'd want to merge this as is, but it is working for me and I hope it's helpful anyway. The implementation using sem_timedwait() in 1.2.17 does not seem to have this problem, I'm not sure what the reason was behind the change.