### PR TITLE
Fix POSIX sh compatibility in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,13 +236,13 @@ AC_DEFUN([MYSQL_LIB_CHK],
 MYSQL_SUB_DIR="include include/mysql include/mariadb mysql";
 for i in $MYSQL_DIR /usr /usr/local /opt /opt/mysql /usr/pkg /usr/local/mysql; do
   for d in $MYSQL_SUB_DIR; do
-    if [[ -f $i/$d/mysql.h ]]; then
+    if [ -f "$i/$d/mysql.h" ]; then
       MYSQL_INC_DIR=$i/$d
       break;
     fi
   done
 
-  if [[ ! -z $MYSQL_INC_DIR ]]; then
+  if [ -n "$MYSQL_INC_DIR" ]; then
     break;
   fi
 #  test -f $i/include/mysql.h          && MYSQL_INC_DIR=$i/include          && break


### PR DESCRIPTION
## Summary

- Replace `[[ ]]` bash-isms with POSIX `[ ]` in MySQL header detection (lines 239, 245)
- Add proper variable quoting to prevent word splitting
- Use `-n` instead of `! -z` because life's too short for double negatives

`./configure` currently fails on Debian/Ubuntu where `/bin/sh` is `dash`, not `bash`. Two lines, zero risk.

## Test plan

- [ ] Run `./configure` on a Debian/Ubuntu system (dash as /bin/sh)
- [ ] Run `./configure` on a system with bash as /bin/sh (no regression)
- [ ] Verify MySQL headers are still detected correctly

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>