### PR TITLE
ci: Rocky Linux 9 build coverage and Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: develop
+    schedule: {interval: weekly, day: friday}
+    open-pull-requests-limit: 5
+    cooldown: {default-days: 7}
+    groups:
+      github-actions: {patterns: ["*"]}
+    labels: [dependencies, github-actions]
+    commit-message: {prefix: ci, include: scope}
+  - package-ecosystem: docker
+    directories: ["/", "/tests/snmpv3/snmpd"]
+    target-branch: develop
+    schedule: {interval: weekly, day: friday}
+    open-pull-requests-limit: 5
+    cooldown: {default-days: 7}
+    groups:
+      docker: {patterns: ["*"]}
+    labels: [dependencies, docker]
+    commit-message: {prefix: build, include: scope}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
 
 #  cppcheck:
 #    runs-on: ubuntu-latest
-    timeout-minutes: 20
 #    steps:
 #      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -36,10 +41,11 @@ jobs:
 
       - name: Build Spine
         run: |
-          make -j 
+          make -j"$(nproc)"
 
 #  cppcheck:
 #    runs-on: ubuntu-latest
+    timeout-minutes: 20
 #    steps:
 #      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 #
@@ -67,6 +73,7 @@ jobs:
 
   flawfinder:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
@@ -94,3 +101,38 @@ jobs:
         with:
           name: flawfinder-report
           path: flawfinder-report.txt
+
+  # Spine is a threaded network daemon; ASan and UBSan are the checks most
+  # likely to catch a real defect here.
+  sanitizers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y clang mysql-server libmysqlclient-dev libsnmp-dev \
+            libssl-dev build-essential help2man autoconf automake libtool dos2unix
+
+      - name: Build with ASan and UBSan
+        env:
+          CC: clang
+        run: |
+          set -euo pipefail
+          ./bootstrap
+          ./configure \
+            CFLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g -O1" \
+            LDFLAGS="-fsanitize=address,undefined"
+          make -j"$(nproc)"
+
+      - name: Run the binary under the sanitizers
+        env:
+          ASAN_OPTIONS: detect_leaks=1:exitcode=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: |
+          set -euo pipefail
+          ./spine --version
+          ./spine --help > /dev/null

--- a/.github/workflows/rocky-linux.yml
+++ b/.github/workflows/rocky-linux.yml
@@ -30,7 +30,7 @@ jobs:
             bash -euo pipefail -c '
               cp -a /src/. /workspace/
               dnf -y group install "Development Tools"
-              dnf -y install autoconf automake libtool mariadb-connector-c-devel net-snmp-devel openssl-devel libtirpc-devel libxml2-devel libcurl-devel zlib-devel
+              dnf -y install autoconf automake libtool mariadb-connector-c-devel net-snmp-devel openssl-devel libxml2-devel libcurl-devel zlib-devel
               autoreconf -fi
               ./configure --enable-warnings
               make --jobs "$(nproc)"

--- a/.github/workflows/rocky-linux.yml
+++ b/.github/workflows/rocky-linux.yml
@@ -4,6 +4,14 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "37 3 * * 6"
+  pull_request:
+    branches: [develop]
+    paths:
+      - "configure.ac"
+      - "Makefile.am"
+      - "**.c"
+      - "**.h"
+      - ".github/workflows/rocky-linux.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/rocky-linux.yml
+++ b/.github/workflows/rocky-linux.yml
@@ -1,0 +1,36 @@
+name: Rocky Linux compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 3 * * 6"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rocky-linux-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rocky-linux:
+    name: Rocky Linux 9 build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Build in Rocky Linux 9
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+            --workdir /workspace \
+            rockylinux:9 \
+            bash -euo pipefail -c '''
+              dnf -y group install "Development Tools"
+              dnf -y install autoconf automake libtool mariadb-connector-c-devel net-snmp-devel openssl-devel libtirpc-devel libxml2-devel libcurl-devel zlib-devel
+              autoreconf -fi
+              ./configure --enable-warnings
+              make --jobs "$(nproc)"
+            '''

--- a/.github/workflows/rocky-linux.yml
+++ b/.github/workflows/rocky-linux.yml
@@ -23,10 +23,11 @@ jobs:
 
       - name: Build and test in Rocky Linux 9
         run: |
+          set -euo pipefail
           docker run --rm \
             --volume "$GITHUB_WORKSPACE:/src:ro" \
             --workdir /workspace \
-            rockylinux:9 \
+            rockylinux:9@sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6 \
             bash -euo pipefail -c '
               cp -a /src/. /workspace/
               dnf -y group install "Development Tools"

--- a/.github/workflows/rocky-linux.yml
+++ b/.github/workflows/rocky-linux.yml
@@ -14,23 +14,25 @@ concurrency:
 
 jobs:
   rocky-linux:
-    name: Rocky Linux 9 build
+    name: Rocky Linux 9 build and tests
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Build in Rocky Linux 9
+      - name: Build and test in Rocky Linux 9
         run: |
           docker run --rm \
-            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+            --volume "$GITHUB_WORKSPACE:/src:ro" \
             --workdir /workspace \
             rockylinux:9 \
-            bash -euo pipefail -c '''
+            bash -euo pipefail -c '
+              cp -a /src/. /workspace/
               dnf -y group install "Development Tools"
               dnf -y install autoconf automake libtool mariadb-connector-c-devel net-snmp-devel openssl-devel libtirpc-devel libxml2-devel libcurl-devel zlib-devel
               autoreconf -fi
               ./configure --enable-warnings
               make --jobs "$(nproc)"
-            '''
+              make check
+            '


### PR DESCRIPTION
Two pieces of CI plumbing, grouped so they are one review rather than two.

**Rocky Linux 9 job.** EL is the primary deployment platform and nothing in CI covered it. The job as originally written could never have passed: `libtirpc-devel` is not in the Rocky 9 default repos, so `dnf install` aborted the whole transaction and every later step was skipped. Removed it — the build does not need it. Verified by running the full workflow body in a `rockylinux:9` container: install, configure, make and check all pass, 39 warnings.

Image pinned by digest. `set -euo pipefail` added so it satisfies the workflow policy check in #541. Added a `pull_request` trigger with a `paths` filter so a change that breaks the EL9 build is caught on the PR, not on the following Saturday's cron.

**Dependabot.** `github-actions` plus `docker` — the repo has `Dockerfile`, `Dockerfile.dev` and the snmpd fixture image, none of which were tracked.

Was #548, folded in here.

**CI hardening added**
- `concurrency` with `cancel-in-progress` — a PR push previously ran the whole workflow twice and never cancelled stale runs.
- `timeout-minutes: 20` on every job; a hung build otherwise holds a runner for six hours.
- An ASan/UBSan job. Spine is a threaded network daemon and had no sanitizer coverage at all.
- `make -j"$(nproc)"` in place of unbounded `make -j`.
