### PR TITLE
Fix Clang 16 warning: format (2)

### DIFF
--- a/util.c
+++ b/util.c
@@ -372,7 +372,7 @@ void read_config_options() {
 	set.cacti_version = get_cacti_version(&mysql, LOCAL);
 
 	/* log the path_webroot variable */
-	SPINE_LOG_DEBUG(("DEBUG: The binary Cacti version is %s", set.cacti_version));
+	SPINE_LOG_DEBUG(("DEBUG: The binary Cacti version is %d", set.cacti_version));
 
 	/* get logging level from database - overrides spine.conf */
 	if ((res = getsetting(&mysql, LOCAL, "log_verbosity")) != 0) {


### PR DESCRIPTION
This one is clear case of a simple format oopsie.