### PR TITLE
build: make Makefile.am more idiomatic

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,6 @@
 # +-------------------------------------------------------------------------+
 
 AUTOMAKE_OPTIONS = foreign
-ACLOCAL_AMFLAGS = -I m4
 
 spine_SOURCES = sql.c spine.c util.c snmp.c locks.c poller.c nft_popen.c php.c ping.c keywords.c error.c
 
@@ -30,8 +29,6 @@ config_DATA = spine.conf.dist
 bin_PROGRAMS = spine
 
 man_MANS = spine.1
-
-EXTRA_DIST = spine.1
 
 # Docker targets — require Dockerfile and Dockerfile.dev (from PR #401)
 .PHONY: docker docker-dev verify cppcheck


### PR DESCRIPTION
## Summary
- remove legacy `ACLOCAL_AMFLAGS = -I m4`
- remove redundant `EXTRA_DIST = spine.1` (already in `man_MANS`)

## Why
These are low-risk automake cleanups that reduce legacy/redundant config.

## Validation
- `./bootstrap`
- `./configure --with-mysql=/opt/homebrew/opt/mysql-client --with-snmp=/opt/homebrew/opt/net-snmp`
- `make -j1 V=1`
- `make check` (when available)

## Linked issue
Fixes #500