### PR TITLE
fix(cli): save --mode argument before comparing to avoid argv advance

### DIFF
--- a/spine.c
+++ b/spine.c
@@ -373,14 +373,15 @@ int main(int argc, char *argv[]) {
 		}
 
 		else if (STRMATCH(arg, "-N") || STRIMATCH(arg, "--mode")) {
-			if (STRIMATCH(getarg(opt, &argv), "online")) {
+			const char *mode_arg = getarg(opt, &argv);
+			if (STRIMATCH(mode_arg, "online")) {
 				set.mode = REMOTE_ONLINE;
-			} else if (STRIMATCH(getarg(opt, &argv), "offline")) {
+			} else if (STRIMATCH(mode_arg, "offline")) {
 				set.mode = REMOTE_OFFLINE;
-			} else if (STRIMATCH(getarg(opt, &argv), "recovery")) {
+			} else if (STRIMATCH(mode_arg, "recovery")) {
 				set.mode = REMOTE_RECOVERY;
 			} else {
-				die("ERROR: invalid polling mode '%s' specified", opt);
+				die("ERROR: invalid polling mode '%s' specified", mode_arg);
 			}
 		}
 


### PR DESCRIPTION
getarg(opt, &argv) advances the argv pointer on each call. Three successive calls in the --mode handler consumed three argv entries instead of one, corrupting subsequent argument parsing when using the space-separated form (--mode online).