### PR TITLE
Cherry-pick #392: fix host_errors buffer overrun (backport to 1.2.x)

### DIFF
--- a/poller.c
+++ b/poller.c
@@ -1933,6 +1933,10 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 		int error_query_len = strlen(error_string) + BUFSIZE;
 		char *error_query = (char *)malloc(error_query_len);
 
+		if (!error_query) {
+			die("ERROR: Fatal malloc error: poller.c error_query!");
+		}
+
 		snprintf(error_query, error_query_len, "INSERT INTO host_errors (host_id, poller_id, errors, local_data_ids)"
 			" VALUES(%i, %i, %i, \"%s\")"
 			" ON DUPLICATE KEY UPDATE"

--- a/poller.c
+++ b/poller.c
@@ -1928,6 +1928,23 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 		snprintf(query1, BUFSIZE, "UPDATE host SET polling_time = %.3f - %.3f WHERE id = %i", poll_time, host_time_double, host_id);
 		db_query(&mysql, LOCAL, query1);
 	}
+
+	if (errors > 0) {
+		int error_query_len = strlen(error_string) + BUFSIZE;
+		char *error_query = (char *)malloc(error_query_len);
+
+		snprintf(error_query, error_query_len, "INSERT INTO host_errors (host_id, poller_id, errors, local_data_ids)"
+			" VALUES(%i, %i, %i, \"%s\")"
+			" ON DUPLICATE KEY UPDATE"
+			" errors = errors + VALUES(errors),"
+			" local_data_ids = CONCAT(local_data_ids, \", \", VALUES(local_data_ids))",
+			host_id, set.poller_id, errors, error_string);
+
+		db_query(&mysql, LOCAL, error_query);
+
+		free(error_query);
+	}
+
 	thread_mutex_unlock(LOCK_THDET);
 
 	if (local_cnn != NULL) {


### PR DESCRIPTION
Cherry-pick of fe44e08 from `develop` (PR #392).

The `host_errors` INSERT query uses `error_string` which can exceed
the fixed 1024-byte `BUFSIZE`, truncating the SQL and causing a
segfault. This dynamically allocates the query buffer based on
actual `error_string` length.

Already merged to `develop` — this backports it to `1.2.x` for
the 1.2.31 release.

Fixes #391
cc @TheWitness