### PR TITLE
fix: minor safety improvements across poller, sql, and spine

### DIFF
--- a/poller.c
+++ b/poller.c
@@ -1040,7 +1040,11 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 							}
 							poll_result[0] = '\0';
 
-							snprintf(poll_result, BUFSIZE, "%d", char_count(exec_poll(host, reindex->arg1, reindex->data_query_id, "DQ"), '\n'));
+							{
+								char *ep_result = exec_poll(host, reindex->arg1, reindex->data_query_id, "DQ");
+								snprintf(poll_result, BUFSIZE, "%d", char_count(ep_result, '\n'));
+								free(ep_result);
+							}
 
 							if (is_debug_device(host->id)) {
 								SPINE_LOG(("Device[%i] HT[%i] DQ[%i] RECACHE CMD COUNT: %s, output: %s", host->id, host_thread, reindex->data_query_id, reindex->arg1, poll_result));
@@ -1057,7 +1061,11 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 
 							php_process = php_get_process();
 
-							sprintf(poll_result, "%d", char_count(php_cmd(reindex->arg1, php_process), '\n'));
+							{
+								char *php_result = php_cmd(reindex->arg1, php_process);
+								snprintf(poll_result, BUFSIZE, "%d", char_count(php_result, '\n'));
+								free(php_result);
+							}
 
 							if (is_debug_device(host->id)) {
 								SPINE_LOG(("Device[%i] HT[%i] DQ[%i] RECACHE SERVER COUNT: %s, output: %s", host->id, host_thread, reindex->data_query_id, reindex->arg1, poll_result));

--- a/spine.c
+++ b/spine.c
@@ -250,7 +250,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	/* create the array of debug devices */
-	debug_devices = calloc(100, sizeof(int));
+	debug_devices = calloc(MAX_DEBUG_DEVICES, sizeof(int));
 
 	/* initialize icmp_avail */
 	set.icmp_avail = TRUE;
@@ -522,7 +522,7 @@ int main(int argc, char *argv[]) {
 		char *token;
 		SPINE_LOG_DEBUG(("DEBUG: Selective Debug Devices %s", set.selective_device_debug));
 		token = strtok(set.selective_device_debug, ",");
-		while(token && i < 99) {
+		while(token && i < MAX_DEBUG_DEVICES - 1) {
 			debug_devices[i]   = atoi(token);
 			debug_devices[i+1] = '\0';
 			token = strtok(NULL, ",");
@@ -734,7 +734,7 @@ int main(int argc, char *argv[]) {
 	while (canexit == FALSE && device_counter < num_rows) {
 		int loop_count = 0;
 		double progress_time = 0;
-		unsigned int sem_err = 0;
+		int sem_err = 0;
 		int spine_timeout = FALSE;
 
 		if (change_host) {

--- a/spine.c
+++ b/spine.c
@@ -522,7 +522,7 @@ int main(int argc, char *argv[]) {
 		char *token;
 		SPINE_LOG_DEBUG(("DEBUG: Selective Debug Devices %s", set.selective_device_debug));
 		token = strtok(set.selective_device_debug, ",");
-		while(token) {
+		while(token && i < 99) {
 			debug_devices[i]   = atoi(token);
 			debug_devices[i+1] = '\0';
 			token = strtok(NULL, ",");
@@ -840,14 +840,14 @@ int main(int argc, char *argv[]) {
 			sem_err = sem_trywait(&available_threads);
 
 			if (sem_err == 0) {
-				// Acquired a thread
+				/* acquired a thread */
 				break;
-			} else if (sem_err == EINTR) {
-				// Interrupted by signal handler
-			} else if (sem_err == EDEADLK) {
+			} else if (errno == EINTR) {
+				/* interrupted by signal handler */
+			} else if (errno == EDEADLK) {
 				SPINE_LOG_DEVDBG(("WARNING: Device[%i] HT[%i] would have deadlocked acquiring Available Thread Lock", host_id, current_thread));
-			} else if (sem_err == EAGAIN) {
-				// Keep trying
+			} else if (errno == EAGAIN) {
+				/* keep trying */
 			}
 
 			loop_count++;

--- a/spine.h
+++ b/spine.h
@@ -130,6 +130,7 @@
 
 /* general constants */
 #define MAX_THREADS 100
+#define MAX_DEBUG_DEVICES 100
 #define TINY_BUFSIZE 16
 #define SMALL_BUFSIZE 256
 #define MEDIUM_BUFSIZE 512

--- a/sql.c
+++ b/sql.c
@@ -281,9 +281,7 @@ void db_connect(int type, MYSQL *mysql) {
 	wtimeout  = 30;
 	attempts  = 1;
 
-	mysql = mysql_init(mysql);
-
-	if (mysql == NULL) {
+	if (mysql_init(mysql) == NULL) {
 		printf("FATAL: Database unable to allocate memory and therefore can not connect\n");
 		exit(1);
 	}

--- a/sql.c
+++ b/sql.c
@@ -281,7 +281,7 @@ void db_connect(int type, MYSQL *mysql) {
 	wtimeout  = 30;
 	attempts  = 1;
 
-	mysql_init(mysql);
+	mysql = mysql_init(mysql);
 
 	if (mysql == NULL) {
 		printf("FATAL: Database unable to allocate memory and therefore can not connect\n");


### PR DESCRIPTION
Fixes #416

Five minor safety fixes:

1. poller.c: `exec_poll()` return value leaked after `char_count()`
2. poller.c: `php_cmd()` return value leaked + `sprintf` to `snprintf`
3. sql.c: `mysql_init()` return value captured to handle reallocation
4. spine.c: `debug_devices` tokenizer bounded to array size
5. spine.c: `sem_trywait` checks `errno` instead of return code for EINTR

All declarations at block top per project convention. Tested with gcc and clang.