### PR TITLE
harden: validate ICMP reply identity and use _exit in fatal handler

### DIFF
--- a/error.c
+++ b/error.c
@@ -73,7 +73,7 @@ static void spine_signal_handler(int spine_signal) {
 			break;
 		case SIGSEGV:
 			fprintf(stderr, "%s FATAL: Spine Encountered a Segmentation Fault\n", logtime);
-			exit(1);
+			_exit(1);
 			break;
 		case SIGBUS:
 			fprintf(stderr, "%s FATAL: Spine Encountered a Bus Error\n", logtime);

--- a/php.c
+++ b/php.c
@@ -34,6 +34,7 @@
 #include "common.h"
 #include "spine.h"
 #include <spawn.h>
+#include <sys/wait.h>
 
 extern char **environ;
 
@@ -258,7 +259,16 @@ char *php_readpipe(int php_process, char *command) {
 			bptr = result_string;
 
 			while (1) {
-				i = read(php_processes[php_process].php_read_fd, bptr, RESULTS_BUFFER-(bptr-result_string));
+				/* reserve one byte for the trailing '\0' written below */
+				int space = RESULTS_BUFFER - 1 - (int)(bptr - result_string);
+
+				if (space <= 0) {
+					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
+					SET_UNDEFINED(result_string);
+					break;
+				}
+
+				i = read(php_processes[php_process].php_read_fd, bptr, space);
 
 				if (i <= 0) {
 					SET_UNDEFINED(result_string);
@@ -272,9 +282,10 @@ char *php_readpipe(int php_process, char *command) {
 					break;
 				}
 
-				if (bptr >= result_string+BUFSIZE) {
+				if (bptr >= result_string + RESULTS_BUFFER - 1) {
 					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
 					SET_UNDEFINED(result_string);
+					break;
 				}
 			}
 		} else {
@@ -569,10 +580,17 @@ void php_close(int php_process) {
 	 	 * a process group leader), and PID 1 is "init".
 	  	 */
 		if (phpp->php_pid > 1) {
+			int status;
+
 			/* end the php script server process */
 			kill(phpp->php_pid, SIGTERM);
 
-			/* reset this PID variable? */
+			/* reap the child so it does not linger as a zombie */
+			while (waitpid(phpp->php_pid, &status, 0) < 0 && errno == EINTR) {
+				;
+			}
+
+			phpp->php_pid = -1;
 		}
 
 		/* close file descriptors */

--- a/ping.c
+++ b/ping.c
@@ -440,8 +440,22 @@ int ping_icmp(host_t *host, ping_t *ping) {
 							goto keep_listening;
 						}
 					} else {
+						int ihl;
+
+						/* the reply must be large enough to hold the IP header */
+						if (return_code < (ssize_t)sizeof(struct ip)) {
+							goto keep_listening;
+						}
+
 						ip  = (struct ip *) socket_reply;
-						pkt = (struct icmp *) (socket_reply + (ip->ip_hl << 2));
+						ihl = ip->ip_hl << 2;
+
+						/* and large enough to hold that header plus the ICMP header */
+						if (ihl < (int)sizeof(struct ip) || return_code < (ssize_t)(ihl + ICMP_HDR_SIZE)) {
+							goto keep_listening;
+						}
+
+						pkt = (struct icmp *) (socket_reply + ihl);
 
 						if (fromname.sin_addr.s_addr == recvname.sin_addr.s_addr) {
 							if (pkt->icmp_type == ICMP_ECHOREPLY) {

--- a/ping.c
+++ b/ping.c
@@ -1028,10 +1028,10 @@ name_t *get_namebyhost(char *hostname, name_t *name) {
 				strncpy(name->hostname, hostname, sizeof(name->hostname));
 				break;
 			} else if (strlen(token) == 3) {
-				if (strncasecmp(token, "TCP", 3)) {
+				if (strncasecmp(token, "TCP", 3) == 0) {
 					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Have TCPv4 method", hostname));
 					name->method = 1;
-				} else if (strncasecmp(hostname, "UDP", 3)) {
+				} else if (strncasecmp(token, "UDP", 3) == 0) {
 					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Have UDPv4 method", hostname));
 					name->method = 2;
 				} else {
@@ -1040,10 +1040,10 @@ name_t *get_namebyhost(char *hostname, name_t *name) {
 					tokens++;
 				}
 			} else if (strlen(token) == 4) {
-				if (strncasecmp(token, "TCP6", 3)) {
+				if (strncasecmp(token, "TCP6", 4) == 0) {
 					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Have TCPv6 method", hostname));
 					name->method = 3;
-				} else if (strncasecmp(hostname, "UDP6", 3)) {
+				} else if (strncasecmp(token, "UDP6", 4) == 0) {
 					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Have UDPv6 method", hostname));
 					name->method = 4;
 				} else {

--- a/ping.c
+++ b/ping.c
@@ -459,6 +459,13 @@ int ping_icmp(host_t *host, ping_t *ping) {
 
 						if (fromname.sin_addr.s_addr == recvname.sin_addr.s_addr) {
 							if (pkt->icmp_type == ICMP_ECHOREPLY) {
+								/* the raw socket is shared, so verify this echo reply
+								 * carries our id and the sequence we just sent before
+								 * treating the device as alive */
+								if (pkt->icmp_id != (getpid() & 0xFFFF) || pkt->icmp_seq != icmp->icmp_seq) {
+									goto keep_listening;
+								}
+
 								if (is_debug_device(host->id)) {
 									SPINE_LOG(("Device[%i] INFO: ICMP Device Alive, Try Count:%i, Time:%.4f ms", host->id, retry_count+1, (total_time)));
 								} else {

--- a/poller.c
+++ b/poller.c
@@ -2343,7 +2343,7 @@ char *exec_poll(host_t *current_host, char *command, int id, const char *type) {
 		sem_err = spine_sem_trywait(&available_scripts);
 		if (sem_err == 0) {
 			break;
-		} else if (sem_err == EAGAIN || sem_err == EWOULDBLOCK) {
+		} else if (errno == EAGAIN || errno == EWOULDBLOCK) {
 			if (is_debug_device(current_host->id)) {
 				SPINE_LOG(("DEBUG: Device[%i]: Pausing as unable to obtain a script execution lock", current_host->id));
 			} else {
@@ -2351,9 +2351,9 @@ char *exec_poll(host_t *current_host, char *command, int id, const char *type) {
 			}
 		} else {
 			if (is_debug_device(current_host->id)) {
-				SPINE_LOG(("DEBUG: Device[%i]: Pausing as error %d whilst obtaining a script execution lock", current_host->id, sem_err));
+				SPINE_LOG(("DEBUG: Device[%i]: Pausing as error %d whilst obtaining a script execution lock", current_host->id, errno));
 			} else {
-				SPINE_LOG_DEVDBG(("DEBUG: Device[%i]: Pausing as error %d whilst obtaining a script execution lock", current_host->id, sem_err));
+				SPINE_LOG_DEVDBG(("DEBUG: Device[%i]: Pausing as error %d whilst obtaining a script execution lock", current_host->id, errno));
 			}
 		}
 		usleep(10000);

--- a/poller.c
+++ b/poller.c
@@ -218,9 +218,15 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 	target_t    *poller_items = NULL;
 	snmp_oids_t *snmp_oids = NULL;
 
-	error_string = malloc(DBL_BUFSIZE);
-	buf_size     = malloc(sizeof(int));
-	buf_errors   = malloc(sizeof(int));
+	if (!(error_string = malloc(DBL_BUFSIZE))) {
+		die("ERROR: Fatal malloc error: poller.c error_string!");
+	}
+	if (!(buf_size = malloc(sizeof(int)))) {
+		die("ERROR: Fatal malloc error: poller.c buf_size!");
+	}
+	if (!(buf_errors = malloc(sizeof(int)))) {
+		die("ERROR: Fatal malloc error: poller.c buf_errors!");
+	}
 
 	*buf_size     = 0;
 	*buf_errors   = 0;
@@ -1279,7 +1285,9 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 
 	if (num_rows > 0) {
 		/* retrieve each hosts polling items from poller cache and load into array */
-		poller_items = (target_t *) calloc(num_rows, sizeof(target_t));
+		if (!(poller_items = (target_t *) calloc(num_rows, sizeof(target_t)))) {
+			die("ERROR: Fatal malloc error: poller.c poller_items!");
+		}
 
 		i = 0;
 		while ((row = mysql_fetch_row(result))) {
@@ -1353,7 +1361,9 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 		db_free_result(result);
 
 		/* create an array for snmp oids */
-		snmp_oids = (snmp_oids_t *) calloc(host->max_oids, sizeof(snmp_oids_t));
+		if (!(snmp_oids = (snmp_oids_t *) calloc(host->max_oids, sizeof(snmp_oids_t)))) {
+			die("ERROR: Fatal malloc error: poller.c snmp_oids!");
+		}
 
 		/* initialize all the memory to insure we don't get issues */
 		memset(snmp_oids, 0, sizeof(snmp_oids_t)*host->max_oids);

--- a/snmp.c
+++ b/snmp.c
@@ -889,7 +889,11 @@ int snmp_count(host_t *current_host, const char *snmp_oid) {
 			//SPINE_LOG_DEBUG(("TRACE: Status %i Response %i", status, response->errstat));
 
 			if (status == STAT_SUCCESS) {
-				if (response->errstat == SNMP_ERR_NOERROR) {
+				if (response == NULL) {
+					SPINE_LOG(("ERROR: An internal Net-Snmp error condition detected in Cacti snmp_count"));
+					ok = 0;
+					error_occurred = 1;
+				} else if (response->errstat == SNMP_ERR_NOERROR) {
 					/* check resulting variables */
 					for (vars = response->variables; vars; vars	= vars->next_variable) {
 						if ((vars->name_length < rootlen) || (memcmp(root, vars->name, rootlen * sizeof(oid)) != 0)) {

--- a/spine.c
+++ b/spine.c
@@ -419,10 +419,10 @@ int main(int argc, char *argv[]) {
 			char *setting = getarg(opt, &argv);
 			char *value   = strchr(setting, ':');
 
-			if (*value) {
-				*value++ = '\0';
-			} else {
+			if (value == NULL) {
 				die("ERROR: -O requires setting:value");
+			} else {
+				*value++ = '\0';
 			}
 
 			set_option(setting, value);
@@ -766,6 +766,12 @@ int main(int argc, char *argv[]) {
 
 		if (change_host) {
 			mysql_row       = mysql_fetch_row(result);
+
+			if (mysql_row == NULL) {
+				/* fewer device rows than expected; stop processing */
+				break;
+			}
+
 			host_id         = atoi(mysql_row[0]);
 			device_threads  = atoi(mysql_row[1]);
 			current_thread  = 1;
@@ -788,7 +794,12 @@ int main(int argc, char *argv[]) {
 			tresult   = db_query(&mysql, LOCAL, querybuf);
 			mysql_row = mysql_fetch_row(tresult);
 
-			total_items = atoi(mysql_row[0]);
+			if (mysql_row == NULL) {
+				total_items = 0;
+			} else {
+				total_items = atoi(mysql_row[0]);
+			}
+
 			db_free_result(tresult);
 
 			if (total_items && total_items < device_threads) {
@@ -812,7 +823,11 @@ int main(int argc, char *argv[]) {
 				tresult   = db_query(&mysql, LOCAL, querybuf);
 				mysql_row = mysql_fetch_row(tresult);
 
-				items_per_thread = atoi(mysql_row[0]);
+				if (mysql_row == NULL) {
+					items_per_thread = 0;
+				} else {
+					items_per_thread = atoi(mysql_row[0]);
+				}
 
 				db_free_result(tresult);
 
@@ -827,7 +842,11 @@ int main(int argc, char *argv[]) {
 			tresult   = db_query(&mysql, LOCAL, querybuf);
 			mysql_row = mysql_fetch_row(tresult);
 
-			items_per_thread = atoi(mysql_row[0]);
+			if (mysql_row == NULL) {
+				items_per_thread = 0;
+			} else {
+				items_per_thread = atoi(mysql_row[0]);
+			}
 
 			db_free_result(tresult);
 

--- a/spine.c
+++ b/spine.c
@@ -928,16 +928,10 @@ int main(int argc, char *argv[]) {
 			sem_err = spine_sem_trywait(&thread_init_sem);
 
 			if (sem_err == 0) {
-				// Acquired a thread
+				/* acquired the thread init lock */
 				break;
-			} else if (sem_err == EINTR) {
-				// Interrupted by signal handler
-			} else if (sem_err == EDEADLK) {
-				SPINE_LOG_DEVDBG(("WARNING: Device[%i] HT[%i] would have deadlocked acquiring Thread Initialization Lock", host_id, current_thread));
-			} else if (sem_err == EAGAIN) {
-				// Keep trying
-			} else {
-				SPINE_LOG_DEVDBG(("WARNING: Device[%i] HT[%i] errored with %d while acquiring Thread Initialization Lock", host_id, current_thread, sem_err));
+			} else if (errno != EAGAIN) {
+				SPINE_LOG_DEVDBG(("WARNING: Device[%i] HT[%i] errored with %d while acquiring Thread Initialization Lock", host_id, current_thread, errno));
 			}
 
 			if (loop_count == 10) {
@@ -982,7 +976,8 @@ int main(int argc, char *argv[]) {
 				spine_sem_getvalue(&available_threads, &a_threads_value);
 				SPINE_LOG_HIGH(("DEBUG: Device[%i] Available Threads is %i (%i outstanding)", poller_details->host_id, a_threads_value, set.threads - a_threads_value));
 
-				spine_sem_post(&thread_init_sem);
+				/* the child releases thread_init_sem once it has copied poller_details
+				 * and dropped LOCK_HOST_TIME; posting here too double-counts the semaphore */
 
 				SPINE_LOG_DEVDBG(("DEBUG: DTS: device = %d, host_id = %d, host_thread = %d,"
 					" host_threads = %d, host_data_ids = %d, complete = %d",

--- a/util.c
+++ b/util.c
@@ -60,6 +60,10 @@ static struct {
  *
  */
 void set_option(const char *option, const char *value) {
+	if (nopts >= (int)(sizeof(opttable) / sizeof(opttable[0]))) {
+		die("ERROR: too many --option overrides");
+	}
+
 	opttable[nopts  ].opt = option;
 	opttable[nopts++].val = value;
 }
@@ -346,6 +350,8 @@ void read_config_options(void) {
 	char       spine_priv[BUFSIZE];
 	char       spine_auth[BUFSIZE];
 	char       spine_capabilities[BUFSIZE];
+
+	web_root[0] = '\0';
 
 	/* publish spine snmpv3 capabilities to the database */
 	memset(spine_capabilities, 0, sizeof(spine_capabilities));

--- a/util.c
+++ b/util.c
@@ -427,13 +427,13 @@ void read_config_options(void) {
 		}
 	}
 
-	/* get log separator */
-	if ((res = getsetting(&mysql, LOCAL, "default_datechar")) != 0) {
-		set.log_datetime_separator = atoi(res);
+	/* get log date format */
+	if ((res = getsetting(&mysql, LOCAL, "default_dateformat")) != 0) {
+		set.log_datetime_format = atoi(res);
 		free(res);
 
-		if (set.log_datetime_separator < GDC_MIN || set.log_datetime_separator > GDC_MAX) {
-			set.log_datetime_separator = GDC_DEFAULT;
+		if (set.log_datetime_format < GD_MIN || set.log_datetime_format > GD_MAX) {
+			set.log_datetime_format = GD_DEFAULT;
 		}
 	}
 
@@ -1267,18 +1267,25 @@ char *get_date_format(void) {
 	switch (set.log_datetime_format) {
 		case GD_MO_D_Y:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%m%c%%d%c%%Y %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_MN_D_Y:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%b%c%%d%c%%Y %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_D_MO_Y:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%d%c%%m%c%%Y %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_D_MN_Y:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%d%c%%b%c%%Y %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_Y_MO_D:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%Y%c%%m%c%%d %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_Y_MN_D:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%Y%c%%b%c%%d %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		default:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%Y%c%%m%c%%d %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 	}
 
 	return (log_fmt);


### PR DESCRIPTION
Two defensive changes split out from the bug-fix PR because they change
runtime behavior rather than fixing an outright defect.

Stacked on #542 (the ICMP length check lands there first). This PR's diff
will show #542's commits until that merges; the hardening-only commits are
the two listed below. Merge #542 first, then this rebases to two commits.

- ping.c: accept an ICMP echo reply only when its id and sequence match
  the request this thread sent. Spine uses a shared raw socket, so a reply
  from any host with the right source address could otherwise mark a
  device up. The request already sets id = pid & 0xFFFF and an
  incrementing sequence; this checks them on the way in.
- error.c: the SIGSEGV handler called exit(1), which runs atexit and stdio
  flush handlers from signal context. Switched to _exit(1).

## Risk
The ICMP id/seq check changes which replies count as "up." Needs a
reachability smoke test on real devices before merge.

## Verification
Compiles clean (cc -fsyntax-only -Wall, 0 warnings). Not yet runtime-tested.

Depends on #542.
