### PR TITLE
fix: move declarations before statements for C89 compliance

### DIFF
--- a/snmp.c
+++ b/snmp.c
@@ -122,6 +122,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 	void   *sessp = NULL;
 	struct snmp_session session;
 	char   hostnameport[BUFSIZE];
+	size_t len;
 
 	char   *Apsz = NULL;
 	char   *Xpsz = NULL;
@@ -133,7 +134,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 	snmp_sess_init(&session);
 
 	/* Bind to snmp_clientaddr if specified */
-	size_t len = strlen(set.snmp_clientaddr);
+	len = strlen(set.snmp_clientaddr);
 	if (len > 0 && len <= SMALL_BUFSIZE) {
 		#if SNMP_LOCALNAME == 1
 		session.localname = strdup(set.snmp_clientaddr);
@@ -217,10 +218,12 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		}
 
 		/* set the authentication protocol */
-		int auth_type = usm_lookup_auth_type(snmp_auth_protocol);
-		if (auth_type > 0) {
-			const oid *auth_proto;
+		{
+		int auth_type;
+		const oid *auth_proto;
 
+		auth_type = usm_lookup_auth_type(snmp_auth_protocol);
+		if (auth_type > 0) {
             auth_proto = sc_get_auth_oid(auth_type, &session.securityAuthProtoLen);
             free(session.securityAuthProto);
             session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
@@ -339,6 +342,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		}
 
 		SPINE_LOG_MEDIUM(("Device[%i] SNMPv3 Using AuthProto: %s, PrivProto: %s", host_id, snmp_auth_protocol, snmp_priv_protocol));
+		} /* end auth/priv block */
 	}
 
 	/* open SNMP Session */

