### PR TITLE
Fix Clang 16 compiler warning: format (1)

### DIFF
--- a/spine.c
+++ b/spine.c
@@ -931,7 +931,7 @@ int main(int argc, char *argv[]) {
 			thread_status = pthread_create(&threads[device_counter], &attr, child, poller_details);
 
 			if (thread_status == 0) {
-				SPINE_LOG_DEBUG(("DEBUG: Device[%i] Valid Thread to be Created (%ld)", poller_details->host_id, threads[device_counter]));
+				SPINE_LOG_DEBUG(("DEBUG: Device[%i] Valid Thread to be Created (%ld)", poller_details->host_id, (long int)threads[device_counter]));
 
 				if (change_host) {
 					device_counter++;

--- a/util.c
+++ b/util.c
@@ -1262,7 +1262,7 @@ int spine_log(const char *format, ...) {
 	fp = stdout;
 
 	/* log message prefix */
-	snprintf(logprefix, SMALL_BUFSIZE, "SPINE: Poller[%i] PID[%i] PT[%ld] ", set.poller_id, getpid(), pthread_self());
+	snprintf(logprefix, SMALL_BUFSIZE, "SPINE: Poller[%i] PID[%i] PT[%ld] ", set.poller_id, getpid(), (long int)pthread_self());
 
 	/* get time for poller_output table */
 	nowbin = time(&nowbin);


### PR DESCRIPTION
While compiling Clang 16 generates the following warnings.

in spine.c:

```
spine.c:934:101: warning: format specifies type 'long' but the argument has type 'pthread_t' (aka 'struct pthread *') [-Wformat]
                                SPINE_LOG_DEBUG(("DEBUG: Device[%i] Valid Thread to be Created (%ld)", poller_details->host_id, threads[device_counter]));
```

in util.c:
```
util.c:1265:100: warning: format specifies type 'long' but the argument has type 'pthread_t' (aka 'struct pthread *') [-Wformat]
        snprintf(logprefix, SMALL_BUFSIZE, "SPINE: Poller[%i] PID[%i] PT[%ld] ", set.poller_id, getpid(), pthread_self());
```
This one i'm not as sure about, maybe this should be cast to a long unsigned int instead? I have not had problems running it this way but i'm not 100% sure this the right fix.
