### PR TITLE
fix: decode USM report errors instead of generic Unknown error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,6 +383,27 @@ AC_DEFINE_UNQUOTED(SNMP_LOCALNAME, $havelocalname, If snmp localname session str
 
 AC_CHECK_LIB(netsnmp, snmp_timeout)
 
+# ****************** SNMPv3 USM Error Constants Check ***********************
+AC_MSG_CHECKING([for SNMPv3 USM error constants])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+  #include <net-snmp/net-snmp-config.h>
+  #include <net-snmp/net-snmp-includes.h>
+]], [[
+  int x;
+#if defined(SNMPERR_NOT_IN_TIME_WINDOW)
+  x = SNMPERR_NOT_IN_TIME_WINDOW;
+#elif defined(SNMPERR_USM_NOTINTIMEWINDOW)
+  x = SNMPERR_USM_NOTINTIMEWINDOW;
+#else
+  #error no USM error constants
+#endif
+  (void)x;
+]])],
+  [AC_MSG_RESULT([yes])
+   AC_DEFINE(HAVE_SNMP_USM_ERRORS, 1, [Net-SNMP provides USM error constants (5.7+)])],
+  [AC_MSG_RESULT([no (USM error decoding disabled)])]
+)
+
 # ****************** Spine Result Buffer Check ***********************
 # Check for the default spine output buffer size
 results_buffer=2048

