### PR TITLE
Add Dockerfile for building and verifying spine

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 The Cacti Group | spine
 
+develop
+-feature#444: Add multi-stage Dockerfile and Dockerfile.dev with ASan/cppcheck/scan-build
+
 1.3.0
 -issue#360: If a Remote Data Collector has not devices, spine does not properly register itself
 -feature#362: Report the number of data collection errors during data collection in host table

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmariadb3 \
         libsnmp40 \
         libssl3 \
+        zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /src/spine /usr/local/bin/spine

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,41 @@
+# +-------------------------------------------------------------------------+
+# | Copyright (C) 2004-2024 The Cacti Group                                 |
+# +-------------------------------------------------------------------------+
+# | Development/verification image — NOT for production use.               |
+# | Builds with ASan + full static analysis tooling.                       |
+# +-------------------------------------------------------------------------+
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    autoconf \
+    automake \
+    libtool \
+    dos2unix \
+    help2man \
+    libmariadb-dev \
+    libsnmp-dev \
+    libssl-dev \
+    zlib1g-dev \
+    cppcheck \
+    clang-tools \
+    valgrind \
+    gdb \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+COPY . .
+
+# ASan build: catches heap/stack overflows and use-after-free at runtime.
+# -fno-omit-frame-pointer gives usable stack traces under valgrind/gdb.
+RUN ./bootstrap \
+  && CFLAGS="-fsanitize=address -fno-omit-frame-pointer -g -Wall -Wextra" \
+     ./configure --enable-warnings \
+  && make -j"$(nproc)"
+
+COPY scripts/verify.sh /usr/local/bin/verify.sh
+RUN chmod +x /usr/local/bin/verify.sh
+
+CMD ["/usr/local/bin/verify.sh"]

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 echo "=== cppcheck ==="
 cppcheck --enable=all --std=c11 --error-exitcode=1 \
   --suppress=missingIncludeSystem \
+  --suppress=unusedFunction \
+  --suppress=checkersReport \
+  --suppress=toomanyconfigs \
   *.c *.h 2>&1 | tee /tmp/cppcheck.txt
 
 echo ""

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== cppcheck ==="
+cppcheck --enable=all --std=c11 --error-exitcode=1 \
+  --suppress=missingIncludeSystem \
+  *.c *.h 2>&1 | tee /tmp/cppcheck.txt
+
+echo ""
+echo "=== scan-build ==="
+make clean
+scan-build -o /tmp/scan-results --status-bugs make -j"$(nproc)" 2>&1
+
+echo ""
+echo "=== smoke tests ==="
+./spine --help > /dev/null 2>&1
+echo "spine --help: OK"
+./spine --version > /dev/null 2>&1
+echo "spine --version: OK"
+
+echo ""
+echo "=== All checks passed ==="


### PR DESCRIPTION
Fixes #444

- **Dockerfile**: multi-stage build. Builder stage compiles spine; final stage is minimal, non-root, with only required shared libs.
- **Dockerfile.dev**: single-stage dev image with ASan, cppcheck, scan-build, valgrind, and gdb. Defaults to running scripts/verify.sh (cppcheck + scan-build + smoke tests).
- **scripts/verify.sh**: runs cppcheck, scan-build, and basic --help/--version smoke tests.
- **.dockerignore**: excludes .git and build artifacts.

Nothing changes about the existing build. Purely additive.