### PR TITLE
fix(snmp): harden USM error handling portability and coverage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -399,8 +399,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #endif
   (void)x;
 ]])],
-  [AC_MSG_RESULT([yes])
-   AC_DEFINE(HAVE_SNMP_USM_ERRORS, 1, [Net-SNMP provides USM error constants (5.7+)])],
+  [AC_MSG_RESULT([yes])],
   [AC_MSG_RESULT([no (USM error decoding disabled)])]
 )
 

--- a/snmp.c
+++ b/snmp.c
@@ -740,7 +740,7 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
 		} else if (status == STAT_TIMEOUT) {
 			SPINE_LOG_HIGH(("ERROR: Timeout getting oid '%s' for Device[%i] with Status[%d]", snmp_oid, current_host->id, status));
 		} else if (status == STAT_ERROR) {
-			/* decode USM-specific errors instead of generic ignore_host
+			/* decode USM-specific errors instead of generic "Unknown error"
 			 * See version notes in snmp_get_base above.
 			 */
 			switch (sess_liberr) {


### PR DESCRIPTION
Builds on #413 with three additional improvements to SNMPv3 error handling.

**snmp_sess_error() retrieval before USM switch**

Without calling `snmp_sess_error()` the `sess_liberr` variable is always `SNMPERR_SUCCESS`, so the USM switch introduced in #413 always falls through to `default`. This call populates `sess_liberr` from the actual session state before the switch runs.

**snmp_sess_close() mutex**

`snmp_sess_open()` acquires `LOCK_SNMP` but `snmp_host_cleanup()` calls `snmp_sess_close()` unprotected. These operations share the net-snmp USM engine cache. Wrap `snmp_sess_close()` with `LOCK_SNMP` to match.

**Portability guards for USM error constants**

The newer `SNMPERR_NOT_IN_TIME_WINDOW` and the older `SNMPERR_USM_NOTINTIMEWINDOW` symbol sets map to different numeric values. Outer `#if defined(A) || defined(B)` guards ensure both sets compile on Net-SNMP 5.7+ and that neither case label appears when neither symbol is defined (older versions).

Same USM decoding applied to `snmp_getnext()` which had the same catch-all gap as `snmp_get_base()`.

Fixes: Cacti/cacti#6668
Ref: #413
Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>