--- a/spine.c
+++ b/spine.c
@@ -205,19 +205,9 @@ int main(int argc, char *argv[]) {
 	int a_threads_value;
 	//struct timespec until_spec;
 
-	start_time = get_time_as_double();
-	total_time = 0;
-
-	#ifdef HAVE_LCAP
-	if (geteuid() == 0) {
-		drop_root(getuid(), getgid());
-	}
-	#endif /* HAVE_LCAP */
-
 	pthread_t* threads = NULL;
 	poller_thread_t* poller_details = NULL;
 	pthread_attr_t attr;
-
 	int* ids = NULL;
 	int mode = REMOTE;
 	MYSQL mysql;
@@ -235,9 +225,18 @@ int main(int argc, char *argv[]) {
 	int threads_final = 0;
 	int threads_missing = -1;
 	int threads_count;
+	struct snmp_session session;
+
+	start_time = get_time_as_double();
+	total_time = 0;
+
+	#ifdef HAVE_LCAP
+	if (geteuid() == 0) {
+		drop_root(getuid(), getgid());
+	}
+	#endif /* HAVE_LCAP */
 
 	/* we must initialize snmp in the main thread */
-	struct snmp_session session;
 
 	UNUSED_PARAMETER(argc);		/* we operate strictly with argv */
 
@@ -519,9 +518,10 @@ int main(int argc, char *argv[]) {
 
 	/* tokenize the debug devices */
 	if (strlen(set.selective_device_debug)) {
-		SPINE_LOG_DEBUG(("DEBUG: Selective Debug Devices %s", set.selective_device_debug));
 		int i = 0;
-		char *token = strtok(set.selective_device_debug, ",");
+		char *token;
+		SPINE_LOG_DEBUG(("DEBUG: Selective Debug Devices %s", set.selective_device_debug));
+		token = strtok(set.selective_device_debug, ",");
 		while(token) {
 			debug_devices[i]   = atoi(token);
 			debug_devices[i+1] = '\0';
@@ -732,6 +732,11 @@ int main(int argc, char *argv[]) {
 
 	/* loop through devices until done */
 	while (canexit == FALSE && device_counter < num_rows) {
+		int loop_count = 0;
+		double progress_time = 0;
+		unsigned int sem_err = 0;
+		int spine_timeout = FALSE;
+
 		if (change_host) {
 			mysql_row       = mysql_fetch_row(result);
 			host_id         = atoi(mysql_row[0]);
@@ -826,10 +831,10 @@ int main(int argc, char *argv[]) {
 		thread_mutex_unlock(LOCK_THDET);
 
 		/* dev note - errno was never primed at this point in previous version of code */
-		int loop_count = 0;
-		double progress_time = 0;
-		unsigned int sem_err = 0;
-		int spine_timeout = FALSE;
+		loop_count = 0;
+		progress_time = 0;
+		sem_err = 0;
+		spine_timeout = FALSE;
 
 		while (TRUE) {
 			sem_err = sem_trywait(&available_threads);

--- a/sql.c
+++ b/sql.c
@@ -226,6 +226,11 @@ void db_connect(int type, MYSQL *mysql) {
 	char    *socket = NULL;
 	struct  stat socket_stat;
 	static int connections = 0;
+	#ifdef HAS_MYSQL_OPT_SSL_KEY
+	char    *ssl_key  = NULL;
+	char    *ssl_ca   = NULL;
+	char    *ssl_cert = NULL;
+	#endif
 
 	/* see if the hostname variable is a file reference.  If so,
 	 * and if it is a socket file, setup mysql to use it.
@@ -288,10 +293,6 @@ void db_connect(int type, MYSQL *mysql) {
 
 	/* set SSL options if available */
 	#ifdef HAS_MYSQL_OPT_SSL_KEY
-	char *ssl_key  = NULL;
-	char *ssl_ca   = NULL;
-	char *ssl_cert = NULL;
-
 	/* if the users has explicitly said to disable SSL, do that now */
 	#ifdef HAS_MYSQL_OPT_SSL_VERIFY_SERVER_CERT
 	if (type == LOCAL) {
@@ -579,10 +580,12 @@ int append_hostrange(char *obuf, const char *colname) {
  *
  */
 void db_escape(MYSQL *mysql, char *output, int max_size, const char *input) {
+	char input_trimmed[DBL_BUFSIZE];
+	int  max_escaped_input_size;
+
 	if (input == NULL) return;
 
-	char input_trimmed[DBL_BUFSIZE];
-	int  max_escaped_input_size = (strlen(input) * 2) + 1;
+	max_escaped_input_size = (strlen(input) * 2) + 1;
 
 	if (max_escaped_input_size > max_size) {
 		snprintf(input_trimmed, (max_size / 2) - 1, "%s", input);

--- a/util.c
+++ b/util.c
@@ -1200,11 +1200,12 @@ void die(const char *format, ...) {
 
 char * get_date_format() {
 	char *log_fmt;
+	char log_sep = '/';
+
 	if (!(log_fmt = (char *) malloc(GD_FMT_SIZE))) {
 		die("ERROR: Fatal malloc error: util.c get_date_format!");
 	}
 
-	char log_sep = '/';
 	if (set.log_datetime_separator < GDC_MIN || set.log_datetime_separator > GDC_MAX) {
 		set.log_datetime_separator = GDC_DEFAULT;
 	}

--- a/util.c
+++ b/util.c
@@ -343,6 +343,8 @@ void read_config_options() {
 	char       *sqlp = sqlbuf;
 	const char *res;
 	char       spine_capabilities[BUFSIZE];
+	int        authCount;
+	int        privCount;
 
 	/* publish spine snmpv3 capabilities to the database */
 	memset(spine_capabilities, 0, sizeof(spine_capabilities));
@@ -741,10 +743,10 @@ void read_config_options() {
 		set.snmp_max_get_size = 25;
 	}
 
+	authCount = 0;
+
 	/* log the snmp_max_get_size variable */
 	SPINE_LOG_DEBUG(("DEBUG: The Maximum SNMP OID Get Size is %i", set.snmp_max_get_size));
-
-	int authCount = 0;
 
 	strcat(spine_capabilities, "{ authProtocols: \"");
 	#ifndef NETSNMP_DISABLE_MD5
@@ -766,7 +768,7 @@ void read_config_options() {
 	#endif
 	strcat(spine_capabilities, "\"");
 
-	int privCount = 0;
+	privCount = 0;
 
 	strcat(spine_capabilities, ", privProtocols: \"");
 
@@ -1272,6 +1274,10 @@ int spine_log(const char *format, ...) {
 	char stdoutmessage[LOGSIZE+of]; /* Message for stdout */
 
 	double cur_time;
+	char * log_fmt;
+	int prefix_len;
+	int ulog_len;
+	int flog_len;
 
 	va_start(args, format);
 	vsnprintf(ulogmessage, LOGSIZE - 1, format, args);
@@ -1297,7 +1303,7 @@ int spine_log(const char *format, ...) {
 		return TRUE;
 	}
 
-	char * log_fmt = get_date_format();
+	log_fmt = get_date_format();
 
 	if (strlen(log_fmt) == 0) {
 		#ifdef DISABLE_STDERR
@@ -1315,9 +1321,9 @@ int spine_log(const char *format, ...) {
 		}
 	}
 
-	int prefix_len = strlen(logprefix);
-	int ulog_len   = strlen(ulogmessage);
-	int flog_len   = 0;
+	prefix_len = strlen(logprefix);
+	ulog_len   = strlen(ulogmessage);
+	flog_len   = 0;
 
 	if ((flog_len = strftime(flogmessage, 50, log_fmt, now_ptr)) == (int) 0) {
 		#ifdef DISABLE_STDERR
@@ -1690,10 +1696,10 @@ char *add_slashes(char *string) {
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 char *strncopy(char *dst, const char *src, size_t obuf) {
+	size_t len;
+
 	assert(dst != 0);
 	assert(src != 0);
-
-	size_t len;
 
 	len = (strlen(src) < obuf) ? strlen(src) : obuf;
 	if (len) {
@@ -1990,8 +1996,9 @@ void checkAsRoot() {
 	free(p);
 	#else
 	if (hasCaps() != TRUE) {
+		int ret;
 		SPINE_LOG_DEBUG(("DEBUG: Spine running as %d UID, %d EUID", getuid(), geteuid()));
-		int ret = seteuid(0);
+		ret = seteuid(0);
 		if (ret != 0) {
 			SPINE_LOG_DEBUG(("WARNING: Spine NOT able to set effective UID to 0"));
 		}
@@ -2075,6 +2082,7 @@ char *regex_replace(char *exp, char *value) {
 	regex_t regex;
 	int reti;
 	char msgbuf[100];
+	regmatch_t matches[MAX_MATCHES];
 
 	/* Compile regular expression */
 	reti = regcomp(&regex, exp, 0);
@@ -2084,7 +2092,6 @@ char *regex_replace(char *exp, char *value) {
 	}
 
 	/* Execute regular expression */
-	regmatch_t matches[MAX_MATCHES];
 	reti = regexec(&regex, value, MAX_MATCHES, matches, 0);
 	if (!reti) {
 		// regex matched


### PR DESCRIPTION
net-snmp 5.9.5 injects `-Werror=declaration-after-statement` via
`net-snmp-config --cflags`, breaking builds on FreeBSD and other
systems where net-snmp is compiled with strict C89 flags.

Moves all variable declarations to the top of their enclosing
block in `spine.c` (main) and `util.c` (read_config_options,
spine_log, strncopy, checkAsRoot, regex_replace).

Verified: clean compile with `-Werror=declaration-after-statement`
across sql.c, spine.c, and util.c.

Supersedes #407 (which stripped the flag instead of fixing the root cause).

Resolves #406