### PR TITLE
configure.ac: fix bashisms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -260,7 +260,7 @@ fi
   CFLAGS="-I$MYSQL_INC_DIR $CFLAGS"
 
 unamestr=$(uname)
-if test $unamestr == 'OpenBSD'; then
+if test $unamestr = 'OpenBSD'; then
   AC_CHECK_LIB(mysqlclient, mysql_init,
     [ LIBS="-lmysqlclient -lm $LIBS"
       AC_DEFINE(HAVE_MYSQL, 1, MySQL Client API)
@@ -285,8 +285,8 @@ else
     if test -f $MYSQL_LIB_DIR/libmysqlclient_r.a -o -f $MYSQL_LIB_DIR/libmysqlclient_r.$ShLib ; then
       LIBS="-lmysqlclient_r -lm -ldl $LIBS"
     else
-      if test "$HAVE_MYSQL" == "yes"; then
-        if test $unamestr == 'OpenBSD'; then
+      if test "$HAVE_MYSQL" = "yes"; then
+        if test $unamestr = 'OpenBSD'; then
           LIBS="-lmysqlclient -lm $LIBS"
         else
           LIBS="-lmysqlclient -lm -ldl $LIBS"


### PR DESCRIPTION
configure needs to work with a POSIX-compliant shell so we need
to avoid bashisms like '=='. This fixes configure with e.g. /bin/sh
provided by dash.

Signed-off-by: Sam James <sam@gentoo.org>