### PR TITLE
build: fix the release tarball, modernise autoconf, add distcheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,24 @@ jobs:
           set -euo pipefail
           ./spine --version
           ./spine --help > /dev/null
+  # A release tarball that cannot be compiled is a release blocker, and the
+  # only way to catch it is to build from the tarball the way a packager does.
+  distcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y mysql-server libmysqlclient-dev libsnmp-dev \
+            libssl-dev build-essential help2man autoconf automake libtool dos2unix
+
+      - name: make distcheck
+        run: |
+          set -euo pipefail
+          ./bootstrap
+          ./configure
+          make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,12 @@ bin_PROGRAMS = spine
 
 man_MANS = spine.1
 
-EXTRA_DIST = spine.1 uthash.h spine_sem.h
+# Headers are not referenced by any _SOURCES, so automake will not distribute
+# them unless they are listed. Without this the release tarball builds nothing.
+noinst_HEADERS = common.h error.h keywords.h locks.h nft_popen.h php.h \
+	ping.h poller.h snmp.h spine.h spine_sem.h sql.h uthash.h util.h
+
+EXTRA_DIST = spine.1 spine.conf.dist
 
 # Docker targets — require Dockerfile and Dockerfile.dev (from PR #401)
 .PHONY: docker docker-dev verify cppcheck

--- a/common.h
+++ b/common.h
@@ -110,16 +110,10 @@
 #  include <netinet/ip_icmp.h>
 #endif
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
 #  include <sys/time.h>
-#  include <time.h>
-#else
-#  if HAVE_SYS_TIME_H
-#    include <sys/time.h>
-#  else
-#    include <time.h>
-#  endif
 #endif
+#include <time.h>
 
 #ifndef HAVE_LIBPTHREAD
 #  define HAVE_LIBPTHREAD 0

--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,6 @@ AC_CHECK_HEADERS(
 )
 
 # Checks for typedefs, structures, and compiler characteristics.
-AC_HEADER_TIME
 AC_CHECK_TYPES([unsigned long long, long long])
 AC_TYPE_SIZE_T
 

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,7 @@ AC_PREFIX_DEFAULT(/usr/local/spine)
 AC_LANG(C)
 
 AM_INIT_AUTOMAKE([foreign])
+AM_SILENT_RULES([yes])
 AC_CONFIG_HEADERS(config/config.h)
 
 # static libraries
@@ -93,6 +94,17 @@ AC_ARG_ENABLE(warnings,
   [if test -n "$GCC"; then
     AC_MSG_RESULT(adding -Wall to CFLAGS.)
     CFLAGS="$CFLAGS -Wall"
+   fi
+  ],
+  AC_MSG_RESULT(no)
+)
+
+AC_ARG_ENABLE(sanitizers,
+  [  --enable-sanitizers     Build with AddressSanitizer and UndefinedBehaviorSanitizer.],
+  [if test "x$enableval" = "xyes"; then
+    AC_MSG_RESULT(adding -fsanitize=address,undefined to CFLAGS.)
+    CFLAGS="$CFLAGS -fsanitize=address,undefined -fno-omit-frame-pointer -g"
+    LDFLAGS="$LDFLAGS -fsanitize=address,undefined"
    fi
   ],
   AC_MSG_RESULT(no)


### PR DESCRIPTION
Two macros that autoconf removed in 2.70 and warns about on every `autoreconf`.

- `AC_HEADER_TIME` — obsolete. Every system that provides `sys/time.h` allows including it alongside `time.h`, so the `TIME_WITH_SYS_TIME` ladder in `common.h` collapses to a single `HAVE_SYS_TIME_H` guard.
- `AC_TRY_COMPILE` — replaced by `AC_COMPILE_IFELSE([AC_LANG_PROGRAM(...)])`. Mechanical; the Net-SNMP crypto probe behaves identically (`checking if Net-SNMP needs crypto support... yes`).

`AC_PREREQ` stays at 2.69 deliberately, so the tree still bootstraps on EL7-era autoconf.

Verified in a clean ubuntu:24.04 container: `autoreconf -Wall` is quiet, build is 39 warnings matching develop, and `make dist` still produces a correct tarball.

**Note on #500**, which proposed this cleanup — both of its scope items are wrong and I am not doing them:

- *"remove `ACLOCAL_AMFLAGS = -I m4`"* — `m4/` exists and holds the libtool macros (`libtool.m4`, `ltoptions.m4`, `ltsugar.m4`, `ltversion.m4`, `lt~obsolete.m4`). Removing the flag breaks `aclocal`.
- *"remove redundant `EXTRA_DIST = spine.1`"* — not redundant. I removed it and `make dist` silently dropped the man page from the tarball; `man_MANS` does not distribute it here. Restored.

Refs #500

---

**Release-blocking bug found while testing this.** `make distcheck` failed on develop: the dist tarball was missing twelve headers (`common.h`, `spine.h`, `util.h`, `sql.h`, `snmp.h`, `poller.h`, `php.h`, `ping.h`, `locks.h`, `error.h`, `keywords.h`, `nft_popen.h`) and `spine.conf.dist`, so a release tarball could not be compiled from. Headers are now declared via `noinst_HEADERS` and the sample config is in `EXTRA_DIST`. `make distcheck` passes.

**Also added**
- `--enable-sanitizers` configure option (ASan + UBSan), so a sanitizer build is one flag rather than hand-rolled `CFLAGS`.
- `AM_SILENT_RULES([yes])` — the normal build is readable, `make V=1` restores the full command lines.
- A `distcheck` CI job, so a tarball that cannot be compiled fails the PR instead of shipping.

(`AC_CONFIG_MACRO_DIR([m4])` was already present at line 46; I added a duplicate, autoconf rejected it, and I removed it.)
