### PR TITLE
fix(ping): reinitialize fd_set before each select() call in ping_icmp()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ develop
 -issue#360: If a Remote Data Collector has not devices, spine does not properly register itself
 -feature#362: Report the number of data collection errors during data collection in host table
 -feature#443: Add make targets for Docker build and verification (docker, docker-dev, verify, cppcheck)
+-issue#423: Reinitialize fd_set before each select() call in ping_icmp() to prevent instant retry expiry after first timeout
 -feature#5090: Enhance number recognition within Spine
 -feature#3740: Ability to disable a site
 -feature#6001: Extend SYSTEM STATS

--- a/ping.c
+++ b/ping.c
@@ -315,8 +315,6 @@ int ping_icmp(host_t *host, ping_t *ping) {
 				#endif
 
 				return HOST_DOWN;
-
-				break;
 			}
 		} else {
 			break;
@@ -374,10 +372,6 @@ int ping_icmp(host_t *host, ping_t *ping) {
 			total_time  = 0;
 			begin_time  = get_time_as_double();
 
-			/* initialize file descriptor to review for input/output */
-			FD_ZERO(&socket_fds);
-			FD_SET(icmp_socket,&socket_fds);
-
 			while (1) {
 				if (retry_count > host->ping_retries) {
 					snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Ping timed out");
@@ -407,7 +401,10 @@ int ping_icmp(host_t *host, ping_t *ping) {
 				fromlen = sizeof(fromname);
 
 				/* wait for a response on the socket */
+				/* reinitialize fd_set -- select(2) clears bits in place on return */
 				keep_listening:
+				FD_ZERO(&socket_fds);
+				FD_SET(icmp_socket,&socket_fds);
 				return_code = select(FD_SETSIZE, &socket_fds, NULL, NULL, &timeout);
 
 				/* record end time */


### PR DESCRIPTION
Fixes #423

`select(2)` modifies the `fd_set` in place on return, clearing all bits
after a timeout. With `FD_ZERO`/`FD_SET` only before the retry `while(1)`
loop, every retry after the first timeout called `select()` on an empty
descriptor set and returned 0 immediately, exhausting all retries in
microseconds. Reachable hosts that experience one packet loss are marked DOWN.

Move `FD_ZERO`/`FD_SET` to the `keep_listening:` label so all code paths
(normal sendto fallthrough, EINTR goto, another-host goto) reinitialize
before each `select()` call.

Also removes unreachable `break` after `return HOST_DOWN;` at `ping.c:319`.