### PR TITLE
feat: add .editorconfig following cacti formatting standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile*]
+indent_style = tab
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Add .editorconfig file configured to match Cacti formatting standards (Tabs, Indent Size 4, LF line endings).

## Linked issue

Fixes #463