--- a/snmp.c
+++ b/snmp.c
@@ -532,10 +532,9 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 		} else {
 			/* decode USM-specific errors instead of generic "Unknown error" */
 			switch (sess_liberr) {
-#ifdef SNMPERR_NOT_IN_TIME_WINDOW
+#if defined(SNMPERR_NOT_IN_TIME_WINDOW)
 				case SNMPERR_NOT_IN_TIME_WINDOW:
-#endif
-#ifdef SNMPERR_USM_NOTINTIMEWINDOW
+#elif defined(SNMPERR_USM_NOTINTIMEWINDOW)
 				case SNMPERR_USM_NOTINTIMEWINDOW:
 #endif
 					SPINE_LOG_MEDIUM(("WARNING: Device[%i] USM notInTimeWindow for oid '%s' -- engine time drift (recoverable)",
@@ -544,46 +543,41 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 					status = STAT_SUCCESS;
 					SET_UNDEFINED(result_string);
 					break;
-#ifdef SNMPERR_UNKNOWN_ENG_ID
+#if defined(SNMPERR_UNKNOWN_ENG_ID)
 				case SNMPERR_UNKNOWN_ENG_ID:
-#endif
-#ifdef SNMPERR_USM_UNKNOWNENGINEID
+#elif defined(SNMPERR_USM_UNKNOWNENGINEID)
 				case SNMPERR_USM_UNKNOWNENGINEID:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownEngineID for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
-#ifdef SNMPERR_UNKNOWN_USER_NAME
+#if defined(SNMPERR_UNKNOWN_USER_NAME)
 				case SNMPERR_UNKNOWN_USER_NAME:
-#endif
-#ifdef SNMPERR_USM_UNKNOWNSECURITYNAME
+#elif defined(SNMPERR_USM_UNKNOWNSECURITYNAME)
 				case SNMPERR_USM_UNKNOWNSECURITYNAME:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownSecurityName for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
-#ifdef SNMPERR_AUTHENTICATION_FAILURE
+#if defined(SNMPERR_AUTHENTICATION_FAILURE)
 				case SNMPERR_AUTHENTICATION_FAILURE:
-#endif
-#ifdef SNMPERR_USM_AUTHENTICATIONFAILURE
+#elif defined(SNMPERR_USM_AUTHENTICATIONFAILURE)
 				case SNMPERR_USM_AUTHENTICATIONFAILURE:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM authenticationFailure for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
-#ifdef SNMPERR_DECRYPTION_ERR
+#if defined(SNMPERR_DECRYPTION_ERR)
 				case SNMPERR_DECRYPTION_ERR:
-#endif
-#ifdef SNMPERR_USM_DECRYPTIONERROR
+#elif defined(SNMPERR_USM_DECRYPTIONERROR)
 				case SNMPERR_USM_DECRYPTIONERROR:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM decryptionError for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
-#ifdef SNMPERR_UNSUPPORTED_SEC_LEVEL
+#if defined(SNMPERR_UNSUPPORTED_SEC_LEVEL)
 				case SNMPERR_UNSUPPORTED_SEC_LEVEL:
-#endif
-#ifdef SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL
+#elif defined(SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL)
 				case SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unsupportedSecurityLevel for oid '%s'",
@@ -699,10 +693,9 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 		} else if (status == STAT_ERROR) {
 			/* decode USM-specific errors instead of generic ignore_host */
 			switch (sess_liberr) {
-#ifdef SNMPERR_NOT_IN_TIME_WINDOW
+#if defined(SNMPERR_NOT_IN_TIME_WINDOW)
 				case SNMPERR_NOT_IN_TIME_WINDOW:
-#endif
-#ifdef SNMPERR_USM_NOTINTIMEWINDOW
+#elif defined(SNMPERR_USM_NOTINTIMEWINDOW)
 				case SNMPERR_USM_NOTINTIMEWINDOW:
 #endif
 					SPINE_LOG_MEDIUM(("WARNING: Device[%i] USM notInTimeWindow for getnext oid '%s' -- engine time drift (recoverable)",
@@ -711,46 +704,41 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 					status = STAT_SUCCESS;
 					SET_UNDEFINED(result_string);
 					break;
-#ifdef SNMPERR_UNKNOWN_ENG_ID
+#if defined(SNMPERR_UNKNOWN_ENG_ID)
 				case SNMPERR_UNKNOWN_ENG_ID:
-#endif
-#ifdef SNMPERR_USM_UNKNOWNENGINEID
+#elif defined(SNMPERR_USM_UNKNOWNENGINEID)
 				case SNMPERR_USM_UNKNOWNENGINEID:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownEngineID for getnext oid '%s'",
 						current_host->id, snmp_oid));
 					break;
-#ifdef SNMPERR_UNKNOWN_USER_NAME
+#if defined(SNMPERR_UNKNOWN_USER_NAME)
 				case SNMPERR_UNKNOWN_USER_NAME:
-#endif
-#ifdef SNMPERR_USM_UNKNOWNSECURITYNAME
+#elif defined(SNMPERR_USM_UNKNOWNSECURITYNAME)
 				case SNMPERR_USM_UNKNOWNSECURITYNAME:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownSecurityName for getnext oid '%s'",
 						current_host->id, snmp_oid));
 					break;
-#ifdef SNMPERR_AUTHENTICATION_FAILURE
+#if defined(SNMPERR_AUTHENTICATION_FAILURE)
 				case SNMPERR_AUTHENTICATION_FAILURE:
-#endif
-#ifdef SNMPERR_USM_AUTHENTICATIONFAILURE
+#elif defined(SNMPERR_USM_AUTHENTICATIONFAILURE)
 				case SNMPERR_USM_AUTHENTICATIONFAILURE:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM authenticationFailure for getnext oid '%s'",
 						current_host->id, snmp_oid));
 					break;
-#ifdef SNMPERR_DECRYPTION_ERR
+#if defined(SNMPERR_DECRYPTION_ERR)
 				case SNMPERR_DECRYPTION_ERR:
-#endif
-#ifdef SNMPERR_USM_DECRYPTIONERROR
+#elif defined(SNMPERR_USM_DECRYPTIONERROR)
 				case SNMPERR_USM_DECRYPTIONERROR:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM decryptionError for getnext oid '%s'",
 						current_host->id, snmp_oid));
 					break;
-#ifdef SNMPERR_UNSUPPORTED_SEC_LEVEL
+#if defined(SNMPERR_UNSUPPORTED_SEC_LEVEL)
 				case SNMPERR_UNSUPPORTED_SEC_LEVEL:
-#endif
-#ifdef SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL
+#elif defined(SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL)
 				case SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unsupportedSecurityLevel for getnext oid '%s'",

--- a/snmp.c
+++ b/snmp.c
@@ -366,7 +366,9 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
  */
 void snmp_host_cleanup(void *snmp_session) {
 	if (snmp_session != NULL) {
+		thread_mutex_lock(LOCK_SNMP);
 		snmp_sess_close(snmp_session);
+		thread_mutex_unlock(LOCK_SNMP);
 	}
 }
 
