### PR TITLE
Add make targets for Docker build and verification

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ The Cacti Group | spine
 
 develop
 -feature#444: Add multi-stage Dockerfile and Dockerfile.dev with ASan/cppcheck/scan-build
+-feature#443: Add make targets for Docker build and verification (docker, docker-dev, verify, cppcheck)
 
 1.3.0
 -issue#360: If a Remote Data Collector has not devices, spine does not properly register itself

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,10 +3,10 @@ The Cacti Group | spine
 develop
 -feature#444: Add multi-stage Dockerfile and Dockerfile.dev with ASan/cppcheck/scan-build
 -feature#443: Add make targets for Docker build and verification (docker, docker-dev, verify, cppcheck)
-
 1.3.0
 -issue#360: If a Remote Data Collector has not devices, spine does not properly register itself
 -feature#362: Report the number of data collection errors during data collection in host table
+-feature#443: Add make targets for Docker build and verification (docker, docker-dev, verify, cppcheck)
 -feature#5090: Enhance number recognition within Spine
 -feature#3740: Ability to disable a site
 -feature#6001: Extend SYSTEM STATS

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ man_MANS = spine.1
 spine.1: $(bin_PROGRAMS)
 	$(HELP2MAN) --output=$@ --name='Data Collector for Cacti' --no-info --version-option='--version' ./spine
 
-# Docker targets — require Dockerfile and Dockerfile.dev from PR #401
+# Docker targets — require Dockerfile and Dockerfile.dev (from PR #401)
 .PHONY: docker docker-dev verify cppcheck
 
 docker:
@@ -50,4 +50,4 @@ cppcheck: docker-dev
 	docker run --rm spine-dev bash -c \
 		"cppcheck --enable=all --std=c11 --error-exitcode=1 \
 		--suppress=missingIncludeSystem --suppress=unusedFunction \
-		--suppress=checkersReport --suppress=toomanyconfigs *.c *.h"
+		--suppress=checkersReport --suppress=toomanyconfigs $(spine_SOURCES)"

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ man_MANS = spine.1
 spine.1: $(bin_PROGRAMS)
 	$(HELP2MAN) --output=$@ --name='Data Collector for Cacti' --no-info --version-option='--version' ./spine
 
-# Docker targets — require Dockerfile and Dockerfile.dev from feat/docker-build
+# Docker targets — require Dockerfile and Dockerfile.dev from PR #401
 .PHONY: docker docker-dev verify cppcheck
 
 docker:
@@ -46,7 +46,7 @@ docker-dev:
 verify: docker-dev
 	docker run --rm spine-dev
 
-cppcheck:
+cppcheck: docker-dev
 	docker run --rm spine-dev bash -c \
 		"cppcheck --enable=all --std=c11 --error-exitcode=1 \
 		--suppress=missingIncludeSystem --suppress=unusedFunction \

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,3 +33,21 @@ man_MANS = spine.1
 
 spine.1: $(bin_PROGRAMS)
 	$(HELP2MAN) --output=$@ --name='Data Collector for Cacti' --no-info --version-option='--version' ./spine
+
+# Docker targets — require Dockerfile and Dockerfile.dev from feat/docker-build
+.PHONY: docker docker-dev verify cppcheck
+
+docker:
+	docker build -t spine .
+
+docker-dev:
+	docker build -f Dockerfile.dev -t spine-dev .
+
+verify: docker-dev
+	docker run --rm spine-dev
+
+cppcheck:
+	docker run --rm spine-dev bash -c \
+		"cppcheck --enable=all --std=c11 --error-exitcode=1 \
+		--suppress=missingIncludeSystem --suppress=unusedFunction \
+		--suppress=checkersReport --suppress=toomanyconfigs *.c *.h"


### PR DESCRIPTION
Fixes #443

Companion to #401. Adds four .PHONY make targets:

    make docker      # build the runtime image
    make docker-dev  # build the dev image (ASan, cppcheck, scan-build, valgrind)
    make verify      # build dev image + run the full analysis suite
    make cppcheck    # just cppcheck

None interfere with the normal make / make install workflow. If Docker is not installed they fail with a clear error. Depends on #401 being merged first.