### PR TITLE
configure.ac: Improve C99 compatibility of NETSNMP_USE_OPENSSL check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -357,7 +357,7 @@ fi
 
 # Net-SNMP includes v3 support and insists on crypto unless compiled --without-openssl
 AC_MSG_CHECKING([if Net-SNMP needs crypto support])
-AC_TRY_COMPILE([#include <net-snmp-config.h>], [exit(NETSNMP_USE_OPENSSL != 1);],
+AC_TRY_COMPILE([#include <net-snmp-config.h>], [return NETSNMP_USE_OPENSSL != 1;],
   [  AC_MSG_RESULT(yes)
      SNMP_SSL=yes
   ],


### PR DESCRIPTION
C99 removed support for implicit function declarations, and the exit function is not necessarily declared at this point.  Just return from main instead.

Related to:

  <https://fedoraproject.org/wiki/Changes/PortingToModernC>
  <https://fedoraproject.org/wiki/Toolchain/PortingToModernC>
