### PR TITLE
fix(poller): correct inverted spike_kill condition for PHP script server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,13 +5,13 @@ develop
 -feature#443: Add make targets for Docker build and verification (docker, docker-dev, verify, cppcheck)
 1.3.0
 -issue#360: If a Remote Data Collector has not devices, spine does not properly register itself
+-issue#424: Correct inverted spike_kill condition for PHP script server (IS_UNDEFINED -> !IS_UNDEFINED)
 -feature#362: Report the number of data collection errors during data collection in host table
 -feature#443: Add make targets for Docker build and verification (docker, docker-dev, verify, cppcheck)
--feature#5090: Enhance number recognition within Spine
 -feature#3740: Ability to disable a site
+-feature#5090: Enhance number recognition within Spine
 -feature#6001: Extend SYSTEM STATS
 -feature: Make spine work with Stream feature
-
 1.2.31
 -issue#365: Removing Backtrace Support
 -issue#366: Failing to actually a poll device that returns "NoSuchObject"

--- a/poller.c
+++ b/poller.c
@@ -1683,9 +1683,9 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 					SPINE_LOG_MEDIUM(("Device[%i] HT[%i] DS[%i] TT[%.2f] SS[%i] SERVER: %s, output: %s", host_id, host_thread, poller_items[i].local_data_id, (float) ((thread_end - thread_start) * 1000), php_process, poller_items[i].arg1, poller_items[i].result));
 				}
 
