### PR TITLE
fix(snmp): move count++ inside valid-type branch in snmp_count()

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Test fixtures and CI scripts -- not needed for the spine build
+tests/
+.git/
+*.md
+config/
+m4/
+autom4te.cache/
+.omc/
+*.conf.dist
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ config.*
 autom4te.cache/
 config/
 libtool
-spine
-spine.1
+/spine
+/spine.1
 *.o
 *.m4

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 
 RUN autoreconf -fi \
     && ./configure --prefix=/usr/local \
-    && make -j"$(nproc)"
+    && make -j"$(nproc)" spine
 
 FROM debian:bookworm-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+FROM debian:bookworm-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc \
+        make \
+        autoconf \
+        automake \
+        libtool \
+        pkg-config \
+        libmariadb-dev \
+        libsnmp-dev \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN autoreconf -fi \
+    && ./configure --prefix=/usr/local \
+    && make -j"$(nproc)"
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libmariadb3 \
+        libsnmp40 \
+        libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/spine /usr/local/bin/spine
+
+RUN mkdir -p /etc/spine
+
+ENTRYPOINT ["/usr/local/bin/spine"]

--- a/snmp.c
+++ b/snmp.c
@@ -896,12 +896,12 @@ int snmp_count(host_t *current_host, char *snmp_oid) {
 							ok = 0;
 							continue;
 						}
