### PR TITLE
fix(php): use RESULTS_BUFFER instead of BUFSIZE for readpipe boundary check

### DIFF
--- a/php.c
+++ b/php.c
@@ -272,7 +272,7 @@ char *php_readpipe(int php_process, char *command) {
 					break;
 				}
 
-				if (bptr >= result_string+BUFSIZE) {
+				if (bptr >= result_string+RESULTS_BUFFER) {
 					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
 					SET_UNDEFINED(result_string);
 				}


### PR DESCRIPTION
result_string is allocated as RESULTS_BUFFER (2048) but the overflow check compared against BUFSIZE (1024). Script server responses between 1024-2048 bytes were incorrectly truncated to 'U'.