@@ -387,6 +389,7 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 	size_t anOID_len           = MAX_OID_LEN;
 	oid    anOID[MAX_OID_LEN];
 	int    status;
+	int    snmp_errno = SNMPERR_SUCCESS;
 	char   *result_string;
 	char   temp_result[RESULTS_BUFFER];
 
@@ -429,6 +432,18 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 			SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_sess_sync_response(%s)", current_host->id, snmp_oid));
 			status = snmp_sess_synch_response(current_host->snmp_session, pdu, &response);
 			SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_sess_sync_response(%s) [complete]", current_host->id, snmp_oid));
+		}
+
+		/* retrieve session-level error code for non-success responses */
+		if (status == STAT_ERROR && current_host->snmp_session != NULL) {
+			int liberr = 0, syserr = 0;
+			char *errstr = NULL;
+
+			snmp_sess_error(current_host->snmp_session, &liberr, &syserr, &errstr);
+			snmp_errno = liberr;
+			SPINE_LOG_DEBUG(("Device[%i] DEBUG: SNMP session error for oid '%s': %s (liberr=%d)",
+				current_host->id, snmp_oid, errstr ? errstr : "unknown", liberr));
+			SNMP_FREE(errstr);
 		}
 
 		/* add status to host structure */
@@ -514,7 +529,43 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 		} else if (status == STAT_TIMEOUT) {
 			SPINE_LOG_HIGH(("ERROR: Timeout getting oid '%s' for Device[%i] with Status[%d]",  snmp_oid, current_host->id, status));
 		} else {
-			SPINE_LOG_HIGH(("ERROR: Unknown error getting oid '%s' for Device[%i] with Status[%d]",  snmp_oid, current_host->id, status));
+			/* decode USM-specific errors instead of generic "Unknown error" */
+			switch (snmp_errno) {
+				case SNMPERR_NOT_IN_TIME_WINDOW:
+#ifdef SNMPERR_USM_NOTINTIMEWINDOW
+				case SNMPERR_USM_NOTINTIMEWINDOW:
+#endif
+					SPINE_LOG_MEDIUM(("WARNING: Device[%i] USM notInTimeWindow for oid '%s' -- engine time drift (recoverable)",
+						current_host->id, snmp_oid));
+					/* treat as transient — do not mark host down */
+					status = STAT_SUCCESS;
+					SET_UNDEFINED(result_string);
+					break;
+				case SNMPERR_USM_UNKNOWNENGINEID:
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownEngineID for oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+				case SNMPERR_USM_UNKNOWNSECURITYNAME:
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownSecurityName for oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+				case SNMPERR_USM_AUTHENTICATIONFAILURE:
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM authenticationFailure for oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+				case SNMPERR_USM_DECRYPTIONERROR:
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM decryptionError for oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+				case SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL:
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unsupportedSecurityLevel for oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+				default:
+					SPINE_LOG_HIGH(("ERROR: Unknown error getting oid '%s' for Device[%i] with Status[%d] Errno[%d]",
+						snmp_oid, current_host->id, status, snmp_errno));
+					break;
+			}
 		}
 
 		if (response != NULL && status != STAT_DESCRIP_ERROR) {

--- a/snmp.c
+++ b/snmp.c
@@ -530,11 +530,16 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 		} else if (status == STAT_TIMEOUT) {
 			SPINE_LOG_HIGH(("ERROR: Timeout getting oid '%s' for Device[%i] with Status[%d]",  snmp_oid, current_host->id, status));
 		} else {
-			/* decode USM-specific errors instead of generic "Unknown error" */
+			/* decode USM-specific errors instead of generic "Unknown error"
+			 * New constant names (SNMPERR_NOT_IN_TIME_WINDOW etc.) added in Net-SNMP 5.8.
+			 * Old names (SNMPERR_USM_NOTINTIMEWINDOW etc.) added in Net-SNMP 5.7.
+			 * On older versions, all USM errors fall through to the default case.
+			 */
 			switch (sess_liberr) {
+#if defined(SNMPERR_NOT_IN_TIME_WINDOW) || defined(SNMPERR_USM_NOTINTIMEWINDOW)
 #if defined(SNMPERR_NOT_IN_TIME_WINDOW)
 				case SNMPERR_NOT_IN_TIME_WINDOW:
-#elif defined(SNMPERR_USM_NOTINTIMEWINDOW)
+#else
 				case SNMPERR_USM_NOTINTIMEWINDOW:
 #endif
 					SPINE_LOG_MEDIUM(("WARNING: Device[%i] USM notInTimeWindow for oid '%s' -- engine time drift (recoverable)",
@@ -543,46 +548,57 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 					status = STAT_SUCCESS;
 					SET_UNDEFINED(result_string);
 					break;
+#endif
+#if defined(SNMPERR_UNKNOWN_ENG_ID) || defined(SNMPERR_USM_UNKNOWNENGINEID)
 #if defined(SNMPERR_UNKNOWN_ENG_ID)
 				case SNMPERR_UNKNOWN_ENG_ID:
-#elif defined(SNMPERR_USM_UNKNOWNENGINEID)
+#else
 				case SNMPERR_USM_UNKNOWNENGINEID:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownEngineID for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
+#if defined(SNMPERR_UNKNOWN_USER_NAME) || defined(SNMPERR_USM_UNKNOWNSECURITYNAME)
 #if defined(SNMPERR_UNKNOWN_USER_NAME)
 				case SNMPERR_UNKNOWN_USER_NAME:
-#elif defined(SNMPERR_USM_UNKNOWNSECURITYNAME)
+#else
 				case SNMPERR_USM_UNKNOWNSECURITYNAME:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownSecurityName for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
+#if defined(SNMPERR_AUTHENTICATION_FAILURE) || defined(SNMPERR_USM_AUTHENTICATIONFAILURE)
 #if defined(SNMPERR_AUTHENTICATION_FAILURE)
 				case SNMPERR_AUTHENTICATION_FAILURE:
-#elif defined(SNMPERR_USM_AUTHENTICATIONFAILURE)
+#else
 				case SNMPERR_USM_AUTHENTICATIONFAILURE:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM authenticationFailure for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
+#if defined(SNMPERR_DECRYPTION_ERR) || defined(SNMPERR_USM_DECRYPTIONERROR)
 #if defined(SNMPERR_DECRYPTION_ERR)
 				case SNMPERR_DECRYPTION_ERR:
-#elif defined(SNMPERR_USM_DECRYPTIONERROR)
+#else
 				case SNMPERR_USM_DECRYPTIONERROR:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM decryptionError for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
+#if defined(SNMPERR_UNSUPPORTED_SEC_LEVEL) || defined(SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL)
 #if defined(SNMPERR_UNSUPPORTED_SEC_LEVEL)
 				case SNMPERR_UNSUPPORTED_SEC_LEVEL:
-#elif defined(SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL)
+#else
 				case SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unsupportedSecurityLevel for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
 				default:
 					SPINE_LOG_HIGH(("ERROR: Unknown error getting oid '%s' for Device[%i] with Status[%d] Errno[%d]",
 						snmp_oid, current_host->id, status, sess_liberr));
@@ -691,11 +707,14 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 		} else if (status == STAT_TIMEOUT) {
 			SPINE_LOG_HIGH(("ERROR: Timeout getting oid '%s' for Device[%i] with Status[%d]", snmp_oid, current_host->id, status));
 		} else if (status == STAT_ERROR) {
-			/* decode USM-specific errors instead of generic ignore_host */
+			/* decode USM-specific errors instead of generic ignore_host
+			 * See version notes in snmp_get_base above.
+			 */
 			switch (sess_liberr) {
+#if defined(SNMPERR_NOT_IN_TIME_WINDOW) || defined(SNMPERR_USM_NOTINTIMEWINDOW)
 #if defined(SNMPERR_NOT_IN_TIME_WINDOW)
 				case SNMPERR_NOT_IN_TIME_WINDOW:
-#elif defined(SNMPERR_USM_NOTINTIMEWINDOW)
+#else
 				case SNMPERR_USM_NOTINTIMEWINDOW:
 #endif
 					SPINE_LOG_MEDIUM(("WARNING: Device[%i] USM notInTimeWindow for getnext oid '%s' -- engine time drift (recoverable)",
@@ -704,46 +723,57 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 					status = STAT_SUCCESS;
 					SET_UNDEFINED(result_string);
 					break;
+#endif
+#if defined(SNMPERR_UNKNOWN_ENG_ID) || defined(SNMPERR_USM_UNKNOWNENGINEID)
 #if defined(SNMPERR_UNKNOWN_ENG_ID)
 				case SNMPERR_UNKNOWN_ENG_ID:
-#elif defined(SNMPERR_USM_UNKNOWNENGINEID)
+#else
 				case SNMPERR_USM_UNKNOWNENGINEID:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownEngineID for getnext oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
+#if defined(SNMPERR_UNKNOWN_USER_NAME) || defined(SNMPERR_USM_UNKNOWNSECURITYNAME)
 #if defined(SNMPERR_UNKNOWN_USER_NAME)
 				case SNMPERR_UNKNOWN_USER_NAME:
-#elif defined(SNMPERR_USM_UNKNOWNSECURITYNAME)
+#else
 				case SNMPERR_USM_UNKNOWNSECURITYNAME:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownSecurityName for getnext oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
+#if defined(SNMPERR_AUTHENTICATION_FAILURE) || defined(SNMPERR_USM_AUTHENTICATIONFAILURE)
 #if defined(SNMPERR_AUTHENTICATION_FAILURE)
 				case SNMPERR_AUTHENTICATION_FAILURE:
-#elif defined(SNMPERR_USM_AUTHENTICATIONFAILURE)
+#else
 				case SNMPERR_USM_AUTHENTICATIONFAILURE:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM authenticationFailure for getnext oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
+#if defined(SNMPERR_DECRYPTION_ERR) || defined(SNMPERR_USM_DECRYPTIONERROR)
 #if defined(SNMPERR_DECRYPTION_ERR)
 				case SNMPERR_DECRYPTION_ERR:
-#elif defined(SNMPERR_USM_DECRYPTIONERROR)
+#else
 				case SNMPERR_USM_DECRYPTIONERROR:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM decryptionError for getnext oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
+#if defined(SNMPERR_UNSUPPORTED_SEC_LEVEL) || defined(SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL)
 #if defined(SNMPERR_UNSUPPORTED_SEC_LEVEL)
 				case SNMPERR_UNSUPPORTED_SEC_LEVEL:
-#elif defined(SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL)
+#else
 				case SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL:
 #endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unsupportedSecurityLevel for getnext oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#endif
 				default:
 					SPINE_LOG_HIGH(("ERROR: Unknown error getting oid '%s' for Device[%i] with Status[%d] Errno[%d]",
 						snmp_oid, current_host->id, status, sess_liberr));

--- a/snmp.c
+++ b/snmp.c
@@ -389,7 +389,7 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 	size_t anOID_len           = MAX_OID_LEN;
 	oid    anOID[MAX_OID_LEN];
 	int    status;
-	int    snmp_errno = SNMPERR_SUCCESS;
+	int    sess_liberr = SNMPERR_SUCCESS;
 	char   *result_string;
 	char   temp_result[RESULTS_BUFFER];
 
@@ -440,14 +440,11 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 			char *errstr = NULL;
 
 			snmp_sess_error(current_host->snmp_session, &liberr, &syserr, &errstr);
-			snmp_errno = liberr;
+			sess_liberr = liberr;
 			SPINE_LOG_DEBUG(("Device[%i] DEBUG: SNMP session error for oid '%s': %s (liberr=%d)",
 				current_host->id, snmp_oid, errstr ? errstr : "unknown", liberr));
 			SNMP_FREE(errstr);
 		}
-
-		/* add status to host structure */
-		current_host->snmp_status = status;
 
 		/* liftoff, successful poll, process it!! */
 		if (status == STAT_DESCRIP_ERROR) {
@@ -530,43 +527,73 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 			SPINE_LOG_HIGH(("ERROR: Timeout getting oid '%s' for Device[%i] with Status[%d]",  snmp_oid, current_host->id, status));
 		} else {
 			/* decode USM-specific errors instead of generic "Unknown error" */
-			switch (snmp_errno) {
+			switch (sess_liberr) {
+#ifdef SNMPERR_NOT_IN_TIME_WINDOW
 				case SNMPERR_NOT_IN_TIME_WINDOW:
+#endif
 #ifdef SNMPERR_USM_NOTINTIMEWINDOW
 				case SNMPERR_USM_NOTINTIMEWINDOW:
 #endif
 					SPINE_LOG_MEDIUM(("WARNING: Device[%i] USM notInTimeWindow for oid '%s' -- engine time drift (recoverable)",
 						current_host->id, snmp_oid));
-					/* treat as transient — do not mark host down */
+					/* treat as transient, do not mark host down */
 					status = STAT_SUCCESS;
 					SET_UNDEFINED(result_string);
 					break;
+#ifdef SNMPERR_UNKNOWN_ENG_ID
+				case SNMPERR_UNKNOWN_ENG_ID:
+#endif
+#ifdef SNMPERR_USM_UNKNOWNENGINEID
 				case SNMPERR_USM_UNKNOWNENGINEID:
+#endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownEngineID for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#ifdef SNMPERR_UNKNOWN_USER_NAME
+				case SNMPERR_UNKNOWN_USER_NAME:
+#endif
+#ifdef SNMPERR_USM_UNKNOWNSECURITYNAME
 				case SNMPERR_USM_UNKNOWNSECURITYNAME:
+#endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownSecurityName for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#ifdef SNMPERR_AUTHENTICATION_FAILURE
+				case SNMPERR_AUTHENTICATION_FAILURE:
+#endif
+#ifdef SNMPERR_USM_AUTHENTICATIONFAILURE
 				case SNMPERR_USM_AUTHENTICATIONFAILURE:
+#endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM authenticationFailure for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#ifdef SNMPERR_DECRYPTION_ERR
+				case SNMPERR_DECRYPTION_ERR:
+#endif
+#ifdef SNMPERR_USM_DECRYPTIONERROR
 				case SNMPERR_USM_DECRYPTIONERROR:
+#endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM decryptionError for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
+#ifdef SNMPERR_UNSUPPORTED_SEC_LEVEL
+				case SNMPERR_UNSUPPORTED_SEC_LEVEL:
+#endif
+#ifdef SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL
 				case SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL:
+#endif
 					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unsupportedSecurityLevel for oid '%s'",
 						current_host->id, snmp_oid));
 					break;
 				default:
 					SPINE_LOG_HIGH(("ERROR: Unknown error getting oid '%s' for Device[%i] with Status[%d] Errno[%d]",
-						snmp_oid, current_host->id, status, snmp_errno));
+						snmp_oid, current_host->id, status, sess_liberr));
 					break;
 			}
 		}
+
+		/* update host status after all adjustments */
+		current_host->snmp_status = status;
 
 		if (response != NULL && status != STAT_DESCRIP_ERROR) {
 			snmp_free_pdu(response);
@@ -604,6 +631,7 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 	size_t anOID_len           = MAX_OID_LEN;
 	oid    anOID[MAX_OID_LEN];
 	int    status;
+	int    sess_liberr = SNMPERR_SUCCESS;
 	char   *result_string;
 	char   temp_result[RESULTS_BUFFER];
 
@@ -629,13 +657,22 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 		/* poll host */
 		status = snmp_sess_synch_response(current_host->snmp_session, pdu, &response);
 
-		/* add status to host structure */
-		current_host->snmp_status = status;
+		/* retrieve session-level error code for non-success responses */
+		if (status == STAT_ERROR && current_host->snmp_session != NULL) {
+			int liberr = 0, syserr = 0;
+			char *errstr = NULL;
+
+			snmp_sess_error(current_host->snmp_session, &liberr, &syserr, &errstr);
+			sess_liberr = liberr;
+			SPINE_LOG_DEBUG(("Device[%i] DEBUG: SNMP getnext session error for oid '%s': %s (liberr=%d)",
+				current_host->id, snmp_oid, errstr ? errstr : "unknown", liberr));
+			SNMP_FREE(errstr);
+		}
 
 		/* liftoff, successful poll, process it!! */
 		if (status == STAT_SUCCESS) {
 			if (response == NULL) {
-				SPINE_LOG(("ERROR: An internal Net-Snmp error condition detected in Cacti snmp_get"));
+				SPINE_LOG(("ERROR: An internal Net-Snmp error condition detected in Cacti snmp_getnext"));
 
 				SET_UNDEFINED(result_string);
 				status = STAT_ERROR;
@@ -653,7 +690,77 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 					}
 				}
 			}
+		} else if (status == STAT_TIMEOUT) {
+			SPINE_LOG_HIGH(("ERROR: Timeout getting oid '%s' for Device[%i] with Status[%d]", snmp_oid, current_host->id, status));
+		} else if (status == STAT_ERROR) {
+			/* decode USM-specific errors instead of generic ignore_host */
+			switch (sess_liberr) {
+#ifdef SNMPERR_NOT_IN_TIME_WINDOW
+				case SNMPERR_NOT_IN_TIME_WINDOW:
+#endif
+#ifdef SNMPERR_USM_NOTINTIMEWINDOW
+				case SNMPERR_USM_NOTINTIMEWINDOW:
+#endif
+					SPINE_LOG_MEDIUM(("WARNING: Device[%i] USM notInTimeWindow for getnext oid '%s' -- engine time drift (recoverable)",
+						current_host->id, snmp_oid));
+					/* treat as transient, do not mark host down */
+					status = STAT_SUCCESS;
+					SET_UNDEFINED(result_string);
+					break;
+#ifdef SNMPERR_UNKNOWN_ENG_ID
+				case SNMPERR_UNKNOWN_ENG_ID:
+#endif
+#ifdef SNMPERR_USM_UNKNOWNENGINEID
+				case SNMPERR_USM_UNKNOWNENGINEID:
+#endif
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownEngineID for getnext oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+#ifdef SNMPERR_UNKNOWN_USER_NAME
+				case SNMPERR_UNKNOWN_USER_NAME:
+#endif
+#ifdef SNMPERR_USM_UNKNOWNSECURITYNAME
+				case SNMPERR_USM_UNKNOWNSECURITYNAME:
+#endif
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unknownSecurityName for getnext oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+#ifdef SNMPERR_AUTHENTICATION_FAILURE
+				case SNMPERR_AUTHENTICATION_FAILURE:
+#endif
+#ifdef SNMPERR_USM_AUTHENTICATIONFAILURE
+				case SNMPERR_USM_AUTHENTICATIONFAILURE:
+#endif
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM authenticationFailure for getnext oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+#ifdef SNMPERR_DECRYPTION_ERR
+				case SNMPERR_DECRYPTION_ERR:
+#endif
+#ifdef SNMPERR_USM_DECRYPTIONERROR
+				case SNMPERR_USM_DECRYPTIONERROR:
+#endif
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM decryptionError for getnext oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+#ifdef SNMPERR_UNSUPPORTED_SEC_LEVEL
+				case SNMPERR_UNSUPPORTED_SEC_LEVEL:
+#endif
+#ifdef SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL
+				case SNMPERR_USM_UNSUPPORTEDSECURITYLEVEL:
+#endif
+					SPINE_LOG_HIGH(("ERROR: Device[%i] USM unsupportedSecurityLevel for getnext oid '%s'",
+						current_host->id, snmp_oid));
+					break;
+				default:
+					SPINE_LOG_HIGH(("ERROR: Unknown error getting oid '%s' for Device[%i] with Status[%d] Errno[%d]",
+						snmp_oid, current_host->id, status, sess_liberr));
+					break;
+			}
 		}
+
+		/* update host status after all adjustments */
+		current_host->snmp_status = status;
 
 		if (response) {
 			snmp_free_pdu(response);


### PR DESCRIPTION
Retrieve the actual session errno via `snmp_sess_error()` after `STAT_ERROR` and decode the six USM report types individually. `notInTimeWindow` is treated as recoverable since net-snmp resolves it via internal retry on the next poll.

Also wraps `snmp_sess_close()` in `LOCK_SNMP` to protect the shared USM engine cache.

Fixes #412
Related: Cacti/cacti#6668