### PR TITLE
fix(C): correct printf format specifiers, guard calloc, and fix shell quoting

### DIFF
--- a/copyright_year.sh
+++ b/copyright_year.sh
@@ -53,7 +53,7 @@ update_copyright() {
 			printf "%60s %s\n" "==============================" "===================="
 			printf "%60s %s\n" "$old_data" "=>"
 			printf "%60s %s\n" "$new_data" ""
-			sed -i -r s/"$old_reg"/"$new_reg"/g $1
+			sed -i -r s/"$old_reg"/"$new_reg"/g "$1"
 			printf "%60s %s\n" "==============================" "===================="
 		fi
 	else

--- a/poller.c
+++ b/poller.c
@@ -967,7 +967,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 									poll_result = snmp_get_base(host, ".1.3.6.1.6.3.10.2.1.3.0", false);
 
 									if (poll_result && is_numeric(poll_result)) {
-										snprintf(sysUptime, BUFSIZE, "%llu", atoll(poll_result) * 100);
+										snprintf(sysUptime, BUFSIZE, "%lld", atoll(poll_result) * 100);
 									}
 
 									SPINE_FREE(poll_result);
@@ -1411,7 +1411,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 							} else if ((is_numeric(snmp_oids[j].result)) || (is_multipart_output(snmp_oids[j].result))) {
 								/* continue */
 							} else if (is_hexadecimal(snmp_oids[j].result, TRUE)) {
-								snprintf(snmp_oids[j].result, RESULTS_BUFFER, "%lld", hex2dec(snmp_oids[j].result));
+								snprintf(snmp_oids[j].result, RESULTS_BUFFER, "%llu", hex2dec(snmp_oids[j].result));
 							} else if ((STRIMATCH(snmp_oids[j].result, "U")) ||
 								(STRIMATCH(snmp_oids[j].result, "Nan"))) {
 								buffer_output_errors(error_string, buf_size, buf_errors, host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, false);
@@ -1512,7 +1512,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 						} else if ((is_numeric(snmp_oids[j].result)) || (is_multipart_output(snmp_oids[j].result))) {
 							/* continue */
 						} else if (is_hexadecimal(snmp_oids[j].result, TRUE)) {
-							snprintf(snmp_oids[j].result, RESULTS_BUFFER, "%lld", hex2dec(snmp_oids[j].result));
+							snprintf(snmp_oids[j].result, RESULTS_BUFFER, "%llu", hex2dec(snmp_oids[j].result));
 						} else if ((STRIMATCH(snmp_oids[j].result, "U")) ||
 							(STRIMATCH(snmp_oids[j].result, "Nan"))) {
 							buffer_output_errors(error_string, buf_size, buf_errors, host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, false);
@@ -1594,7 +1594,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 				} else if ((is_numeric(poll_result)) || (is_multipart_output(trim(poll_result)))) {
 					snprintf(poller_items[i].result, RESULTS_BUFFER, "%s", poll_result);
 				} else if (is_hexadecimal(poll_result, TRUE)) {
-					snprintf(poller_items[i].result, RESULTS_BUFFER, "%lld", hex2dec(poll_result));
+					snprintf(poller_items[i].result, RESULTS_BUFFER, "%llu", hex2dec(poll_result));
 				} else {
 					/* remove double or single quotes from string */
 					snprintf(temp_result, RESULTS_BUFFER, "%s", regex_replace(REGEX_NUMBER, strip_alpha(poll_result)));
@@ -1652,7 +1652,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 				} else if ((is_numeric(poll_result)) || (is_multipart_output(trim(poll_result)))) {
 					snprintf(poller_items[i].result, RESULTS_BUFFER, "%s", poll_result);
 				} else if (is_hexadecimal(poll_result, TRUE)) {
-					snprintf(poller_items[i].result, RESULTS_BUFFER, "%lld", hex2dec(poll_result));
+					snprintf(poller_items[i].result, RESULTS_BUFFER, "%llu", hex2dec(poll_result));
 				} else {
 					/* remove double or single quotes from string */
 					snprintf(temp_result, RESULTS_BUFFER, "%s", regex_replace(REGEX_NUMBER, strip_alpha(poll_result)));
@@ -1724,7 +1724,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 				} else if ((is_numeric(snmp_oids[j].result)) || (is_multipart_output(snmp_oids[j].result))) {
 					/* continue */
 				} else if (is_hexadecimal(snmp_oids[j].result, TRUE)) {
-					snprintf(snmp_oids[j].result, RESULTS_BUFFER, "%lld", hex2dec(snmp_oids[j].result));
+					snprintf(snmp_oids[j].result, RESULTS_BUFFER, "%llu", hex2dec(snmp_oids[j].result));
 				} else if ((STRIMATCH(snmp_oids[j].result, "U")) ||
 					(STRIMATCH(snmp_oids[j].result, "Nan"))) {
 					buffer_output_errors(error_string, buf_size, buf_errors, host_id, host_thread, poller_items[snmp_oids[j].array_position].local_data_id, false);

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -7,7 +7,7 @@ cppcheck --enable=all --std=c11 --error-exitcode=1 \
   --suppress=unusedFunction \
   --suppress=checkersReport \
   --suppress=toomanyconfigs \
-  *.c *.h 2>&1 | tee /tmp/cppcheck.txt
+  -- *.c *.h 2>&1 | tee /tmp/cppcheck.txt
 
 echo ""
 echo "=== scan-build ==="

--- a/snmp.c
+++ b/snmp.c
@@ -187,6 +187,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		session.securityModel = USM_SEC_MODEL_NUMBER;
 	} else {
 		SPINE_LOG(("Device[%i] ERROR: SNMP Version Error for Device '%s'", host_id, hostname));
+		free(session.localname);
 		return 0;
 	}
 
