### PR TITLE
Issue-366: Failing to actually a poll device that returns "NoSuchObject" for sysDecr or sysUpTime

### DIFF
--- a/snmp.c
+++ b/snmp.c
@@ -482,8 +482,15 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 				vars = response->variables;
 
 				if (vars->type == SNMP_NOSUCHOBJECT) {
-					SET_UNDEFINED(result_string);
-					status = STAT_ERROR;
+					if (!strstr(snmp_oid, ".1.3.6.1.2.1.1.1.0") && !strstr(snmp_oid, ".1.3.6.1.2.1.1.3.0")) {
+                                                SET_UNDEFINED(result_string);
+                                                status = STAT_ERROR;
+                                                SPINE_LOG_DEBUG(("DEBUG: OID '%s' for Device[%d], SNMP_NOSUCHOBJECT not sysDesc or sysUptime", snmp_oid, current_host->id));
+                                        } else {
+                                                SPINE_LOG_HIGH(("DEBUG: OID '%s' for Device[%d], SNMP_NOSUCHOBJECT for sysDesc or sysUptime", snmp_oid, current_host->id));
+                                                snprint_value(temp_result, RESULTS_BUFFER, vars->name, vars->name_length, vars);
+                                                snprintf(result_string, RESULTS_BUFFER, "%s", trim(temp_result));
+                                        }
 					SPINE_LOG_HIGH(("ERROR: No such Object for oid '%s' for Device[%d] with Status[%d]",  snmp_oid, current_host->id, status));
 				} else if (vars->type == SNMP_NOSUCHINSTANCE) {
 					SET_UNDEFINED(result_string);


### PR DESCRIPTION
If sysDescr or sysUpTime return "NoSuchObject" then accept the return and process normally, otherwise clear it and change status to an error.
The behavior changed due to the patch for #272, and I have not been able to poll a few devices with spine newer than 1.2.21. I have tested this change on 1.2.27 (my current version in production)