### PR TITLE
ci: add Cygwin 1.2.x build coverage

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -21,6 +21,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # windows-latest defaults to autocrlf=true, which gives the shell scripts
+      # CRLF endings that Cygwin bash cannot parse. Force LF before checkout.
+      - name: Use LF line endings
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -1,0 +1,48 @@
+name: Cygwin Build
+
+on:
+  pull_request:
+    branches:
+      - 1.2.x
+  push:
+    branches:
+      - 1.2.x
+      - develop-1.2.x
+      - ci/cygwin-1.2.x
+  workflow_dispatch:
+
+jobs:
+  cygwin:
+    name: Cygwin x86_64
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        shell: C:\cygwin64\bin\bash.exe -eo pipefail '{0}'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Cygwin packages
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile C:\cygwin-setup.exe
+          C:\cygwin-setup.exe --quiet-mode --root C:\cygwin64 --site https://mirrors.kernel.org/sourceware/cygwin/ --packages autoconf,automake,dos2unix,gcc-core,gzip,help2man,inetutils,libmariadb-devel,libssl-devel,libtool,m4,make,net-snmp-devel,openssl-devel,pkg-config,wget
+
+      - name: Bootstrap
+        run: |
+          export PATH=/usr/bin:$PATH
+          ./bootstrap
+
+      - name: Configure
+        run: |
+          export PATH=/usr/bin:$PATH
+          ./configure --with-mysql=/usr --with-snmp=/usr
+
+      - name: Build
+        run: |
+          export PATH=/usr/bin:$PATH
+          make -j2 V=1

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -37,7 +37,7 @@ jobs:
           packages: >-
             autoconf automake dos2unix gcc-core gzip help2man inetutils
             libmariadb-devel libssl-devel libtool m4 make net-snmp-devel
-            openssl-devel pkg-config wget
+            libssl-devel pkg-config wget
 
       # The Cygwin bash is on PATH via cygwin-install-action. We invoke it from
       # the default shell rather than via `shell: C:\...\bash.exe`, because the

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -32,20 +32,15 @@ jobs:
             libmariadb-devel libssl-devel libtool m4 make net-snmp-devel
             openssl-devel pkg-config wget
 
+      # The Cygwin bash is on PATH via cygwin-install-action. We invoke it from
+      # the default shell rather than via `shell: C:\...\bash.exe`, because the
+      # runner rejects an absolute drive path there ("Second path fragment must
+      # not be a drive or UNC name").
       - name: Bootstrap
-        shell: C:\cygwin64\bin\bash.exe --login --norc -o igncr -eo pipefail '{0}'
-        run: |
-          cd "$(cygpath -u "$GITHUB_WORKSPACE")"
-          ./bootstrap
+        run: bash -lc 'cd "$(cygpath -u "$GITHUB_WORKSPACE")" && ./bootstrap'
 
       - name: Configure
-        shell: C:\cygwin64\bin\bash.exe --login --norc -o igncr -eo pipefail '{0}'
-        run: |
-          cd "$(cygpath -u "$GITHUB_WORKSPACE")"
-          ./configure --with-mysql=/usr --with-snmp=/usr
+        run: bash -lc 'cd "$(cygpath -u "$GITHUB_WORKSPACE")" && ./configure --with-mysql=/usr --with-snmp=/usr'
 
       - name: Build
-        shell: C:\cygwin64\bin\bash.exe --login --norc -o igncr -eo pipefail '{0}'
-        run: |
-          cd "$(cygpath -u "$GITHUB_WORKSPACE")"
-          make -j2 V=1
+        run: bash -lc 'cd "$(cygpath -u "$GITHUB_WORKSPACE")" && make -j2 V=1'

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -11,38 +11,41 @@ on:
       - ci/cygwin-1.2.x
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   cygwin:
     name: Cygwin x86_64
     runs-on: windows-latest
     timeout-minutes: 30
 
