### PR TITLE
fix(spine): validate --hostlist input against SQL injection

### DIFF
--- a/spine.c
+++ b/spine.c
@@ -385,6 +385,11 @@ int main(int argc, char *argv[]) {
 
 		else if (STRIMATCH(arg, "-H") || STRIMATCH(arg, "--hostlist")) {
 			snprintf(set.host_id_list, BIG_BUFSIZE, "%s", getarg(opt, &argv));
+
+			/* validate host_id_list contains only digits and commas */
+			if (strlen(set.host_id_list) != strspn(set.host_id_list, "0123456789,")) {
+				die("ERROR: --hostlist must contain only numeric host IDs separated by commas");
+			}
 		}
 
 		else if (STRIMATCH(arg, "-M") || STRMATCH(arg, "--mibs")) {


### PR DESCRIPTION
## Summary

- `set.host_id_list` from `--hostlist` / `-H` was interpolated directly into SQL `WHERE IN(...)` clauses in `spine.c` (line 636) and `util.c` (lines 712, 839, 981) with no sanitization.
- Added `strspn`-based validation immediately after `snprintf` populates `set.host_id_list`: if the value contains anything other than digits and commas, `die()` is called before any DB query is issued.
- Single-point fix; all four downstream `IN(...)` interpolation sites are covered by validating at parse time.

## Test plan

- [ ] `./spine --hostlist 1,2,3` — accepted, polls normally
- [ ] `./spine --hostlist "1,2,3 OR 1=1"` — exits with `ERROR: --hostlist must contain only numeric host IDs separated by commas`
- [ ] `./spine --hostlist "1; DROP TABLE host--"` — same error, no DB query issued
- [ ] `./spine --hostlist ""` — empty string passes `strspn` (zero length equals zero span); existing downstream length-check at line 474 handles this case
- [ ] Build with `make` / `cmake` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)