### PR TITLE
fix(poller): add NULL check after db_get_connection at poll entry

### DIFF
--- a/poller.c
+++ b/poller.c
@@ -231,12 +231,21 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
-	//db_connect(LOCAL, &mysql);
+	/* db_get_connection can return NULL after a connection pool error */
 	local_cnn = db_get_connection(LOCAL);
+	if (local_cnn == NULL) {
+		SPINE_LOG(("FATAL: Unable to obtain local database connection in poller"));
+		return;
+	}
 	mysql = local_cnn->mysql;
 
 	if (set.poller_id > 1 && set.mode == REMOTE_ONLINE) {
 		remote_cnn = db_get_connection(REMOTE);
+		if (remote_cnn == NULL) {
+			SPINE_LOG(("FATAL: Unable to obtain remote database connection in poller"));
+			db_release_connection(LOCAL, local_cnn);
+			return;
+		}
 		mysqlr = remote_cnn->mysql;
 	}
 


### PR DESCRIPTION
Follow-up to #531 which fixed the same NULL-dereference pattern at a different call site in poller.c.

## Problem

`db_get_connection(LOCAL)` at poller.c:235 can return NULL after a connection pool error (sql.c:525). The code immediately dereferences `local_cnn->mysql` without checking, causing a segfault when the pool is exhausted or the database is unreachable.

The same pattern exists for the `db_get_connection(REMOTE)` call at line 239.

## Fix

Add NULL checks for both LOCAL and REMOTE connections before dereferencing. On LOCAL failure, return immediately. On REMOTE failure, release the LOCAL connection before returning to avoid a pool leak.

Identified during code review of the spine PR batch (#525-#532).