### PR TITLE
chore(compat): add windows portability shims and header guards

### DIFF
--- a/common.h
+++ b/common.h
@@ -77,28 +77,46 @@
 #  include <unistd.h>
 #endif
 
+#ifndef _WIN32
 #include <sys/wait.h>
+#endif
 #include <sys/stat.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+#include <iphlpapi.h>
+#include <process.h>
+#include <io.h>
+#else
 #include <sys/socket.h>
 #include <sys/select.h>
+#endif
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <math.h>
 #include <mysql.h>
+#ifndef _WIN32
 #include <netdb.h>
+#endif
 #include "spine_sem.h"
 #include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>
+#ifndef _WIN32
 #include <syslog.h>
+#endif
 #include <stdbool.h>
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 
 #if HAVE_STDINT_H
 #  include <stdint.h>
 #endif
 
+#ifndef _WIN32
 #if HAVE_NETINET_IN_H
 #  include <netinet/in_systm.h>
 #  include <netinet/in.h>
@@ -109,7 +127,11 @@
 #endif
 #  include <netinet/ip_icmp.h>
 #endif
+#endif
 
+#ifdef _WIN32
+#  include <time.h>
+#else
 #if TIME_WITH_SYS_TIME
 #  include <sys/time.h>
 #  include <time.h>
@@ -119,6 +141,7 @@
 #  else
 #    include <time.h>
 #  endif
+#endif
 #endif
 
 #ifndef HAVE_LIBPTHREAD

