### PR TITLE
Fix no-op memset in poll_host() reindex path

### DIFF
--- a/poller.c
+++ b/poller.c
@@ -1100,7 +1100,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 									}
 
 									/* set zeros */
-									memset(query3, 0, buf_length);
+									memset(query3, 0, LRG_BUFSIZE);
 								}
 
 								assert_fail = TRUE;
@@ -1126,7 +1126,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 									}
 
 									/* set zeros */
-									memset(query3, 0, buf_length);
+									memset(query3, 0, LRG_BUFSIZE);
 								}
 
 								assert_fail = TRUE;
@@ -1154,7 +1154,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 										}
 
 										/* set zeros */
-										memset(query3, 0, buf_length);
+										memset(query3, 0, LRG_BUFSIZE);
 									}
 
 									assert_fail = TRUE;
@@ -1176,7 +1176,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 									db_insert(&mysql, LOCAL, query3);
 
 									/* set zeros */
-									memset(query3, 0, buf_length);
+									memset(query3, 0, LRG_BUFSIZE);
 								}
 
 								if ((assert_fail) &&


### PR DESCRIPTION
## Summary

`buf_length` is initialized to 0 and never updated before four `memset(query3, 0, buf_length)` calls in the reindex assert logic. So these memsets clear exactly zero bytes — they're expensive no-ops.

`query3` is allocated with `malloc(LRG_BUFSIZE)` right before this code, so the fix is straightforward: use `LRG_BUFSIZE` instead of `buf_length` in those four calls.

The fifth memset at line 1777 is fine — `buf_length` gets its real value assigned at line 1769, well before that call. Left it alone.

Not a security issue (the buffer gets overwritten by `snprintf` before each use anyway), but it's the kind of bug that bites you the day someone refactors the surrounding code and assumes the buffer is actually zeroed.

## Test plan

- [x] Builds clean with `-Wall -Wextra` + ASan (verified via Docker dev image)
- [x] cppcheck identical to develop baseline — zero new findings
- [x] `spine --version` exits 0
- [ ] Run against a host with data query reindex configured, confirm reindex asserts work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)