-    defaults:
-      run:
-        shell: C:\cygwin64\bin\bash.exe -eo pipefail '{0}'
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Install Cygwin packages
-        shell: powershell
-        run: |
-          $ErrorActionPreference = 'Stop'
-          Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile C:\cygwin-setup.exe
-          C:\cygwin-setup.exe --quiet-mode --root C:\cygwin64 --site https://mirrors.kernel.org/sourceware/cygwin/ --packages autoconf,automake,dos2unix,gcc-core,gzip,help2man,inetutils,libmariadb-devel,libssl-devel,libtool,m4,make,net-snmp-devel,openssl-devel,pkg-config,wget
+      - name: Install Cygwin
+        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52
+        with:
+          packages: >-
+            autoconf automake dos2unix gcc-core gzip help2man inetutils
+            libmariadb-devel libssl-devel libtool m4 make net-snmp-devel
+            openssl-devel pkg-config wget
 
       - name: Bootstrap
+        shell: C:\cygwin64\bin\bash.exe --login --norc -o igncr -eo pipefail '{0}'
         run: |
-          export PATH=/usr/bin:$PATH
+          cd "$(cygpath -u "$GITHUB_WORKSPACE")"
           ./bootstrap
 
       - name: Configure
+        shell: C:\cygwin64\bin\bash.exe --login --norc -o igncr -eo pipefail '{0}'
         run: |
-          export PATH=/usr/bin:$PATH
+          cd "$(cygpath -u "$GITHUB_WORKSPACE")"
           ./configure --with-mysql=/usr --with-snmp=/usr
 
       - name: Build
+        shell: C:\cygwin64\bin\bash.exe --login --norc -o igncr -eo pipefail '{0}'
         run: |
-          export PATH=/usr/bin:$PATH
+          cd "$(cygpath -u "$GITHUB_WORKSPACE")"
           make -j2 V=1

--- a/INSTALL
+++ b/INSTALL
@@ -50,16 +50,22 @@ please be aware that Cacti no longer officially supports MySQL prior to 5.5.
 Windows Installation
 ====================
 
-CYGWIN Prerequisite
+Cygwin is the supported Windows environment for Spine 1.2.x when using current
+64-bit Cygwin on x86_64 Windows. Native Windows builds and 32-bit Cygwin builds
+are not supported by this build system. Current Cygwin releases support recent
+x86_64 Windows versions starting with Windows 8.1; use the Cygwin Time Machine
+only if you must build for older Windows releases.
+
+Cygwin Prerequisite
 -------------------
 
-1. Download Cygwin for Window from https://www.cygwin.com/
+1. Download Cygwin for Windows from https://www.cygwin.com/
 
 2. Install Cygwin by executing the downloaded setup program
 
 3. Select _Install from Internet_
 
-4. Select Root Directory:  _C:\cygwin_
+4. Select Root Directory:  _C:\cygwin64_
 
 5. Select a mirror which is close to your location
 
@@ -69,11 +75,11 @@ CYGWIN Prerequisite
       * automake
       * dos2unix
       * gcc-core
-      * gcc-debuginfo
       * gzip
       * help2man
-      * libmysqlclient
-      * libmysqlclient-devel
+      * inetutils
+      * libmariadb-devel
+      * libssl-devel
       * libtool
       * m4
       * make
@@ -83,17 +89,18 @@ CYGWIN Prerequisite
 
 7. Wait for installation to complete, coffee time!
 
-8. Move the cygwin setup to the C:\cygwin\ folder for future usage.
+8. Move the Cygwin setup to the C:\cygwin64\ folder for future usage.
 
 Compile Spine
 -------------
 
-1. Open Cygwin shell prompt (C:\Cygwin\cygwin.bat) and brace yourself to use unix commands on Windows.
+1. Open the Cygwin shell prompt (C:\cygwin64\cygwin.bat) and use Unix commands
+   in the Cygwin environment.
 
 2. Download the Spine source to the current directory:
 	http://www.cacti.net/spine_download.php
 
-3. Extract Spine into C:\Cygwin\usr\src\<spineversion>:
+3. Extract Spine into C:\cygwin64\usr\src\<spineversion>:
 	tar xzvf cacti-spine-*.tar.gz
 
 4. Change into the Spine directory:
@@ -111,9 +118,9 @@ Compile Spine
 8. Ensure that Spine runs well by running with:
 	/usr/local/spine/spine -R -S -V 3
 
-9. Update Cacti 'Paths' Setting to point to the Spine binary and update the
-   'Poller Type' to Spine. For the spine binary on Windows x64, and using default
-   locations, that would be:
+9. Update Cacti 'Paths' Setting to point to the Cygwin-built Spine binary and
+   update the 'Poller Type' to Spine. For the spine binary on Windows x64, and
+   using default locations, that would be:
 	C:\cygwin64\usr\local\spine\bin\spine.exe
 
 10. If all is good Spine will be run from the poller in place of cmd.php.
@@ -122,9 +129,10 @@ Compile Spine
 
 Known Issues
 ============
-1. On Windows, Microsoft does not support a TCP Socket send timeout. Therefore,
-   if you are using TCP ping on Windows, spine will not perform a second or subsequent
-   retries to connect and the host will be assumed down on the first failure.
+1. On Cygwin/Windows, TCP ping retries are limited by Windows socket timeout
+   behavior. If you are using TCP ping on Cygwin/Windows, Spine will not perform
+   a second or subsequent retry to connect and the host will be assumed down on
+   the first failure.
 
    If this is a problem it is suggested to use another Availability/Reachability
    method, or moving to Linux/UNIX.

--- a/README.md
+++ b/README.md
@@ -42,15 +42,21 @@ chmod +s /usr/local/spine/bin/spine
 
 ## Windows Installation
 
-### CYGWIN Prerequisite
+Spine 1.2.x supports Windows through current 64-bit Cygwin on x86_64 Windows.
+Native Windows builds and 32-bit Cygwin builds are not supported by this build
+system. Current Cygwin releases support recent x86_64 Windows versions starting
+with Windows 8.1; use the Cygwin Time Machine only if you must build for older
+Windows releases.
 
-1. Download Cygwin for Window from [https://www.cygwin.com/](https://www.cygwin.com/)
+### Cygwin Prerequisite
+
+1. Download Cygwin for Windows from [https://www.cygwin.com/](https://www.cygwin.com/)
 
 2. Install Cygwin by executing the downloaded setup program
 
 3. Select _Install from Internet_
 
-4. Select Root Directory:  _C:\cygwin_
+4. Select Root Directory:  _C:\cygwin64_
 
 5. Select a mirror which is close to your location
 
@@ -63,8 +69,7 @@ chmod +s /usr/local/spine/bin/spine
    * gcc-core
    * gzip
    * help2man
-   * inetutils-src
-   * libmysqlclient
+   * inetutils
    * libmariadb-devel
    * libssl-devel
    * libtool
@@ -76,18 +81,18 @@ chmod +s /usr/local/spine/bin/spine
 
 7. Wait for installation to complete, coffee time!
 
-8. Move the cygwin setup to the C:\cygwin\ folder for future usage.
+8. Move the Cygwin setup to the C:\cygwin64\ folder for future usage.
 
 ### Compile Spine
 
-1. Open Cygwin shell prompt (C:\Cygwin\cygwin.bat) and brace yourself to use
-   unix commands on Windows.
+1. Open the Cygwin shell prompt (C:\cygwin64\cygwin.bat) and use Unix commands
+   in the Cygwin environment.
 
 2. Download the Spine source to the current directory:
 
    [http://www.cacti.net/spine_download.php](http://www.cacti.net/spine_download.php)
 
-3. Extract Spine into C:\Cygwin\usr\src\<spineversion>:
+3. Extract Spine into C:\cygwin64\usr\src\<spineversion>:
 
    `tar xzvf cacti-spine-*.tar.gz`
 
@@ -107,18 +112,19 @@ chmod +s /usr/local/spine/bin/spine
 
 8. Ensure that Spine runs well by running with `/usr/local/spine/spine -R -S -V 3`
 
-9. Update Cacti `Paths` Setting to point to the Spine binary and update the
-   `Poller Type` to Spine. For the spine binary on Windows x64, and using default
-   locations, that would be `C:\cygwin64\usr\local\spine\bin\spine.exe`
+9. Update Cacti `Paths` Setting to point to the Cygwin-built Spine binary and
+   update the `Poller Type` to Spine. For the spine binary on Windows x64, and
+   using default locations, that would be
+   `C:\cygwin64\usr\local\spine\bin\spine.exe`
 
 10. If all is good Spine will be run from the poller in place of cmd.php.
 
 ## Known Issues
 
-1. On Windows, Microsoft does not support a TCP Socket send timeout. Therefore,
-   if you are using TCP ping on Windows, spine will not perform a second or
-   subsequent retries to connect and the host will be assumed down on the first
-   failure.
+1. On Cygwin/Windows, TCP ping retries are limited by Windows socket timeout
+   behavior. If you are using TCP ping on Cygwin/Windows, Spine will not perform
+   a second or subsequent retry to connect and the host will be assumed down on
+   the first failure.
 
    If this is a problem it is suggested to use another Availability/Reachability
    method, or moving to Linux/UNIX.

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,11 @@ case $host_alias in
   AC_DEFINE(HAVE_LIBPTHREAD, 1);;
 *darwin*)
   ShLib="dylib";;
+x86_64-*-cygwin*)
+  LIBS="-lpthread -lssl $LIBS"
+  AC_DEFINE(HAVE_LIBPTHREAD, 1, [Define when pthreads are available]);;
+*cygwin*)
+  AC_MSG_ERROR([Spine 1.2.x supports Cygwin only on x86_64 Windows. Please use 64-bit Cygwin.]);;
 *)
   LIBS="-lpthread -lssl $LIBS"
 esac