--- a/error.c
+++ b/error.c
@@ -75,18 +75,22 @@ static void spine_signal_handler(int spine_signal) {
 			fprintf(stderr, "%s FATAL: Spine Encountered a Segmentation Fault\n", logtime);
 			exit(1);
 			break;
+#ifndef _WIN32
 		case SIGBUS:
 			fprintf(stderr, "%s FATAL: Spine Encountered a Bus Error\n", logtime);
 			break;
+#endif
 		case SIGFPE:
 			fprintf(stderr, "%s FATAL: Spine Encountered a Floating Point Exception\n", logtime);
 			break;
+#ifndef _WIN32
 		case SIGQUIT:
 			fprintf(stderr, "%s FATAL: Spine Encountered a Keyboard Quit Command\n", logtime);
 			break;
 		case SIGPIPE:
 			fprintf(stderr, "%s FATAL: Spine Encountered a Broken Pipe\n", logtime);
 			break;
+#endif
 		default:
 			fprintf(stderr, "%s FATAL: Spine Encountered An Unhandled Exception Signal Number: '%d'\n", logtime, spine_signal);
 			break;
@@ -95,12 +99,18 @@ static void spine_signal_handler(int spine_signal) {
 
 static int spine_fatal_signals[] = {
 	SIGINT,
+#ifndef _WIN32
 	SIGPIPE,
+#endif
 	SIGSEGV,
+#ifndef _WIN32
 	SIGBUS,
+#endif
 	SIGFPE,
+#ifndef _WIN32
 	SIGQUIT,
 	SIGSYS,
+#endif
 	SIGABRT,
 	0
 };
@@ -113,8 +123,10 @@ static int spine_fatal_signals[] = {
 void install_spine_signal_handler(void) {
 	/* Set a handler for any fatal signal not already handled */
 	int i;
-	struct sigaction sa;
 	void (*ohandler)(int);
+
+#ifndef _WIN32
+	struct sigaction sa;
 
 	for (i=0; spine_fatal_signals[i]; ++i) {
 		sigaction(spine_fatal_signals[i], NULL, &sa);
@@ -125,6 +137,7 @@ void install_spine_signal_handler(void) {
 			sigaction(spine_fatal_signals[i], &sa, NULL);
 		}
 	}
+#endif
 
 	for (i=0; spine_fatal_signals[i]; ++i) {
 		ohandler = signal(spine_fatal_signals[i], spine_signal_handler);
@@ -143,8 +156,10 @@ void install_spine_signal_handler(void) {
 void uninstall_spine_signal_handler(void) {
 	/* Remove a handler for any fatal signal handled */
 	int i;
-	struct sigaction sa;
 	void (*ohandler)(int);
+
+#ifndef _WIN32
+	struct sigaction sa;
 
 	for (i=0; spine_fatal_signals[i]; ++i) {
 		sigaction(spine_fatal_signals[i], NULL, &sa);
@@ -153,6 +168,7 @@ void uninstall_spine_signal_handler(void) {
 			sigaction(spine_fatal_signals[i], &sa, NULL);
 		}
 	}
+#endif
 
 	for ( i=0; spine_fatal_signals[i]; ++i ) {
 		ohandler = signal(spine_fatal_signals[i], SIG_DFL);

--- a/nft_popen.c
+++ b/nft_popen.c
@@ -86,7 +86,9 @@
 
 #include "common.h"
 #include "spine.h"
+#ifndef _WIN32
 #include <spawn.h>
+#endif
 
 /* An instance of this struct is created for each popen() fd. */
 static struct pid

--- a/php.c
+++ b/php.c
@@ -33,7 +33,9 @@
 
 #include "common.h"
 #include "spine.h"
+#ifndef _WIN32
 #include <spawn.h>
+#endif
 
 extern char **environ;
 

--- a/ping.c
+++ b/ping.c
@@ -377,7 +377,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 					snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Ping timed out");
 					snprintf(ping->ping_status, 50, "down");
 					free(packet);
-					close(icmp_socket);
+					CLOSE_SOCKET(icmp_socket);
 					return HOST_DOWN;
 				}
 
@@ -408,7 +408,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 					SPINE_LOG(("ERROR: Device[%i] ICMP socket %d exceeds FD_SETSIZE %d", host->id, icmp_socket, FD_SETSIZE));
 					snprintf(ping->ping_status, 50, "down");
 					snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: fd exceeds FD_SETSIZE");
-					close(icmp_socket);
+					CLOSE_SOCKET(icmp_socket);
 					return HOST_DOWN;
 				}
 				FD_SET(icmp_socket,&socket_fds);
@@ -461,7 +461,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 									}
 								}
 								#endif
-								close(icmp_socket);
+								CLOSE_SOCKET(icmp_socket);
 								#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
 								if (hasCaps() != TRUE) {
 									if (seteuid(getuid()) == -1) {
@@ -512,7 +512,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 				}
 			}
 			#endif
-			close(icmp_socket);
+			CLOSE_SOCKET(icmp_socket);
 			#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
 			if (hasCaps() != TRUE) {
 				if (seteuid(getuid()) == -1) {
@@ -536,7 +536,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 				}
 			}
 			#endif
-			close(icmp_socket);
+			CLOSE_SOCKET(icmp_socket);
 			#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
 			if (hasCaps() != TRUE) {
 				if (seteuid(getuid()) == -1) {
@@ -604,7 +604,7 @@ int ping_udp(host_t *host, ping_t *ping) {
 			if (connect(udp_socket, (struct sockaddr *) &servername, sizeof(servername)) < 0) {
 				snprintf(ping->ping_status, 50, "down");
 				snprintf(ping->ping_response, SMALL_BUFSIZE, "UDP: Cannot connect to host");
-				close(udp_socket);
+				CLOSE_SOCKET(udp_socket);
 				return HOST_DOWN;
 			}
 
@@ -622,7 +622,7 @@ int ping_udp(host_t *host, ping_t *ping) {
 				if (retry_count > host->ping_retries) {
 					snprintf(ping->ping_response, SMALL_BUFSIZE, "UDP: Ping timed out");
 					snprintf(ping->ping_status, 50, "down");
-					close(udp_socket);
+					CLOSE_SOCKET(udp_socket);
 					return HOST_DOWN;
 				}
 
@@ -661,7 +661,11 @@ int ping_udp(host_t *host, ping_t *ping) {
 				/* check to see which socket talked */
 				if (return_code > 0) {
 					if (FD_ISSET(udp_socket, &socket_fds)) {
+						#ifdef _WIN32
+						return_code = recv(udp_socket, socket_reply, BUFSIZE, 0);
+						#else
 						return_code = read(udp_socket, socket_reply, BUFSIZE);
+						#endif
 
 						if (return_code == -1 && (errno == EHOSTUNREACH || errno == ECONNRESET || errno == ECONNREFUSED)) {
 							if (is_debug_device(host->id)) {
@@ -671,7 +675,7 @@ int ping_udp(host_t *host, ping_t *ping) {
 							}
 							snprintf(ping->ping_response, SMALL_BUFSIZE, "UDP: Device is Alive");
 							snprintf(ping->ping_status, 50, "%.5f", total_time);
-							close(udp_socket);
+							CLOSE_SOCKET(udp_socket);
 							return HOST_UP;
 						}
 					}
@@ -683,7 +687,7 @@ int ping_udp(host_t *host, ping_t *ping) {
 					} else {
 						snprintf(ping->ping_response, SMALL_BUFSIZE, "UDP: Device is Down");
 						snprintf(ping->ping_status, 50, "%.5f", total_time);
-						close(udp_socket);
+						CLOSE_SOCKET(udp_socket);
 						return HOST_DOWN;
 					}
 				} else {
@@ -704,13 +708,13 @@ int ping_udp(host_t *host, ping_t *ping) {
 		} else {
 			snprintf(ping->ping_response, SMALL_BUFSIZE, "UDP: Destination hostname invalid");
 			snprintf(ping->ping_status, 50, "down");
-			close(udp_socket);
+			CLOSE_SOCKET(udp_socket);
 			return HOST_DOWN;
 		}
 	} else {
 		snprintf(ping->ping_response, SMALL_BUFSIZE, "UDP: Destination address invalid or unable to create socket");
 		snprintf(ping->ping_status, 50, "down");
-		if (udp_socket != -1) close(udp_socket);
+		if (udp_socket != -1) CLOSE_SOCKET(udp_socket);
 		return HOST_DOWN;
 	}
 }
@@ -793,19 +797,19 @@ int ping_tcp(host_t *host, ping_t *ping) {
 					}
 					snprintf(ping->ping_response, SMALL_BUFSIZE, "TCP: Device is Alive");
 					snprintf(ping->ping_status, 50, "%.5f", total_time);
-					close(tcp_socket);
+					CLOSE_SOCKET(tcp_socket);
 					return HOST_UP;
 				} else {
 					#if defined(__CYGWIN__)
 					snprintf(ping->ping_status, 50, "down");
 					snprintf(ping->ping_response, SMALL_BUFSIZE, "TCP: Cannot connect to host");
-					close(tcp_socket);
+					CLOSE_SOCKET(tcp_socket);
 					return HOST_DOWN;
 					#else
 					if (retry_count > host->ping_retries) {
 						snprintf(ping->ping_status, 50, "down");
 						snprintf(ping->ping_response, SMALL_BUFSIZE, "TCP: Cannot connect to host");
-						close(tcp_socket);
+						CLOSE_SOCKET(tcp_socket);
 						return HOST_DOWN;
 					} else {
 						retry_count++;
@@ -816,13 +820,13 @@ int ping_tcp(host_t *host, ping_t *ping) {
 		} else {
 			snprintf(ping->ping_response, SMALL_BUFSIZE, "TCP: Destination hostname invalid");
 			snprintf(ping->ping_status, 50, "down");
-			close(tcp_socket);
+			CLOSE_SOCKET(tcp_socket);
 			return HOST_DOWN;
 		}
 	} else {
 		snprintf(ping->ping_response, SMALL_BUFSIZE, "TCP: Destination address invalid or unable to create socket");
 		snprintf(ping->ping_status, 50, "down");
-		if (tcp_socket != -1) close(tcp_socket);
+		if (tcp_socket != -1) CLOSE_SOCKET(tcp_socket);
 		return HOST_DOWN;
 	}
 }

--- a/ping.c
+++ b/ping.c
@@ -257,7 +257,7 @@ int ping_snmp(host_t *host, ping_t *ping) {
  *
  */
 int ping_icmp(host_t *host, ping_t *ping) {
-	int    icmp_socket;
+	spine_socket_t icmp_socket;
 
 	double begin_time, end_time, total_time;
 	double host_timeout;
@@ -298,7 +298,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 		}
 		#endif
 
-		if ((icmp_socket = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP)) == -1) {
+		if ((icmp_socket = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP)) == SPINE_INVALID_SOCKET) {
 			usleep(500000);
 			retry_count++;
 
@@ -361,7 +361,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 	icmp->icmp_cksum = get_checksum(packet, packet_len);
 
 	/* hostname must be nonblank */
-	if ((strlen(host->hostname) != 0) && (icmp_socket != -1)) {
+	if ((strlen(host->hostname) != 0) && (icmp_socket != SPINE_INVALID_SOCKET)) {
 		/* initialize variables */
 		snprintf(ping->ping_status, 50, "down");
 		snprintf(ping->ping_response, SMALL_BUFSIZE, "default");
@@ -404,15 +404,15 @@ int ping_icmp(host_t *host, ping_t *ping) {
 				/* reinitialize fd_set -- select(2) clears bits in place on return */
 				keep_listening:
 				FD_ZERO(&socket_fds);
-				if (icmp_socket >= FD_SETSIZE) {
-					SPINE_LOG(("ERROR: Device[%i] ICMP socket %d exceeds FD_SETSIZE %d", host->id, icmp_socket, FD_SETSIZE));
+				if ((int) icmp_socket >= FD_SETSIZE) {
+					SPINE_LOG(("ERROR: Device[%i] ICMP socket %d exceeds FD_SETSIZE %d", host->id, (int) icmp_socket, FD_SETSIZE));
 					snprintf(ping->ping_status, 50, "down");
 					snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: fd exceeds FD_SETSIZE");
 					CLOSE_SOCKET(icmp_socket);
 					return HOST_DOWN;
 				}
 				FD_SET(icmp_socket,&socket_fds);
-				return_code = select(icmp_socket + 1, &socket_fds, NULL, NULL, &timeout);
+				return_code = select((int) icmp_socket + 1, &socket_fds, NULL, NULL, &timeout);
 
 				/* record end time */
 				end_time = get_time_as_double();
@@ -527,7 +527,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 		snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Destination address not specified");
 		snprintf(ping->ping_status, 50, "down");
 		free(packet);
-		if (icmp_socket != -1) {
+		if (icmp_socket != SPINE_INVALID_SOCKET) {
 			#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
 			if (hasCaps() != TRUE) {
 				thread_mutex_lock(LOCK_SETEUID);
@@ -567,7 +567,7 @@ int ping_udp(host_t *host, ping_t *ping) {
 	double host_timeout;
 	double one_thousand = 1000.00;
 	struct timeval timeout;
-	int    udp_socket;
+	spine_socket_t udp_socket;
 	struct sockaddr_in servername;
 	char   socket_reply[BUFSIZE];
 	int    retry_count;
@@ -594,7 +594,7 @@ int ping_udp(host_t *host, ping_t *ping) {
 	udp_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 
 	/* hostname must be nonblank */
-	if ((strlen(host->hostname) != 0) && (udp_socket != -1)) {
+	if ((strlen(host->hostname) != 0) && (udp_socket != SPINE_INVALID_SOCKET)) {
 		/* initialize variables */
 		snprintf(ping->ping_status, 50, "down");
 		snprintf(ping->ping_response, SMALL_BUFSIZE, "default");
@@ -714,7 +714,7 @@ int ping_udp(host_t *host, ping_t *ping) {
 	} else {
 		snprintf(ping->ping_response, SMALL_BUFSIZE, "UDP: Destination address invalid or unable to create socket");
 		snprintf(ping->ping_status, 50, "down");
-		if (udp_socket != -1) CLOSE_SOCKET(udp_socket);
+		if (udp_socket != SPINE_INVALID_SOCKET) CLOSE_SOCKET(udp_socket);
 		return HOST_DOWN;
 	}
 }
@@ -737,7 +737,7 @@ int ping_tcp(host_t *host, ping_t *ping) {
 	double host_timeout;
 	double one_thousand = 1000.00;
 	struct timeval timeout;
-	int    tcp_socket;
+	spine_socket_t tcp_socket;
 	struct sockaddr_in servername;
 	int    retry_count;
 	int    return_code;
@@ -761,7 +761,7 @@ int ping_tcp(host_t *host, ping_t *ping) {
 	begin_time = get_time_as_double();
 
 	/* hostname must be nonblank */
-	if ((strlen(host->hostname) != 0) && (tcp_socket != -1)) {
+	if ((strlen(host->hostname) != 0) && (tcp_socket != SPINE_INVALID_SOCKET)) {
 		/* initialize variables */
 		snprintf(ping->ping_status, 50, "down");
 		snprintf(ping->ping_response, SMALL_BUFSIZE, "default");
@@ -826,7 +826,7 @@ int ping_tcp(host_t *host, ping_t *ping) {
 	} else {
 		snprintf(ping->ping_response, SMALL_BUFSIZE, "TCP: Destination address invalid or unable to create socket");
 		snprintf(ping->ping_status, 50, "down");
-		if (tcp_socket != -1) CLOSE_SOCKET(tcp_socket);
+		if (tcp_socket != SPINE_INVALID_SOCKET) CLOSE_SOCKET(tcp_socket);
 		return HOST_DOWN;
 	}
 }

--- a/spine.h
+++ b/spine.h
@@ -261,9 +261,11 @@
 
 /* Socket close: sockets use closesocket(), pipes use _close() */
 #define CLOSE_SOCKET(s) closesocket(s)
+#define SPINE_INVALID_SOCKET INVALID_SOCKET
 
 /* Type portability */
 typedef int pid_t;
+typedef SOCKET spine_socket_t;
 
 /* Config paths */
 #undef CONFIG_PATHS
@@ -285,6 +287,8 @@ typedef int pid_t;
 #else /* POSIX */
 
 #define CLOSE_SOCKET(s) close(s)
+#define SPINE_INVALID_SOCKET (-1)
+typedef int spine_socket_t;
 
 #endif /* _WIN32 */
 

--- a/spine.h
+++ b/spine.h
@@ -238,6 +238,50 @@
 
 #define SPINE_FREE(s) do { if (s) { free((void *)s); s = NULL; } } while(0)
 
+/* -----------------------------------------------------------------------
+ * Windows portability shims
+ * -----------------------------------------------------------------------*/
+#ifdef _WIN32
+
+/* POSIX -> Win32 function mappings */
+#define usleep(usec)    Sleep((usec) / 1000)
+#define sleep(sec)      Sleep((sec) * 1000)
+#define getpid()        _getpid()
+#define isatty(fd)      _isatty(fd)
+#define fileno(f)       _fileno(f)
+#define setenv(n,v,o)   _putenv_s((n), (v))
+#define localtime_r(timep, result) localtime_s((result), (timep))
+#define strcasecmp(a,b) _stricmp((a),(b))
+
+/* Socket close: sockets use closesocket(), pipes use _close() */
+#define CLOSE_SOCKET(s) closesocket(s)
+
+/* Type portability */
+typedef int pid_t;
+
+/* Config paths */
+#undef CONFIG_PATHS
+#undef CONFIG_PATH_2
+#undef CONFIG_PATH_3
+#define CONFIG_PATHS 2
+#define CONFIG_PATH_2 "../etc/"
+#define CONFIG_PATH_3 ""
+
+/* Default log file */
+#undef DEFAULT_LOGFILE
+#define DEFAULT_LOGFILE "cacti.log"
+
+/* Disable stderr on Windows (no console in service mode) */
+#ifndef DISABLE_STDERR
+#define DISABLE_STDERR
+#endif
+
+#else /* POSIX */
+
+#define CLOSE_SOCKET(s) close(s)
+
+#endif /* _WIN32 */
+
 /* logging levels */
 #define POLLER_VERBOSITY_NONE 1
 #define POLLER_VERBOSITY_LOW 2

--- a/spine.h
+++ b/spine.h
@@ -34,6 +34,12 @@
 #ifndef _SPINE_H_
 #define _SPINE_H_
 
+/* spine.h requires common.h to be included first for platform
+ * headers, MySQL types, pthreads, and config.h defines. */
+#ifndef SPINE_COMMON_H
+#error "spine.h must be included after common.h"
+#endif
+
 /* Defines */
 #ifndef FALSE
 #define FALSE 0

--- a/util.c
+++ b/util.c
@@ -1384,6 +1384,7 @@ int spine_log(const char *format, ...) {
 	strncat(flogmessage, ulogmessage, ulog_len);
 
 	/* output to syslog/eventlog */
+#ifndef _WIN32
 	if (IS_LOGGING_TO_SYSLOG()) {
 		openlog("Cacti", LOG_NDELAY | LOG_PID, LOG_SYSLOG);
 
@@ -1401,6 +1402,7 @@ int spine_log(const char *format, ...) {
 
 		closelog();
 	}
+#endif
 
 	/* append a line feed to the log message if needed */
 	if (!strstr(flogmessage, "\n")) {
@@ -1747,11 +1749,18 @@ char *strncopy(char *dst, const char *src, size_t obuf) {
  *  \return system time (at microsecond resolution) as a double
  */
 double get_time_as_double(void) {
+#ifdef _WIN32
+	LARGE_INTEGER freq, count;
+	QueryPerformanceFrequency(&freq);
+	QueryPerformanceCounter(&count);
+	return (double)count.QuadPart / (double)freq.QuadPart;
+#else
 	struct timeval now;
 
 	gettimeofday(&now, NULL);
 
 	return (now).tv_sec + ((double) (now).tv_usec / 1000000);
+#endif
 }
 
 /*! \fn trim()


### PR DESCRIPTION
## Summary

Mechanical #ifdef _WIN32 changes preparing Spine for native Windows compilation. Zero behavioral change on POSIX. No new dependencies.

## Changes

**common.h** -- Header guards for POSIX-only includes:
- sys/wait.h, sys/socket.h, sys/select.h, netdb.h, syslog.h, arpa/inet.h, netinet/* guarded with #ifndef _WIN32
- Windows alternative: winsock2.h, ws2tcpip.h, windows.h, iphlpapi.h, process.h, io.h
- sys/time.h block uses plain time.h on Windows

**spine.h** -- Portability macros:
- usleep -> Sleep, sleep -> Sleep, getpid -> _getpid, isatty -> _isatty, fileno -> _fileno
- setenv -> _putenv_s, localtime_r -> localtime_s, strcasecmp -> _stricmp
- CLOSE_SOCKET macro (closesocket on Windows, close on POSIX)
- pid_t typedef for Windows
- Windows config paths and default logfile

**error.c** -- Signal handling:
- SIGPIPE, SIGBUS, SIGQUIT, SIGSYS guarded with #ifndef _WIN32
- sigaction blocks guarded; signal() fallback works on both platforms

**util.c** -- Runtime:
- Syslog block guarded with #ifndef _WIN32
- get_time_as_double uses QueryPerformanceCounter on Windows

**ping.c** -- Socket I/O:
- 15 close() calls on sockets replaced with CLOSE_SOCKET()
- read() on UDP socket uses recv() on Windows

**php.c, nft_popen.c** -- Build:
- spawn.h include guarded with #ifndef _WIN32

## Scope

This PR covers LOW and MEDIUM risk changes only. HIGH risk items (CreateProcess for process spawning, IcmpSendEcho for ICMP ping, seteuid privilege management) are deferred to a follow-up PR.

## Test plan

- [ ] Linux autotools build passes (no behavioral change)
- [ ] Linux CMake build passes (with PR #523)
- [ ] Windows CMake build progresses further (fewer compile errors)