### PR TITLE
fix: correct codespell-detected spelling errors in C source

### DIFF
--- a/snmp.c
+++ b/snmp.c
@@ -413,7 +413,7 @@ void snmp_host_cleanup(void *snmp_session) {
  *	This function will poll a specific snmp OID for a host.  The host snmp
  *  session must already be established.
  *
- *  \return returns the character representaton of the snmp OID, or "U" if
+ *  \return returns the character representation of the snmp OID, or "U" if
  *  unsuccessful.
  *
  */
@@ -666,7 +666,7 @@ char *snmp_get(host_t *current_host, char *snmp_oid) {
  *	This function will poll a specific snmp OID for a host.  The host snmp
  *  session must already be established.
  *
- *  \return returns the character representaton of the snmp OID, or "U" if
+ *  \return returns the character representation of the snmp OID, or "U" if
  *  unsuccessful.
  *
  */

--- a/spine.h
+++ b/spine.h
@@ -266,7 +266,7 @@
 #define GD_MAX 5
 #define GD_DEFAULT 5
 
-/* host availability statics */
+/* host availability statistics */
 #define AVAIL_NONE 0
 #define AVAIL_SNMP_AND_PING 1
 #define AVAIL_SNMP 2


### PR DESCRIPTION
## Summary

Fix 3 spelling errors in C comments detected by automated `codespell` scan.
No logic changes.

## Corrections

| File | Line | Typo | Correction |
|------|------|------|------------|
| `snmp.c` | 416 | `representaton` | `representation` |
| `snmp.c` | 669 | `representaton` | `representation` |
| `spine.h` | 269 | `statics` | `statistics` |

## Exclusions

CHANGELOG, `config/` (autoconf-generated), `configure` (autoconf-generated),
`m4/` (libtool macros), `*.backup`/`*.bak2` (local backup files).

## Test plan

- [ ] `make` compiles cleanly — comment-only changes, no compilation impact
- [ ] `codespell` scan passes on modified files after merge

Fixes #450