### PR TITLE
Fix non-void return in thread_mutex_trylock

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+1.2.19
+-issue#227: Fix non-void return in thread_mutex_trylock
+
 1.2.18
 -issue#207: Missing time parameter on FROM_UNIXTIME function
 -issue#221: IPv6 devices are not properly parsed

--- a/locks.c
+++ b/locks.c
@@ -235,4 +235,5 @@ int thread_mutex_trylock(int mutex) {
 	SPINE_LOG_DEVDBG(( "LOCKS: [START] Mutex try lock for %s", get_name(mutex) ));
 	int ret_val = pthread_mutex_trylock(get_lock(mutex));
 	SPINE_LOG_DEVDBG(( "LOCKS: [ END ] Mutex try lock for %s, result = %d", get_name(mutex), ret_val ));
+	return ret_val;
 }


### PR DESCRIPTION
Fixes #227, 9e1f588. For `develop` branch see #223.