### PR TITLE
Add GitHub Actions CI: build, cppcheck, flawfinder, CodeQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+    env:
+      CC: ${{ matrix.compiler }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libmariadb-dev libmariadb-dev-compat \
+            libsnmp-dev libssl-dev \
+            help2man autoconf automake libtool dos2unix
+
+      - name: Build
+        run: |
+          ./bootstrap
+          ./configure
+          make -j$(nproc) CFLAGS="-Wall -Wextra"
+
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install cppcheck
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck
+        run: |
+          cppcheck \
+            --enable=all \
+            --std=c11 \
+            --error-exitcode=1 \
+            --suppress=missingIncludeSystem \
+            --suppress=unusedFunction \
+            --suppress=checkersReport \
+            --suppress=toomanyconfigs \
+            *.c *.h
+
+  flawfinder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.x"
+
+      - name: Install flawfinder
+        run: pip install flawfinder==2.0.19
+
+      # Note: flawfinder will light up like a christmas tree on this codebase.
+      # error-level=5 means only critical hits fail the build — the rest is
+      # informational so we have a baseline to chip away at.
+      - name: Run flawfinder
+        run: |
+          flawfinder \
+            --minlevel=3 \
+            --error-level=5 \
+            --columns \
+            --context \
+            . | tee flawfinder-report.txt
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: flawfinder-report
+          path: flawfinder-report.txt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - uses: github/codeql-action/init@ce28f5bb42b7a342e9c1c977301c0a1aca3958b1
+        with:
+          languages: c-cpp
+
+      - name: Build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libmariadb-dev libmariadb-dev-compat \
+            libsnmp-dev libssl-dev \
+            help2man autoconf automake libtool dos2unix
+          ./bootstrap
+          ./configure
+          make -j$(nproc)
+
+      - uses: github/codeql-action/analyze@ce28f5bb42b7a342e9c1c977301c0a1aca3958b1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 The Cacti Group | spine
 
 develop
--feature#444: Add multi-stage Dockerfile and Dockerfile.dev with ASan/cppcheck/scan-build
+-feature#442: Add GitHub Actions CI: build matrix (gcc/clang), cppcheck, flawfinder, CodeQL
 -feature#443: Add make targets for Docker build and verification (docker, docker-dev, verify, cppcheck)
+-feature#444: Add multi-stage Dockerfile and Dockerfile.dev with ASan/cppcheck/scan-build
 1.3.0
 -issue#360: If a Remote Data Collector has not devices, spine does not properly register itself
 -feature#362: Report the number of data collection errors during data collection in host table


### PR DESCRIPTION
Fixes #442

Spine has no CI. This adds a basic safety net.

- **Build matrix** (gcc + clang): catches cross-compiler regressions
- **cppcheck**: configured with reasonable flags; suppresses known false positives
- **flawfinder**: `error-level=5` blocks only critical hits; full report uploads as artifact
- **CodeQL**: GitHub's semantic scanner, runs weekly and on every push/PR

All actions pinned to full SHA. Least-privilege permissions per job.

What this does not do: run tests (there are none), use -Werror (existing warning count would block it), or block on every flawfinder hit.