### PR TITLE
Fix backtrace/execinfo.h compilation issue on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,6 @@ AC_SEARCH_LIBS([clock_gettime], [rt pthread])
 AC_CHECK_HEADERS(sys/socket.h sys/select.h sys/wait.h sys/time.h)
 AC_CHECK_HEADERS(assert.h ctype.h errno.h signal.h math.h malloc.h netdb.h)
 AC_CHECK_HEADERS(signal.h stdarg.h stdio.h syslog.h)
-AC_CHECK_HEADERS(execinfo.h)
 AC_CHECK_HEADERS(
   netinet/in_systm.h netinet/in.h netinet/ip.h netinet/ip_icmp.h,
   [],


### PR DESCRIPTION
On FreeBSD when configured with default settings, compilation of spine will always fail:

```
/bin/sh ./libtool  --tag=CC    --mode=link cc  -I/usr/local/include/net-snmp -I/usr/local/include/net-snmp/.. -I/usr/local/include/mysql -g -O2   -L/usr/local/lib -L/usr/local/lib/mysql -o spine sql.o spine.o util.o  snmp.o locks.o poller.o  nft_popen.o php.o ping.o  keywords.o error.o  -lnetsnmp -lmysqlclient_r -lm -ldl -lmysqlclient -lm -ldl -lcrypto -lz -lpthread -ldl -lm -lpthread -lssl
libtool: link: cc -I/usr/local/include/net-snmp -I/usr/local/include/net-snmp/.. -I/usr/local/include/mysql -g -O2 -o spine sql.o spine.o util.o snmp.o locks.o poller.o nft_popen.o php.o ping.o keywords.o error.o  -L/usr/local/lib -L/usr/local/lib/mysql -lnetsnmp -lmysqlclient_r -lmysqlclient -lcrypto -lz -ldl -lm -lpthread -lssl
ld: error: undefined symbol: backtrace
>>> referenced by error.c:85
>>>               error.o:(spine_signal_handler)

ld: error: undefined symbol: backtrace_symbols
>>> referenced by error.c:86
>>>               error.o:(spine_signal_handler)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
*** Error code 1

Stop.
```

When the configure script is run it correctly shows that backtraces are not supported on this platform:

```
...
checking whether we are using traditional popen... no
checking whether to verify net-snmp library vs header versions... no
checking if we can support backtracing... no
checking if we can support mysql/mariadb retry count... no
checking if we can support mysql/mariadb ssl keys... yes
...
```

And yet in config/config.h we have HAVE_EXECINFO_H defined:

```
/* Do we have backtracing capabilities? */
#define HAVE_EXECINFO_H 1
```

This is because of an error in configure.ac where the value of HAVE_EXECINFO_H is set twice, the first time by AC_CHECK_HEADERS(execinfo.h) which returns true (The FreeBSD system does have execinfo.h, it just does not support the function used here) and a 2nd time later on by a AC_LINK_IFELSE:

```
# See if we can support backtracing
AC_MSG_CHECKING([if we can support backtracing])
AC_LINK_IFELSE([AC_LANG_PROGRAM([[
    #include <stdlib.h>
    #include <execinfo.h>
  ]], [[
    void *array[10];
    size_t size;

    // get void*'s for all entries on the stack
    size = backtrace(array, 10);
    if (size) {
      exit(0);
    } else {
      exit(1);
    }
  ]])],[  AC_MSG_RESULT(yes)
     AC_DEFINE(HAVE_EXECINFO_H,1,[Do we have backtracing capabilities?])
  ],[AC_MSG_RESULT(no)
])
```
Even though the above AC_LANG_PROGRAM fails on FreeBSD, because of the earlier AC_CHECK_HEADERS succeeding HAVE_EXECINFO_H is already defined and remains that way leading to the compilation failure.

Since the AC_LANG_PROGRAM check here seems more thorough then the simple header check and will fail anyway if execinfo.h does not exist I think the correct course of action here is to remove the AC_CHECK_HEADERS macro for this particular header completely.