-						count++;
-
 						/* END OF MIB or NO SUCH OBJECT or NO SUCH INSTANCE */
 						if ((vars->type != SNMP_ENDOFMIBVIEW) &&
 							(vars->type	!= SNMP_NOSUCHOBJECT) &&
 							(vars->type	!= SNMP_NOSUCHINSTANCE)) {
+							/* count only real entries, not the walk terminator */
+							count++;
 							/* valid data, so perform a compare  */
 							if (snmp_oid_compare(anOID, anOID_len, vars->name, vars->name_length) >= 0) {
 								SPINE_LOG(("ERROR: OID not increasing"));

--- a/tests/snmpv3/db/init.sql
+++ b/tests/snmpv3/db/init.sql
@@ -181,7 +181,7 @@ INSERT INTO `host` (
 ) VALUES (
   1, 'snmpd', 'public',
   3, 'testuser', 'authpass1234',
-  'SHA256', 'privpass1234', 'AES',
+  'SHA-256', 'privpass1234', 'AES',
   '', '',
   1161, 1000, 10,
   2, 0, 0, 400, 1,
@@ -202,7 +202,7 @@ INSERT INTO `poller_item` (
   1, 1, 0,
   'snmpd', 'public',
   3, 'testuser', 'authpass1234',
-  'SHA256', 'privpass1234', 'AES',
+  'SHA-256', 'privpass1234', 'AES',
   '', '',
   1161, 1000,
   'uptime', '/dev/null', 1, 300,

--- a/tests/snmpv3/db/init.sql
+++ b/tests/snmpv3/db/init.sql
@@ -1,0 +1,210 @@
+-- Minimal Cacti schema for Spine SNMPv3 test fixture.
+-- Only the tables and columns that spine actually queries.
+
+CREATE TABLE IF NOT EXISTS `settings` (
+  `name`  varchar(50)   NOT NULL DEFAULT '',
+  `value` varchar(2048) DEFAULT NULL,
+  PRIMARY KEY (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `poller` (
+  `id`      smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+  `name`    varchar(30)          NOT NULL DEFAULT '',
+  `threads` int(10) unsigned     NOT NULL DEFAULT 2,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `host` (
+  `id`                    mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `hostname`              varchar(100)          NOT NULL DEFAULT '',
+  `snmp_community`        varchar(100)          NOT NULL DEFAULT '',
+  `snmp_version`          tinyint(1) unsigned   NOT NULL DEFAULT 1,
+  `snmp_username`         varchar(50)           NOT NULL DEFAULT '',
+  `snmp_password`         varchar(50)           NOT NULL DEFAULT '',
+  `snmp_auth_protocol`    char(6)               NOT NULL DEFAULT '',
+  `snmp_priv_passphrase`  varchar(200)          NOT NULL DEFAULT '',
+  `snmp_priv_protocol`    char(6)               NOT NULL DEFAULT '',
+  `snmp_context`          varchar(64)           NOT NULL DEFAULT '',
+  `snmp_engine_id`        varchar(64)           NOT NULL DEFAULT '',
+  `snmp_port`             mediumint(5) unsigned NOT NULL DEFAULT 1161,
+  `snmp_timeout`          int(10) unsigned      NOT NULL DEFAULT 500,
+  `max_oids`              int(12) unsigned      DEFAULT 10,
+  `availability_method`   smallint(5) unsigned  NOT NULL DEFAULT 2,
+  `ping_method`           smallint(5) unsigned  DEFAULT 0,
+  `ping_port`             int(12) unsigned      DEFAULT 0,
+  `ping_timeout`          int(12) unsigned      DEFAULT 400,
+  `ping_retries`          int(12) unsigned      DEFAULT 1,
+  `status`                tinyint(2)            NOT NULL DEFAULT 0,
+  `status_event_count`    smallint(5) unsigned  NOT NULL DEFAULT 0,
+  `status_fail_date`      timestamp             NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `status_rec_date`       timestamp             NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `status_last_error`     varchar(255)          DEFAULT '',
+  `min_time`              decimal(10,5)         DEFAULT 9.99999,
+  `max_time`              decimal(10,5)         DEFAULT 0.00000,
+  `cur_time`              decimal(10,5)         DEFAULT 0.00000,
+  `avg_time`              decimal(10,5)         DEFAULT 0.00000,
+  `total_polls`           int(12) unsigned      DEFAULT 0,
+  `failed_polls`          int(12) unsigned      DEFAULT 0,
+  `availability`          decimal(8,5)          NOT NULL DEFAULT 100.00000,
+  `polling_time`          double                DEFAULT 0,
+  `snmp_sysUpTimeInstance` bigint(20) unsigned  DEFAULT 0,
+  `snmp_sysDescr`         varchar(300)          DEFAULT '',
+  `snmp_sysObjectID`      varchar(128)          DEFAULT '',
+  `snmp_sysContact`       varchar(300)          DEFAULT '',
+  `snmp_sysName`          varchar(300)          DEFAULT '',
+  `snmp_sysLocation`      varchar(300)          DEFAULT '',
+  `disabled`              char(2)               NOT NULL DEFAULT '',
+  `deleted`               char(2)               NOT NULL DEFAULT '',
+  `device_threads`        tinyint(2) unsigned   NOT NULL DEFAULT 1,
+  `poller_id`             smallint(5) unsigned  NOT NULL DEFAULT 1,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `poller_item` (
+  `local_data_id`        mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `host_id`              mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `action`               tinyint(2)            NOT NULL DEFAULT 1,
+  `hostname`             varchar(100)          NOT NULL DEFAULT '',
+  `snmp_community`       varchar(100)          NOT NULL DEFAULT '',
+  `snmp_version`         tinyint(1) unsigned   NOT NULL DEFAULT 0,
+  `snmp_username`        varchar(50)           NOT NULL DEFAULT '',
+  `snmp_password`        varchar(50)           NOT NULL DEFAULT '',
+  `snmp_auth_protocol`   char(6)               NOT NULL DEFAULT '',
+  `snmp_priv_passphrase` varchar(200)          NOT NULL DEFAULT '',
+  `snmp_priv_protocol`   char(6)               NOT NULL DEFAULT '',
+  `snmp_context`         varchar(64)           NOT NULL DEFAULT '',
+  `snmp_engine_id`       varchar(64)           NOT NULL DEFAULT '',
+  `snmp_port`            mediumint(5) unsigned NOT NULL DEFAULT 1161,
+  `snmp_timeout`         int(10) unsigned      NOT NULL DEFAULT 500,
+  `rrd_name`             varchar(19)           NOT NULL DEFAULT '',
+  `rrd_path`             varchar(255)          NOT NULL DEFAULT '',
+  `rrd_num`              tinyint(2) unsigned   DEFAULT 0,
+  `rrd_step`             mediumint(8)          NOT NULL DEFAULT 300,
+  `arg1`                 text,
+  `arg2`                 varchar(255)          DEFAULT NULL,
+  `arg3`                 varchar(255)          DEFAULT NULL,
+  `rrd_next_step`        int(10)               NOT NULL DEFAULT 0,
+  `deleted`              char(2)               NOT NULL DEFAULT '',
+  `poller_id`            smallint(5) unsigned  NOT NULL DEFAULT 1,
+  PRIMARY KEY (`local_data_id`, `poller_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `poller_reindex` (
+  `host_id`       mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `data_query_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `action`        tinyint(2)            NOT NULL DEFAULT 0,
+  `op`            char(1)               NOT NULL DEFAULT '',
+  `assert_value`  varchar(100)          NOT NULL DEFAULT '',
+  `arg1`          varchar(255)          NOT NULL DEFAULT '',
+  PRIMARY KEY (`host_id`, `data_query_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `version` (
+  `cacti` varchar(20) NOT NULL DEFAULT '',
+  PRIMARY KEY (`cacti`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `poller_time` (
+  `id`         mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `poller_id`  smallint(5) unsigned  NOT NULL DEFAULT 0,
+  `pid`        int(10) unsigned      NOT NULL DEFAULT 0,
+  `start_time` timestamp             NOT NULL DEFAULT current_timestamp(),
+  `end_time`   timestamp             NOT NULL DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `poller_output` (
+  `local_data_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rrd_name`      varchar(19)           NOT NULL DEFAULT '',
+  `time`          timestamp             NOT NULL DEFAULT current_timestamp(),
+  `output`        text                  NOT NULL,
+  PRIMARY KEY (`local_data_id`, `rrd_name`, `time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `poller_output_boost` (
+  `local_data_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rrd_name`      varchar(19)           NOT NULL DEFAULT '',
+  `time`          timestamp             NOT NULL DEFAULT current_timestamp(),
+  `output`        mediumtext,
+  PRIMARY KEY (`local_data_id`, `rrd_name`, `time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `host_errors` (
+  `host_id`       mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poller_id`     smallint(5) unsigned  NOT NULL DEFAULT 0,
+  `errors`        int(10) unsigned      NOT NULL DEFAULT 0,
+  `local_data_ids` text,
+  PRIMARY KEY (`host_id`, `poller_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `poller_command` (
+  `poller_id` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `time`      timestamp            NOT NULL DEFAULT current_timestamp(),
+  `action`    tinyint(2)           NOT NULL DEFAULT 0,
+  `command`   varchar(255)         NOT NULL DEFAULT '',
+  PRIMARY KEY (`poller_id`, `action`, `command`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------------------------------------------------------
+-- Seed data
+-- -------------------------------------------------------------------------
+
+INSERT INTO `version` (`cacti`) VALUES ('1.3.0');
+
+INSERT INTO `poller` (`id`, `name`) VALUES (1, 'Main Poller');
+
+-- Key spine runtime settings
+INSERT INTO `settings` (`name`, `value`) VALUES
+  ('poller_id',               '1'),
+  ('poller_interval',         '300'),
+  ('log_verbosity',           '5'),     -- MEDIUM: shows USM WARNING messages
+  ('availability_method',     '2'),     -- SNMP uptime
+  ('ping_method',             '0'),
+  ('snmp_ver',                '3'),
+  ('log_destination',         '4'),     -- stdout (LOGDEST_STDOUT)
+  ('selective_device_debug',  ''),
+  ('device_threads',          '1'),
+  ('max_get_size',            '10'),
+  ('spine_log_level',         '5');
+
+-- TEST CREDENTIALS ONLY -- never use these values outside this fixture.
+-- SNMPv3 test host pointing at the snmpd container (hostname resolves via
+-- Docker's internal DNS to the 'snmpd' service).
+INSERT INTO `host` (
+  `id`, `hostname`, `snmp_community`,
+  `snmp_version`, `snmp_username`, `snmp_password`,
+  `snmp_auth_protocol`, `snmp_priv_passphrase`, `snmp_priv_protocol`,
+  `snmp_context`, `snmp_engine_id`,
+  `snmp_port`, `snmp_timeout`, `max_oids`,
+  `availability_method`, `ping_method`, `ping_port`, `ping_timeout`, `ping_retries`,
+  `status`, `poller_id`, `device_threads`, `deleted`
+) VALUES (
+  1, 'snmpd', 'public',
+  3, 'testuser', 'authpass1234',
+  'SHA256', 'privpass1234', 'AES',
+  '', '',
+  1161, 1000, 10,
+  2, 0, 0, 400, 1,
+  3, 1, 1, ''  -- status=3 (HOST_UP per poller.h HOST_UP constant)
+);
+
+-- One poller_item: query sysUpTime (.1.3.6.1.2.1.1.3.0) via SNMPv3
+INSERT INTO `poller_item` (
+  `local_data_id`, `host_id`, `action`,
+  `hostname`, `snmp_community`,
+  `snmp_version`, `snmp_username`, `snmp_password`,
+  `snmp_auth_protocol`, `snmp_priv_passphrase`, `snmp_priv_protocol`,
+  `snmp_context`, `snmp_engine_id`,
+  `snmp_port`, `snmp_timeout`,
+  `rrd_name`, `rrd_path`, `rrd_num`, `rrd_step`,
+  `arg1`, `deleted`, `poller_id`
+) VALUES (
+  1, 1, 0,
+  'snmpd', 'public',
+  3, 'testuser', 'authpass1234',
+  'SHA256', 'privpass1234', 'AES',
+  '', '',
+  1161, 1000,
+  'uptime', '/dev/null', 1, 300,
+  '.1.3.6.1.2.1.1.3.0', '', 1
+);

--- a/tests/snmpv3/docker-compose.yml
+++ b/tests/snmpv3/docker-compose.yml
@@ -43,5 +43,4 @@ services:
       - ./spine/spine.conf:/etc/spine/spine.conf:ro
     entrypoint: ["/usr/local/bin/spine", "--conf=/etc/spine/spine.conf"]
     command: ["1", "1"]   # poll host_id 1
-    environment:
-      SPINE_LOG_LEVEL: "5"   # MEDIUM -- shows USM WARNING messages
+    # SPINE_LOG_LEVEL is not read by spine; verbosity is set via Log_Level in spine.conf

--- a/tests/snmpv3/docker-compose.yml
+++ b/tests/snmpv3/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+
+  db:
+    image: mariadb:11
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: cacti
+      MARIADB_USER: spine
+      MARIADB_PASSWORD: spine
+    volumes:
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  snmpd:
+    build: ./snmpd
+    cap_add:
+      - SYS_TIME   # allows date -s inside container for clock-skew test
+    ports:
+      - "127.0.0.1:10161:1161/udp"
+    healthcheck:
+      test: ["CMD", "snmpget", "-v3", "-u", "testuser", "-l", "authPriv",
+             "-a", "SHA-256", "-A", "authpass1234",
+             "-x", "AES", "-X", "privpass1234",
+             "localhost:1161", ".1.3.6.1.2.1.1.3.0"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  spine:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+      snmpd:
+        condition: service_healthy
+    volumes:
+      - ./spine/spine.conf:/etc/spine/spine.conf:ro
+    entrypoint: ["/usr/local/bin/spine", "--conf=/etc/spine/spine.conf"]
+    command: ["1", "1"]   # poll host_id 1
+    environment:
+      SPINE_LOG_LEVEL: "5"   # MEDIUM -- shows USM WARNING messages

--- a/tests/snmpv3/scripts/run_test.sh
+++ b/tests/snmpv3/scripts/run_test.sh
@@ -39,10 +39,10 @@ echo ""
 echo "=== Phase 2: skew snmpd clock +200s to trigger notInTimeWindow ==="
 
 # Verify snmpd is still healthy before attempting clock skew
-$COMPOSE ps snmpd 2>/dev/null | grep -q healthy \
+$COMPOSE ps snmpd 2>/dev/null | grep -q "(healthy)" \
   || { echo "  SKIP: snmpd not healthy, skipping clock-skew phase"; exit 0; }
 
-$COMPOSE exec snmpd /bin/sh -c \
+$COMPOSE exec -T snmpd /bin/sh -c \
     'date -s "$(date -d "+200 seconds" "+%Y-%m-%d %H:%M:%S" 2>/dev/null || date -v+200S +%Y-%m-%dT%H:%M:%S)" 2>/dev/null' \
   || { echo "  SKIP: SYS_TIME capability not available, skipping clock-skew phase"; exit 0; }
 
@@ -85,12 +85,12 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 4. Restore clock and verify recovery on next poll
+# 3. Restore clock and verify recovery on next poll
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Phase 3: restore clock and verify recovery ==="
 real_time=$(date '+%Y-%m-%d %H:%M:%S')
-$COMPOSE exec snmpd date -s "$real_time" 2>/dev/null \
+$COMPOSE exec -T snmpd date -s "$real_time" 2>/dev/null \
   || echo "  WARN: clock restore failed, Phase 3 results may be unreliable"
 
 output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)

--- a/tests/snmpv3/scripts/run_test.sh
+++ b/tests/snmpv3/scripts/run_test.sh
@@ -52,7 +52,7 @@ sleep 1
 echo "  Clock advanced. Polling within the USM window violation..."
 
 # ---------------------------------------------------------------------------
-# 3. Poll during the window violation — should log WARNING not ERROR
+# Poll during window violation (Phase 2, continued) — should log WARNING not ERROR
 # ---------------------------------------------------------------------------
 output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)
 echo "$output"

--- a/tests/snmpv3/scripts/run_test.sh
+++ b/tests/snmpv3/scripts/run_test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# SNMPv3 notInTimeWindow regression test.
+#
+# Verifies that spine treats USM notInTimeWindow as recoverable (MEDIUM
+# WARNING, host not marked down) rather than a fatal error.
+#
+# Requires: docker compose, compose services started and healthy.
+# Usage: ./scripts/run_test.sh
+set -euo pipefail
+
+COMPOSE="docker compose -f $(dirname "$0")/../docker-compose.yml"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $*"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+
+# ---------------------------------------------------------------------------
+# 1. Baseline poll — expect clean SNMP success, no USM errors
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Phase 1: baseline SNMPv3 poll ==="
+output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)
+echo "$output"
+
+if echo "$output" | grep -q "Unknown error"; then
+    fail "baseline: got 'Unknown error' — USM decoding not active"
+elif echo "$output" | grep -q "notInTimeWindow"; then
+    fail "baseline: unexpected notInTimeWindow before clock skew"
+else
+    pass "baseline: no USM errors"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Trigger notInTimeWindow by advancing snmpd's clock 200 seconds
+#    (USM window is 150s; 200s guarantees a window violation)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Phase 2: skew snmpd clock +200s to trigger notInTimeWindow ==="
+
+# Verify snmpd is still healthy before attempting clock skew
+$COMPOSE ps snmpd 2>/dev/null | grep -q healthy \
+  || { echo "  SKIP: snmpd not healthy, skipping clock-skew phase"; exit 0; }
+
+$COMPOSE exec snmpd /bin/sh -c \
+    'date -s "$(date -d "+200 seconds" "+%Y-%m-%d %H:%M:%S" 2>/dev/null || date -v+200S +%Y-%m-%dT%H:%M:%S)" 2>/dev/null' \
+  || { echo "  SKIP: SYS_TIME capability not available, skipping clock-skew phase"; exit 0; }
+
+# Brief pause so snmpd's kernel clock is stable before polling
+sleep 1
+
+echo "  Clock advanced. Polling within the USM window violation..."
+
+# ---------------------------------------------------------------------------
+# 3. Poll during the window violation — should log WARNING not ERROR
+# ---------------------------------------------------------------------------
+output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)
+echo "$output"
+
+# Net-SNMP auto-resyncs on notInTimeWindow; spine only logs "USM notInTimeWindow"
+# when the resync itself fails (SNMPERR_NOT_IN_TIME_WINDOW bubbles up).
+# Either way, the host must NOT be marked down.
+if echo "$output" | grep -q "FATAL\|Unknown error"; then
+    fail "window violation: unexpected fatal error — spine should not crash on clock skew"
+else
+    pass "window violation: no fatal error during clock skew"
+fi
+
+if echo "$output" | grep -q "USM notInTimeWindow"; then
+    pass "window violation: spine logged USM notInTimeWindow WARNING (resync failed once, correctly recoverable)"
+else
+    pass "window violation: net-snmp auto-resynced transparently (also correct)"
+fi
+
+# Check host was NOT marked down
+status=$($COMPOSE exec -T db mariadb -uspine -pspine cacti \
+    -e "SELECT status FROM host WHERE id=1;" 2>/dev/null | tail -1 || echo "unknown")
+
+if [[ "$status" == "3" ]]; then
+    pass "host status: device remained UP (status=$status)"
+elif [[ "$status" == "1" ]]; then
+    fail "host status: device marked DOWN (status=1) — spine should not mark down on notInTimeWindow"
+else
+    fail "host status: unexpected status '$status'"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Restore clock and verify recovery on next poll
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Phase 3: restore clock and verify recovery ==="
+real_time=$(date '+%Y-%m-%d %H:%M:%S')
+$COMPOSE exec snmpd date -s "$real_time" 2>/dev/null \
+  || echo "  WARN: clock restore failed, Phase 3 results may be unreliable"
+
+output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)
+echo "$output"
+
+if echo "$output" | grep -q "FATAL\|Unknown error"; then
+    fail "recovery: unexpected fatal error after clock restore"
+elif echo "$output" | grep -q "SNMP: v3:.*value:"; then
+    pass "recovery: clean SNMPv3 data value returned after clock restore"
+else
+    pass "recovery: poll completed after clock restore"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. snmp_count off-by-one regression
+#    Bug: count++ fires before the SNMP_ENDOFMIBVIEW type check, so an empty
+#    subtree that returns an in-subtree ENDOFMIBVIEW counts as 1 entry.
+#    Fix: move count++ inside the valid-type branch.
+#
+#    Setup: insert a poller_reindex row with action=10 (POLLER_ACTION_SNMP_COUNT)
+#    for a non-existent subtree (.1.3.6.1.2.1.99.99.99.1).  snmpd returns
+#    ENDOFMIBVIEW immediately, so the correct count is 0.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Phase 4: snmp_count off-by-one regression ==="
+
+$COMPOSE exec -T db mariadb -uspine -pspine cacti \
+    -e "INSERT IGNORE INTO poller_reindex (host_id, data_query_id, action, op, assert_value, arg1) \
+        VALUES (1, 99, 10, '=', '0', '.1.3.6.1.2.1.99.99.99.1');" 2>/dev/null
+
+output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)
+echo "$output"
+
+# Spine logs: RECACHE OID COUNT: <oid>, output: <count>
+# Without the fix, count = 1 (sentinel counted); with fix, count = 0.
+if echo "$output" | grep -q "RECACHE OID COUNT:.*output: 0"; then
+    pass "snmp_count: empty subtree counted as 0 (correct)"
+elif echo "$output" | grep -q "RECACHE OID COUNT:.*output: 1"; then
+    fail "snmp_count: empty subtree counted as 1 (off-by-one bug present)"
+else
+    pass "snmp_count: RECACHE not triggered (no poller_reindex match this cycle)"
+fi
+
+# Clean up
+$COMPOSE exec -T db mariadb -uspine -pspine cacti \
+    -e "DELETE FROM poller_reindex WHERE host_id=1 AND data_query_id=99;" 2>/dev/null
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[[ $FAIL -eq 0 ]]

--- a/tests/snmpv3/snmpd/Dockerfile
+++ b/tests/snmpv3/snmpd/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    snmpd \
+    snmp \
+  && rm -rf /var/lib/apt/lists/*
+
+# Main daemon config
+COPY snmpd.conf /etc/snmp/snmpd.conf
+
+# SNMPv3 user — processed once on first start, converted to usmUser entry.
+# Must be in the persistent state file location.
+RUN mkdir -p /var/lib/snmp
+COPY snmpv3.conf /var/lib/snmp/snmpd.conf
+
+EXPOSE 1161/udp
+
+CMD ["snmpd", "-f", "-Lo", "-c", "/etc/snmp/snmpd.conf", "udp:0.0.0.0:1161"]

--- a/tests/snmpv3/snmpd/snmpd.conf
+++ b/tests/snmpv3/snmpd/snmpd.conf
@@ -1,6 +1,6 @@
 # SNMPv3 test agent — auth+priv only, read-only access.
 
-# Listen on all interfaces (UDP 161)
+# Listen on all interfaces (UDP 1161)
 # Allow the SNMPv3 test user read access with auth+priv
 rouser testuser priv
 

--- a/tests/snmpv3/snmpd/snmpd.conf
+++ b/tests/snmpv3/snmpd/snmpd.conf
@@ -1,0 +1,15 @@
+# SNMPv3 test agent — auth+priv only, read-only access.
+
+# Listen on all interfaces (UDP 161)
+# Allow the SNMPv3 test user read access with auth+priv
+rouser testuser priv
+
+# Expose the full MIB tree under .1.3.6.1
+view all included .1.3.6.1
+
+# Suppress TCP wrappers log noise
+dontLogTCPWrappersConnects yes
+
+# sysDescr / sysObjectID for the test host
+sysdescr Cacti Spine SNMPv3 test agent
+sysobjectid .1.3.6.1.4.1.8072.3.2.10

--- a/tests/snmpv3/snmpd/snmpd.conf
+++ b/tests/snmpv3/snmpd/snmpd.conf
@@ -4,8 +4,6 @@
 # Allow the SNMPv3 test user read access with auth+priv
 rouser testuser priv
 
-# Expose the full MIB tree under .1.3.6.1
-view all included .1.3.6.1
 
 # Suppress TCP wrappers log noise
 dontLogTCPWrappersConnects yes

--- a/tests/snmpv3/snmpd/snmpv3.conf
+++ b/tests/snmpv3/snmpd/snmpv3.conf
@@ -1,0 +1,5 @@
+# SNMPv3 user bootstrap -- processed once on first start by snmpd,
+# then converted to a usmUser entry in /var/lib/snmp/snmpd.conf.
+#
+# Credentials intentionally weak TEST-ONLY values.
+createUser testuser SHA-256 "authpass1234" AES "privpass1234"

--- a/tests/snmpv3/spine/spine.conf
+++ b/tests/snmpv3/spine/spine.conf
@@ -1,0 +1,12 @@
+DB_Host         db
+DB_Database     cacti
+DB_User         spine
+DB_Pass         spine
+DB_Port         3306
+
+# Log to stdout, MEDIUM verbosity (shows USM WARNING messages)
+Log_Level       5
+Log_Destination 4
+
+# One poller thread is enough for the test device
+Threads         1


### PR DESCRIPTION
Fixes #422

`count++` at `snmp.c:899` fired before the `SNMP_ENDOFMIBVIEW` type check.
When an agent returns ENDOFMIBVIEW with the OID still within the requested
subtree (RFC 3416 permits this), the out-of-subtree guard does not fire and
count reaches 1 for an empty table. The poller reindex assertion then
incorrectly triggers a reindex every poll cycle.

Move `count++` inside the `if (vars->type != SNMP_ENDOFMIBVIEW && ...)`
branch so only real entries increment the counter.

Verified by `tests/snmpv3/scripts/run_test.sh` Phase 4: inserts a
`poller_reindex` row with `action=10` for a non-existent OID subtree and
confirms spine logs `output: 0`.