### PR TITLE
prevent host ignore on NoSuchObject for system OIDs

### DIFF
--- a/poller.c
+++ b/poller.c
@@ -2153,18 +2153,18 @@ void get_system_information(host_t *host, MYSQL *mysql, int system)  {
 			SPINE_LOG_MEDIUM(("Device[%d] Updating Full System Information Table", host->id));
 		}
 
-		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.1.0');", host->id));
-		poll_result = snmp_get(host, ".1.3.6.1.2.1.1.1.0");
-		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.1.0'); [complete]", host->id));
+		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.1.0');", host->id));
+		poll_result = snmp_get_allow_fail(host, ".1.3.6.1.2.1.1.1.0");
+		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.1.0'); [complete]", host->id));
 
 		if (poll_result) {
 			db_escape(mysql, host->snmp_sysDescr, sizeof(host->snmp_sysDescr), poll_result);
 			SPINE_FREE(poll_result);
 		}
 
-		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.2.0');", host->id));
-		poll_result = snmp_get(host, ".1.3.6.1.2.1.1.2.0");
-		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.2.0'); [complete]", host->id));
+		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.2.0');", host->id));
+		poll_result = snmp_get_allow_fail(host, ".1.3.6.1.2.1.1.2.0");
+		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.2.0'); [complete]", host->id));
 
 		if (poll_result) {
 			db_escape(mysql, host->snmp_sysObjectID, sizeof(host->snmp_sysObjectID), poll_result);
@@ -2172,18 +2172,18 @@ void get_system_information(host_t *host, MYSQL *mysql, int system)  {
 		}
 
 		// Get the legacy system uptime instance first
-		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.3.0');", host->id));
-		poll_result = snmp_get(host, ".1.3.6.1.2.1.1.3.0");
-		SPINE_LOG_DEVDBG(("DEVDGB: Device[%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.3.0'); [complete]", host->id));
+		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.3.0');", host->id));
+		poll_result = snmp_get_allow_fail(host, ".1.3.6.1.2.1.1.3.0");
+		SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.3.0'); [complete]", host->id));
 
 		if (poll_result && is_numeric(poll_result)) {
 			host->snmp_sysUpTimeInstance = atoll(poll_result);
 			SPINE_FREE(poll_result);
 
 			// Attempt to get the more modern version
-			SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get(host, '.1.3.6.1.6.3.10.2.1.3.0');", host->id));
-			poll_result = snmp_get_base(host, ".1.3.6.1.6.3.10.2.1.3.0", false);
-			SPINE_LOG_DEVDBG(("DEVDGB: Device[%d] poll_result = snmp_get(host, '.1.3.6.1.6.3.10.2.1.3.0'); [complete]", host->id));
+			SPINE_LOG_DEVDBG(("DEVDBG: Device[%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.6.3.10.2.1.3.0');", host->id));
+			poll_result = snmp_get_allow_fail(host, ".1.3.6.1.6.3.10.2.1.3.0");
+			SPINE_LOG_DEVDBG(("DEVDGB: Device[%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.6.3.10.2.1.3.0'); [complete]", host->id));
 
 			if (poll_result && is_numeric(poll_result)) {
 				host->snmp_sysUpTimeInstance = atoll(poll_result) * 100;
@@ -2193,27 +2193,27 @@ void get_system_information(host_t *host, MYSQL *mysql, int system)  {
 			SPINE_FREE(poll_result);
 		}
 
-		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.4.0');", host->id));
-		poll_result = snmp_get(host, ".1.3.6.1.2.1.1.4.0");
-		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.4.0'); [complete]", host->id));
+		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.4.0');", host->id));
+		poll_result = snmp_get_allow_fail(host, ".1.3.6.1.2.1.1.4.0");
+		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.4.0'); [complete]", host->id));
 
 		if (poll_result) {
 			db_escape(mysql, host->snmp_sysContact, sizeof(host->snmp_sysContact), poll_result);
 			SPINE_FREE(poll_result);
 		}
 
-		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.5.0');", host->id));
-		poll_result = snmp_get(host, ".1.3.6.1.2.1.1.5.0");
-		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.5.0'); [complete]", host->id));
+		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.5.0');", host->id));
+		poll_result = snmp_get_allow_fail(host, ".1.3.6.1.2.1.1.5.0");
+		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.5.0'); [complete]", host->id));
 
 		if (poll_result) {
 			db_escape(mysql, host->snmp_sysName, sizeof(host->snmp_sysName), poll_result);
 			SPINE_FREE(poll_result);
 		}
 
-		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.6.0');", host->id));
-		poll_result = snmp_get(host, ".1.3.6.1.2.1.1.6.0");
-		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get(host, '.1.3.6.1.2.1.1.6.0'); [complete]", host->id));
+		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.6.0');", host->id));
+		poll_result = snmp_get_allow_fail(host, ".1.3.6.1.2.1.1.6.0");
+		SPINE_LOG_DEVDBG(("DEVDBG: Device [%d] poll_result = snmp_get_allow_fail(host, '.1.3.6.1.2.1.1.6.0'); [complete]", host->id));
 
 		if (poll_result) {
 			db_escape(mysql, host->snmp_sysLocation, sizeof(host->snmp_sysLocation), poll_result);

--- a/snmp.c
+++ b/snmp.c
@@ -682,6 +682,10 @@ char *snmp_get(host_t *current_host, const char *snmp_oid) {
 	return snmp_get_base(current_host, snmp_oid, true);
 }
 
+char *snmp_get_allow_fail(host_t *current_host, const char *snmp_oid) {
+	return snmp_get_base(current_host, snmp_oid, false);
+}
+
 /*! \fn char *snmp_getnext(host_t *current_host, const char *snmp_oid)
  *  \brief performs a single snmp_getnext for a specific snmp OID
  *

--- a/snmp.h
+++ b/snmp.h
@@ -42,6 +42,7 @@ extern void snmp_host_cleanup(void *snmp_session);
 extern char *snmp_get_base(host_t *current_host, const char *snmp_oid, bool should_fail);
 extern int snmp_varbind_is_exception(const struct variable_list *vars);
 extern char *snmp_get(host_t *current_host, const char *snmp_oid);
+extern char *snmp_get_allow_fail(host_t *current_host, const char *snmp_oid);
 extern char *snmp_getnext(host_t *current_host, const char *snmp_oid);
 extern int snmp_count(host_t *current_host, const char *snmp_oid);
 extern void snmp_get_multi(host_t *current_host, target_t *poller_items, snmp_oids_t *snmp_oids, int num_oids);


### PR DESCRIPTION
**Problem Description**

When a device does not support one or more of the system OIDs queried by get_system_information(), not only system information collection but also resource-related SNMP polling may fail.

This issue is especially noticeable when the device's Poller Thread setting is 1, where resource-related SNMP polling does not occur at all.

During analysis, I found that if one of the OIDs queried in get_system_information() returns NoSuchObject, the host is marked as ignored through the following call path:

snmp_get()
  -> snmp_get_base(current_host, snmp_oid, true)
     -> NoSuchObject returned
        -> current_host->ignore_host = TRUE


The OIDs queried by get_system_information() are:
- sysDescr
- sysObjectID
- sysUpTime
- sysContact
- sysName
- sysLocation
- Existing Behavior

Issue #366 already introduced special handling for the following OIDs:
- sysDescr
- sysUpTime

Reference: 
Issue #366: Failing to actually poll a device that returns "NoSuchObject"

However, the same handling was not applied to:
- sysObjectID
- sysContact
- sysName
- sysLocation

As a result, devices that do not implement one or more of these OIDs can still be marked as ignored, causing polling to stop unexpectedly.

**Observed Behavior**
The following log shows the issue occurring when the target device returns NoSuchObject for sysContact (.1.3.6.1.2.1.1.4.0).
After the error is detected, ignore_host becomes active and subsequent system OID requests are skipped. The device polling thread then completes without polling any of the scheduled data sources.

```
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502752032320] ERROR: No such Object for oid '.1.3.6.1.2.1.1.4.0' for Device[72] with Status[1]
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502752032320] WARNING: Skipped oid '.1.3.6.1.2.1.1.5.0' for Device[72] as host ignore flag is active
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502752032320] WARNING: Skipped oid '.1.3.6.1.2.1.1.6.0' for Device[72] as host ignore flag is active
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502752032320] Device[72] HT[1] NOTE: There are '17' Polling Items for this Device
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502752032320] DEBUG: Setting up writes to local database
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502752032320] Device[72] HT[1] Total Time: 0.019 Seconds
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502752032320] DEBUG: Freeing Local Pool ID 0
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502752032320] DEBUG: Device[72] HT[1] DEBUG: HOST COMPLETE: About to Exit Device Polling Thread Function
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502985176896] The final count of Threads is 0
2026-07-30 10:56:53 - SPINE: Poller[1] PID[1069197] PT[140502985176896] INFO: Device[72] Thread complete and 0 to 17 sources
```

In this example, the device contains 17 polling items, but polling completes with:
INFO: Device[72] Thread complete and 0 to 17 sources
indicating that none of the scheduled data sources were successfully polled.

**Fix**
This change adds the same exception handling for the remaining four OIDs:
- sysObjectID
- sysContact
- sysName
- sysLocation

If any of these OIDs return NoSuchObject, the host will no longer be marked as ignored, allowing normal resource-related polling to continue.

**Expected Result**
Devices that do not implement one or more optional system OIDs should still be polled successfully for resource-related metrics.
Only the unavailable system information fields should be skipped, while normal SNMP data collection continues without interruption.