### PR TITLE
Fix issue#279 - spine 1.2.22 does not compile with SQL TLS deactivated

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 The Cacti Group | spine
 
 1.2.23
--feature#277 Spine should prevent the script server from connecting to remote when offline
+-issue#279: spine does not compile with SQL TLS deactivated
+-feature#277: Spine should prevent the script server from connecting to remote when offline
 
 1.2.22
 -issue#265: Periodically spine crashes with sigabort due to MariaDB API buffer overruns

--- a/sql.c
+++ b/sql.c
@@ -350,6 +350,7 @@ void db_connect(int type, MYSQL *mysql) {
 		free(hostname);
 	}
 
+    #ifdef HAS_MYSQL_OPT_SSL_KEY
 	if (ssl_key != NULL) {
 		free(ssl_key);
 	}
@@ -361,6 +362,7 @@ void db_connect(int type, MYSQL *mysql) {
 	if (ssl_cert != NULL) {
 		free(ssl_cert);
 	}
+    #endif
 
 	if (!success){
 		printf("FATAL: Connection Failed, Error:'%i', Message:'%s'\n", error, mysql_error(mysql));


### PR DESCRIPTION
ssl_key variables being used in free section although they are not being defined. Added the compile check to skip when MySQL SSL/TLS was not activated.