### PR TITLE
fix: plug resource leaks in SNMP session setup and poll paths

### DIFF
--- a/poller.c
+++ b/poller.c
@@ -2288,13 +2288,13 @@ char *exec_poll(host_t *current_host, char *command, int id, char *type) {
 
 		/* peel the executable from the command */
 		saveptr = proc_command;
-		sprintf(executable, "%s", proc_command);
+		snprintf(executable, BUFSIZE, "%s", proc_command);
 		strtok_r(executable, " ", &saveptr);
 
 		/* cheesy little hack to add /usr/bin/ if its not included */
 		if (strstr(executable, "/") == NULL) {
 			saveptr = proc_command;
-			sprintf(executable, "/usr/bin/%s", proc_command);
+			snprintf(executable, BUFSIZE, "/usr/bin/%s", proc_command);
 			strtok_r(executable, " ", &saveptr);
 		}
 

--- a/snmp.c
+++ b/snmp.c
@@ -367,6 +367,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 	free(session.peername);
 	free(session.securityAuthProto);
 	free(session.securityPrivProto);
+	free(session.localname);
 
 	if (!sessp) {
 		if (is_debug_device(host_id)) {

--- a/snmp.c
+++ b/snmp.c
@@ -192,6 +192,10 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 
 	snprintf(hostnameport, BUFSIZE, "%s:%i", hostname, snmp_port);
 	session.peername    = strdup(hostnameport);
+	if (!session.peername) {
+		SPINE_LOG(("Device[%i] ERROR: Failed to allocate peername for '%s'", host_id, hostname));
+		return 0;
+	}
 	session.retries     = set.snmp_retries;
 	session.timeout     = (snmp_timeout * 1000); /* net-snmp likes microseconds */
 
@@ -314,6 +318,10 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					free(session.securityPrivProto);
 					free(Apsz);
 					free(Xpsz);
+					if (session.localname) {
+						free(session.localname);
+						session.localname = NULL;
+					}
 					return 0;
 				}
 

--- a/snmp.c
+++ b/snmp.c
@@ -252,6 +252,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				SPINE_LOG(("SNMP: Device[%i] Error privacy protocol %s is invalid.", host_id, snmp_priv_protocol));
 				free(session.peername);
 				free(session.securityAuthProto);
+				free(session.localname);
 				return 0;
 			}
 

--- a/snmp.c
+++ b/snmp.c
@@ -344,6 +344,10 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					free(session.securityAuthProto);
 					free(session.securityPrivProto);
 					free(Xpsz);
+					if (session.localname) {
+						free(session.localname);
+						session.localname = NULL;
+					}
 					return 0;
 				}
 

--- a/snmp.c
+++ b/snmp.c
@@ -190,7 +190,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 	}
 
 	snprintf(hostnameport, BUFSIZE, "%s:%i", hostname, snmp_port);
-	session.peername    = hostnameport;
+	session.peername    = strdup(hostnameport);
 	session.retries     = set.snmp_retries;
 	session.timeout     = (snmp_timeout * 1000); /* net-snmp likes microseconds */
 
@@ -226,6 +226,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
             session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
 		} else {
 			SPINE_LOG(("SNMP: Device[%i] Error auth protocol %s is invalid.", host_id, snmp_auth_protocol));
+			free(session.peername);
 			return 0;
 		}
 
@@ -248,6 +249,8 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 
 			if (priv_type < 0) {
 				SPINE_LOG(("SNMP: Device[%i] Error privacy protocol %s is invalid.", host_id, snmp_priv_protocol));
+				free(session.peername);
+				free(session.securityAuthProto);
 				return 0;
 			}
 
@@ -301,6 +304,11 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					session.securityAuthKey,
 					&session.securityAuthKeyLen) != SNMPERR_SUCCESS) {
 					SPINE_LOG(("SNMP: Device[%i] Error generating SNMPv3 Ku from authentication passphrase.", host_id));
+					free(session.peername);
+					free(session.securityAuthProto);
+					free(session.securityPrivProto);
+					free(Apsz);
+					free(Xpsz);
 					return 0;
 				}
 
@@ -330,6 +338,10 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					session.securityPrivKey,
 					&session.securityPrivKeyLen) != SNMPERR_SUCCESS) {
 					SPINE_LOG(("SNMP: Device[%i] Error generating SNMPv3 Ku from privacy pass phrase.", host_id));
+					free(session.peername);
+					free(session.securityAuthProto);
+					free(session.securityPrivProto);
+					free(Xpsz);
 					return 0;
 				}
 
@@ -345,6 +357,10 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 	thread_mutex_lock(LOCK_SNMP);
 	sessp = snmp_sess_open(&session);
 	thread_mutex_unlock(LOCK_SNMP);
+
+	free(session.peername);
+	free(session.securityAuthProto);
+	free(session.securityPrivProto);
 
 	if (!sessp) {
 		if (is_debug_device(host_id)) {
@@ -416,6 +432,7 @@ char *snmp_get_base(host_t *current_host, char *snmp_oid, bool should_fail) {
 			if (!snmp_parse_oid(snmp_oid, anOID, &anOID_len)) {
 				SPINE_LOG_DEVDBG(("Device[%i] DEBUG: snmp_parse_oid(%s) [complete]", current_host->id, snmp_oid));
 				SPINE_LOG(("Device[%i] ERROR: SNMP Get Problems parsing SNMP OID %s", current_host->id, snmp_oid));
+				snmp_free_pdu(pdu);
 				SET_UNDEFINED(result_string);
 				return result_string;
 			} else {
@@ -569,6 +586,7 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 
 		if (!snmp_parse_oid(snmp_oid, anOID, &anOID_len)) {
 			SPINE_LOG(("Device[%i] ERROR: SNMP Getnext Problems parsing SNMP OID %s", current_host->id, snmp_oid));
+			snmp_free_pdu(pdu);
 			SET_UNDEFINED(result_string);
 			return result_string;
 		} else {

--- a/snmp.c
+++ b/snmp.c
@@ -227,6 +227,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		} else {
 			SPINE_LOG(("SNMP: Device[%i] Error auth protocol %s is invalid.", host_id, snmp_auth_protocol));
 			free(session.peername);
+			free(session.localname);
 			return 0;
 		}
 


### PR DESCRIPTION
Fixes #415

Four resource leaks in snmp.c and poller.c:

1. snmp.c: `session.peername` not `strdup()`'d, dangling reference after `snmp_sess_open()`
2. snmp.c: `securityAuthProto`/`securityPrivProto` OIDs leaked on 4 error paths and happy path
3. snmp.c: PDU leaked in `snmp_get_base()` and `snmp_getnext()` when `snmp_parse_oid()` fails
4. poller.c: `sprintf` overflow in `exec_poll()`, switched to `snprintf`

All declarations at block top per project convention. Tested with gcc and clang.