### PR TITLE
Fix Clang 16 warning: pointer-sign

### DIFF
--- a/snmp.c
+++ b/snmp.c
@@ -587,7 +587,7 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 					if (vars != NULL) {
 						snprint_value(temp_result, RESULTS_BUFFER, vars->name, vars->name_length, vars);
 
-						snprint_asciistring(result_string, RESULTS_BUFFER, temp_result, strlen(temp_result));
+						snprint_asciistring(result_string, RESULTS_BUFFER, (unsigned char *)temp_result, strlen(temp_result));
 					} else {
 						SET_UNDEFINED(result_string);
 						status = STAT_ERROR;


### PR DESCRIPTION
while compiling spine clang 16 generates the following warning:

```
snmp.c:590:58: warning: passing 'char[2048]' to parameter of type 'const u_char *' (aka 'const unsigned char *') converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
                                                snprint_asciistring(result_string, RESULTS_BUFFER, temp_result, strlen(temp_result));
```

If the function treats this as a unsigned char *, I don't see any issue casting it as such before passing it in to suppress the warning.