### PR TITLE
Bounds-check die() to prevent stack overflow

### DIFF
--- a/util.c
+++ b/util.c
@@ -1168,13 +1168,13 @@ void die(const char *format, ...) {
 	int old_errno = errno;
 
 	va_start(args, format);
-	vsprintf(logmessage, format, args);
+	vsnprintf(logmessage, BUFSIZE, format, args);
 	va_end(args);
 
 	if (set.log_perror) {
 		char perr[BUFSIZE];
 		snprintf(perr, BUFSIZE, " [%d, %s]", old_errno, strerror(old_errno));
-		strcat(logmessage,perr);
+		strncat(logmessage, perr, BUFSIZE - strlen(logmessage) - 1);
 	}
 
 	if (set.logfile_processed) {


### PR DESCRIPTION
## Summary

`die()` uses `vsprintf` to format error messages into a 1024-byte stack buffer with no length limit. If the formatted string is long enough (think: a really verbose database error with a hostname and query fragment), it writes past the end of the buffer.

Same story with the `strcat` that appends the errno string — no check on remaining space.

Swapped both for their bounded cousins:
- `vsprintf` → `vsnprintf` with `BUFSIZE`
- `strcat` → `strncat` with remaining capacity

Two-line fix. Truncation beats a stack smash.

## Test plan

- [x] Builds clean with `-Wall -Wextra` (verified via Docker ASan build)
- [x] cppcheck shows zero new findings vs develop baseline
- [x] `spine --version` exits 0
- [ ] ASan build: trigger `die()` with a >1024 char format string — should exit cleanly, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)