@@ -996,6 +997,10 @@ void snmp_get_multi(host_t *current_host, target_t *poller_items, snmp_oids_t *s
 
 	/* load up oids */
 	namep = name = (struct nameStruct *) calloc(num_oids, sizeof(*name));
+	if (name == NULL) {
+		SPINE_LOG(("ERROR: Failed to allocate memory for SNMP OID name array"));
+		return;
+	}
 	pdu = snmp_pdu_create(SNMP_MSG_GET);
 	for (i = 0; i < num_oids; i++) {
 		namep->name_len = MAX_OID_LEN;

--- a/sql.c
+++ b/sql.c
@@ -348,11 +348,11 @@ void db_connect(int type, MYSQL *mysql) {
 				tries++;
 				success = FALSE;
 			} else if (error == 2002) {
-				printf("Database: Connection Failed: Attempt:'%u', Error:'%u', Message:'%s'\n", attempts, mysql_errno(mysql), mysql_error(mysql));
+				printf("Database: Connection Failed: Attempt:'%d', Error:'%u', Message:'%s'\n", attempts, mysql_errno(mysql), mysql_error(mysql));
 				sleep(1);
 				success = FALSE;
 			} else if (error != 1049 && error != 2005 && error != 1045) {
-				printf("Database: Connection Failed: Error:'%u', Message:'%s'\n", error, mysql_error(mysql));
+				printf("Database: Connection Failed: Error:'%d', Message:'%s'\n", error, mysql_error(mysql));
 				success = FALSE;
 				usleep(50000);
 			} else {
@@ -406,7 +406,6 @@ void db_disconnect(MYSQL *mysql) {
 		mysql_close(mysql);
 	}
 
-	mysql = NULL;
 }
 
 /*! \fn void db_create_connection_pool(int type)

--- a/util.c
+++ b/util.c
@@ -1288,7 +1288,7 @@ int spine_log(const char *format, ...) {
 
 	/* log message prefix */
 
-	snprintf(logprefix, LOGSIZE, "SPINE: Poller[%i] PID[%i] PT[%ld] ", set.poller_id, getpid(), (unsigned long int)pthread_self());
+	snprintf(logprefix, LOGSIZE, "SPINE: Poller[%i] PID[%i] PT[%lu] ", set.poller_id, getpid(), (unsigned long int)pthread_self());
 
 	/* get time for poller_output table */
 	nowbin = time(&nowbin);


### PR DESCRIPTION
Twelve bugs found by running cppcheck 2.20 (--enable=warning,portability) and shellcheck v0.10.0.1 across the full source tree.

**poller.c**

- `%llu` used for `atoll()` return (signed `long long`) at line 970 — changed to `%lld`
- `%lld` used for `hex2dec()` return (unsigned `long long`) at five call sites (lines 1414, 1515, 1597, 1655, 1727) — changed to `%llu`

Mismatched sign in printf format specifiers is undefined behaviour under C99 §7.19.6.1.

**snmp.c**

- `session.localname` is `strdup()`'d at line 140 (when `SNMP_LOCALNAME == 1`) but the early-return path for an unknown SNMP version at line 190 did not free it. Added `free(session.localname)` before that return. `free(NULL)` is a no-op so the call is safe when `SNMP_LOCALNAME != 1`.
- `calloc(num_oids, sizeof(*name))` at line 999 has no NULL check. If allocation fails, the immediately following `namep->name_len = MAX_OID_LEN` dereferences a null pointer. Added a NULL guard that logs via `SPINE_LOG` and returns early before the PDU is created.

**sql.c**

- `attempts` is `int` but printed with `%u` — changed to `%d`.
- `error` is `int` but printed with `%u` — changed to `%d`.
- `mysql = NULL` in `db_disconnect()` assigns to a by-value parameter; the write has no effect on the caller. Removed the dead assignment.

**util.c**

- `pthread_self()` is cast to `unsigned long int` then printed with `%ld` (signed) — changed to `%lu`.

**copyright_year.sh / scripts/verify.sh**

- `$1` unquoted in `sed` invocation in `copyright_year.sh` — word-splits on filenames with spaces.
- `*.c *.h` glob in `scripts/verify.sh` passed without `--` separator — filenames starting with `-` would be misinterpreted as cppcheck options.