### PR TITLE
fix(cli): check strchr return for NULL before dereference in -O handler

### DIFF
--- a/spine.c
+++ b/spine.c
@@ -419,7 +419,7 @@ int main(int argc, char *argv[]) {
 			char *setting = getarg(opt, &argv);
 			char *value   = strchr(setting, ':');
 
-			if (*value) {
+			if (value != NULL && *value) {
 				*value++ = '\0';
 			} else {
 				die("ERROR: -O requires setting:value");


### PR DESCRIPTION
When -O is passed without a colon separator, strchr returns NULL. The next line dereferences it unconditionally, causing a segfault. Add NULL check before dereference.