### PR TITLE
fix(db): correct inverted return value in putsetting

### DIFF
--- a/util.c
+++ b/util.c
@@ -149,11 +149,7 @@ static int putsetting(MYSQL *psql, int mode, const char *mysetting, const char *
 
 	result = db_insert(psql, mode, qstring);
 
-	if (result == 0) {
-		return TRUE;
-	} else {
-		return FALSE;
-	}
+	return result;
 }
 
 /*! \fn static char *getpsetting(MYSQL *psql, const char *setting)


### PR DESCRIPTION
db_insert returns TRUE on success and FALSE on failure. putsetting checked 'result == 0' and returned TRUE, inverting the semantics. Callers received success on insert failure.