-				if (IS_UNDEFINED(poller_items[i].result)) {
+				if (!IS_UNDEFINED(poller_items[i].result)) {
 					/* insert a NaN in place of the actual value if the snmp agent restarts */
-					if ((spike_kill) && (!STRIMATCH(poller_items[i].result,":"))) {
+					if ((spike_kill) && (!strstr(poller_items[i].result,":"))) {
 						SET_UNDEFINED(poller_items[i].result);
 					}
 				}

--- a/tests/snmpv3/scripts/run_test.sh
+++ b/tests/snmpv3/scripts/run_test.sh
@@ -8,7 +8,7 @@
 # Usage: ./scripts/run_test.sh
 set -euo pipefail
 
-COMPOSE="docker compose -f $(dirname "$0")/../docker-compose.yml"
+COMPOSE=(docker compose -f "$(dirname "$0")/../docker-compose.yml")
 PASS=0
 FAIL=0
 
@@ -20,7 +20,7 @@ fail() { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Phase 1: baseline SNMPv3 poll ==="
-output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)
+output=$("${COMPOSE[@]}" run --rm --no-deps spine 2>&1 || true)
 echo "$output"
 
 if echo "$output" | grep -q "Unknown error"; then
@@ -39,10 +39,10 @@ echo ""
 echo "=== Phase 2: skew snmpd clock +200s to trigger notInTimeWindow ==="
 
 # Verify snmpd is still healthy before attempting clock skew
-$COMPOSE ps snmpd 2>/dev/null | grep -q "(healthy)" \
+"${COMPOSE[@]}" ps snmpd 2>/dev/null | grep -qw "healthy" \
   || { echo "  SKIP: snmpd not healthy, skipping clock-skew phase"; exit 0; }
 
-$COMPOSE exec -T snmpd /bin/sh -c \
+"${COMPOSE[@]}" exec -T snmpd /bin/sh -c \
     'date -s "$(date -d "+200 seconds" "+%Y-%m-%d %H:%M:%S" 2>/dev/null || date -v+200S +%Y-%m-%dT%H:%M:%S)" 2>/dev/null' \
   || { echo "  SKIP: SYS_TIME capability not available, skipping clock-skew phase"; exit 0; }
 
@@ -54,7 +54,7 @@ echo "  Clock advanced. Polling within the USM window violation..."
 # ---------------------------------------------------------------------------
 # Poll during window violation (Phase 2, continued) — should log WARNING not ERROR
 # ---------------------------------------------------------------------------
-output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)
+output=$("${COMPOSE[@]}" run --rm --no-deps spine 2>&1 || true)
 echo "$output"
 
 # Net-SNMP auto-resyncs on notInTimeWindow; spine only logs "USM notInTimeWindow"
@@ -73,7 +73,7 @@ else
 fi
 
 # Check host was NOT marked down
-status=$($COMPOSE exec -T db mariadb -uspine -pspine cacti \
+status=$("${COMPOSE[@]}" exec -T db mariadb -uspine -pspine cacti \
     -e "SELECT status FROM host WHERE id=1;" 2>/dev/null | tail -1 || echo "unknown")
 
 if [[ "$status" == "3" ]]; then
@@ -90,10 +90,10 @@ fi
 echo ""
 echo "=== Phase 3: restore clock and verify recovery ==="
 real_time=$(date '+%Y-%m-%d %H:%M:%S')
-$COMPOSE exec -T snmpd date -s "$real_time" 2>/dev/null \
+"${COMPOSE[@]}" exec -T snmpd date -s "$real_time" 2>/dev/null \
   || echo "  WARN: clock restore failed, Phase 3 results may be unreliable"
 
-output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)
+output=$("${COMPOSE[@]}" run --rm --no-deps spine 2>&1 || true)
 echo "$output"
 
 if echo "$output" | grep -q "FATAL\|Unknown error"; then
@@ -117,11 +117,11 @@ fi
 echo ""
 echo "=== Phase 4: snmp_count off-by-one regression ==="
 
-$COMPOSE exec -T db mariadb -uspine -pspine cacti \
+"${COMPOSE[@]}" exec -T db mariadb -uspine -pspine cacti \
     -e "INSERT IGNORE INTO poller_reindex (host_id, data_query_id, action, op, assert_value, arg1) \
         VALUES (1, 99, 10, '=', '0', '.1.3.6.1.2.1.99.99.99.1');" 2>/dev/null
 
-output=$($COMPOSE run --rm --no-deps spine 2>&1 || true)
+output=$("${COMPOSE[@]}" run --rm --no-deps spine 2>&1 || true)
 echo "$output"
 
 # Spine logs: RECACHE OID COUNT: <oid>, output: <count>
@@ -135,7 +135,7 @@ else
 fi
 
 # Clean up
-$COMPOSE exec -T db mariadb -uspine -pspine cacti \
+"${COMPOSE[@]}" exec -T db mariadb -uspine -pspine cacti \
     -e "DELETE FROM poller_reindex WHERE host_id=1 AND data_query_id=99;" 2>/dev/null
 
 # ---------------------------------------------------------------------------

--- a/tests/snmpv3/spine/spine.conf
+++ b/tests/snmpv3/spine/spine.conf
@@ -1,12 +1,8 @@
-DB_Host         db
-DB_Database     cacti
-DB_User         spine
-DB_Pass         spine
-DB_Port         3306
+# spine.conf for docker-compose integration tests
+# DB service name matches docker-compose service "db"
+DB_Host       db
+DB_Database   cacti
+DB_User       spine
+DB_Pass       spine
+DB_Port       3306
 
-# Log to stdout, MEDIUM verbosity (shows USM WARNING messages)
-Log_Level       5
-Log_Destination 4
-
-# One poller thread is enough for the test device
-Threads         1


### PR DESCRIPTION
Fixes #424

`POLLER_ACTION_PHP_SCRIPT_SERVER` at `poller.c:1678` used `IS_UNDEFINED`
where it should use `!IS_UNDEFINED`. The guard was true only when the result
was already `"U"`, making `SET_UNDEFINED` a no-op. PHP script server data
sources were never spike-killed after agent restarts, producing spurious
spikes in graphs.

Change `IS_UNDEFINED` to `!IS_UNDEFINED` to match the adjacent
`POLLER_ACTION_SCRIPT` block.

Also adds a Docker-based SNMPv3 regression fixture under `tests/snmpv3/` that covers the spike_kill fix and serves as a shared harness for related poller correctness tests.