### PR TITLE
fix(net): use fd+1 instead of FD_SETSIZE in select() calls

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -650,7 +650,7 @@ int ping_udp(host_t *host, ping_t *ping) {
 
 				/* wait for a response on the socket */
 				wait_more:
-				return_code = select(FD_SETSIZE, &socket_fds, NULL, NULL, &timeout);
+				return_code = select(udp_socket + 1, &socket_fds, NULL, NULL, &timeout);
 
 				/* record end time */
 				end_time = get_time_as_double();

--- a/poller.c
+++ b/poller.c
@@ -2398,7 +2398,7 @@ char *exec_poll(host_t *current_host, char *command, int id, const char *type) {
 				FD_SET(cmd_fd, &fds);
 
 				/* wait x seconds for pipe response */
-				switch (select(FD_SETSIZE, &fds, NULL, NULL, &timeout)) {
+				switch (select(cmd_fd + 1, &fds, NULL, NULL, &timeout)) {
 					case -1:
 						switch (errno) {
 							case EBADF:


### PR DESCRIPTION
select() first argument should be the highest fd + 1, not FD_SETSIZE. Passing FD_SETSIZE scans up to 1024 fds unnecessarily. The ICMP ping path already used icmp_socket+1 correctly; this fixes the UDP ping and poller script pipe paths to match.