--- a/nft_popen.c
+++ b/nft_popen.c
@@ -240,11 +240,7 @@ int nft_popen(const char * command, const char * type) {
 
 		/* Execute the command. */
 		#if defined(__CYGWIN__)
-		if (set.cygwinshloc == 0) {
-			execve("sh.exe", argv, environ);
-		}else{
-			execve("/bin/sh", argv, environ);
-		}
+		execve(set.cygwin_sh_path[0] != '\0' ? set.cygwin_sh_path : "/bin/sh", argv, environ);
 		#else
 		execve("/bin/sh", argv, environ);
 		#endif
@@ -398,4 +394,3 @@ close_cleanup(void * arg)
 
 	free(cur);
 }
-

--- a/ping.c
+++ b/ping.c
@@ -408,7 +408,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 
 				/* wait for a response on the socket */
 				keep_listening:
-				return_code = select(FD_SETSIZE, &socket_fds, NULL, NULL, &timeout);
+				return_code = select(icmp_socket + 1, &socket_fds, NULL, NULL, &timeout);
 
 				/* record end time */
 				end_time = get_time_as_double();
@@ -646,7 +646,7 @@ int ping_udp(host_t *host, ping_t *ping) {
 
 				/* wait for a response on the socket */
 				wait_more:
-				return_code = select(FD_SETSIZE, &socket_fds, NULL, NULL, &timeout);
+				return_code = select(udp_socket + 1, &socket_fds, NULL, NULL, &timeout);
 
 				/* record end time */
 				end_time = get_time_as_double();

--- a/poller.c
+++ b/poller.c
@@ -2304,7 +2304,7 @@ char *exec_poll(host_t *current_host, char *command, int id, char *type) {
 				FD_SET(cmd_fd, &fds);
 
 				/* wait x seconds for pipe response */
-				switch (select(FD_SETSIZE, &fds, NULL, NULL, &timeout)) {
+				switch (select(cmd_fd + 1, &fds, NULL, NULL, &timeout)) {
 					case -1:
 						switch (errno) {
 							case EBADF:

--- a/spine.c
+++ b/spine.c
@@ -454,14 +454,23 @@ int main(int argc, char *argv[]) {
 
 	/* we attempt to support scripts better in cygwin */
 	#if defined(__CYGWIN__)
-	setenv("CYGWIN", "nodosfilewarning", 1);
-	if (file_exists("./sh.exe")) {
-		set.cygwinshloc = 0;
+	const char *cygwin_env = getenv("CYGWIN");
+	if (cygwin_env == NULL || strstr(cygwin_env, "nodosfilewarning") == NULL) {
+		char cygwin_opts[BUFSIZE];
+
+		snprintf(cygwin_opts, sizeof(cygwin_opts), "%s%s%s",
+			cygwin_env != NULL ? cygwin_env : "",
+			cygwin_env != NULL && cygwin_env[0] != '\0' ? " " : "",
+			"nodosfilewarning");
+		setenv("CYGWIN", cygwin_opts, 1);
+	}
+	if (access("./sh.exe", X_OK | F_OK) == 0) {
+		snprintf(set.cygwin_sh_path, sizeof(set.cygwin_sh_path), "%s", "./sh.exe");
 		if (set.log_level == POLLER_VERBOSITY_DEBUG) {
 			printf("The Shell Command Exists in the current directory\n");
 		}
 	} else {
-		set.cygwinshloc = 1;
+		snprintf(set.cygwin_sh_path, sizeof(set.cygwin_sh_path), "%s", "/bin/sh");
 		if (set.log_level == POLLER_VERBOSITY_DEBUG) {
 			printf("The Shell Command Exists in the /bin directory\n");
 		}
@@ -667,7 +676,7 @@ int main(int argc, char *argv[]) {
 
 	memset(host_time, 0, SMALL_BUFSIZE);
 
-	/* initialize winsock library on Windows */
+	/* initialize socket library on Cygwin/Windows */
 	SOCK_STARTUP;
 
 	/* mark the spine process as started */
@@ -1092,7 +1101,7 @@ int main(int argc, char *argv[]) {
 	/* uninstall the spine signal handler */
 	uninstall_spine_signal_handler();
 
-	/* clueanup winsock library on Windows */
+	/* cleanup socket library on Cygwin/Windows */
 	SOCK_CLEANUP;
 
 	exit(EXIT_SUCCESS);

--- a/spine.h
+++ b/spine.h
@@ -53,7 +53,7 @@
 # define __attribute__(x)  /* NOTHING */
 #endif
 
-/* Windows does not support stderr.  Therefore, don't use it. */
+/* Cygwin service launches may not provide a usable stderr. */
 #ifdef __CYGWIN__
 #define DISABLE_STDERR
 #endif
@@ -355,7 +355,7 @@ typedef struct config_struct {
 	int    logfile_processed;
 	int    boost_enabled;
 	int    boost_redirect;
-	int    cygwinshloc;
+	char   cygwin_sh_path[BUFSIZE];
 	/* debugging options */
 	int    snmponly;
 	int    SQL_readonly;


### PR DESCRIPTION
## Summary

Adds a separate Cygwin/Windows support PR for the 1.2.x branch.

- add a Windows-hosted GitHub Actions workflow that installs 64-bit Cygwin dependencies, runs `bootstrap`, configures against `/usr`, and builds with verbose output
- make `configure.ac` explicitly support only x86_64 Cygwin and fail clearly for unsupported 32-bit Cygwin hosts
- clarify documentation that Spine 1.2.x supports Cygwin on Windows, not native Windows builds
- preserve existing `CYGWIN` environment options while adding `nodosfilewarning` when missing
- store the selected Cygwin shell path explicitly instead of using an integer location flag
- use `select(fd + 1, ...)` in poller/ping paths instead of `FD_SETSIZE`

## Validation

- `git diff --check`
- workflow YAML parse with Ruby `YAML.load_file`
- local C syntax check with installed MySQL/MariaDB, Net-SNMP, OpenSSL headers and `-DHAVE_LIBPTHREAD=1`

The actual Cygwin build is expected to run in GitHub Actions after this PR is opened.
