### PR TITLE
port: memory-safety fixes from Spine #544 to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, '1.2.x']
   pull_request:
-    branches: [develop]
+    branches: [develop, '1.2.x']
 
 permissions:
   contents: read

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,34 +1,18 @@
 The Cacti Group | spine
 
-1.3.0
--issue#360: If a Remote Data Collector has not devices, spine does not properly register itself
--issue#423: Reinitialize fd_set before each select() call in ping_icmp() to prevent instant retry expiry after first timeout
--issue#424: Correct inverted spike_kill condition for PHP script server (IS_UNDEFINED -> !IS_UNDEFINED)
--issue#425: Mark all OIDs undefined when snmp_get_multi() receives errindex==0 from agent
--issue#426: Add NULL check after malloc in host_errors insert path to prevent UB on memory pressure
--issue#438: Resolve stale content in spine.c (--help search path), configure.ac (AC_PREREQ, obsolete macros), spine.conf.dist (missing settings), and Copilot instructions
--issue#441: Update copyright year to 2026 in 12 source files
--issue#445: Replace vfork/execv with posix_spawn in php_init; fix stack-local return in regex_replace
--issue#447: Correct off-by-one OOB write in strncopy() when src fills buffer; remove suppressing pragma
--feature#362: Report the number of data collection errors during data collection in host table
--feature#439: Add idiomatic RPM spec for cacti-spine (%autosetup, %config(noreplace), man1)
--feature#442: Add GitHub Actions CI: build matrix (gcc/clang), cppcheck, flawfinder, CodeQL
--feature#443: Add make targets for Docker build and verification (docker, docker-dev, verify, cppcheck)
--feature#444: Add multi-stage Dockerfile and Dockerfile.dev with ASan/cppcheck/scan-build
--feature#3740: Ability to disable a site
--feature#5090: Enhance number recognition within Spine
--feature#6001: Extend SYSTEM STATS
--feature: Make spine work with Stream feature
-
 1.2.31
--issue#365: Removing Backtrace Support
--issue#366: Failing to actually a poll device that returns "NoSuchObject"
--issue#370: Errors experienced with very long OIDs
--issue#373: Spine SNMPv3 SHA-512 auth doesn't work
--issue#374: Error DES is no longer supported on this system
--issue#383: Spine returns Segmentation fault
--issue#384: ICMP Buffer overflows on Debian/Unbuntu related recvfrom() calls
--issue: Clear up a few very minor leaks in spine
+-issue: Bound PHP script-server shutdown and use width-safe pipe capacity arithmetic
+-issue#365: Removed Backtrace Support due to lack of OS support
+-issue#366: Prevent polling from stopping when sysDescr OID returns noSuchObject
+-issue#370: Increase buffer sizes to handle large OID numbers
+-issue#373: Spine cannot generate SNMPv3 Ku for SHA-384/SHA-512
+-issue#374: Improve depreciated DES support
+-issue#383: Improve Spine buffer handling #383
+-issue#384: Buffer overflow in ping_icmp() causes Spine crash
+-issue: Clear up some minor memory leaks
+
+1.2.30
+-no changes
 
 1.2.29
 -no changes
@@ -671,4 +655,4 @@ The Cacti Group | spine
 -bug: small log file reformatting
 
 -----------------------------------------------
-Copyright (c) 2004-2026 - The Cacti Group, Inc.
+Copyright (c) 2004-2024 - The Cacti Group, Inc.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,18 +1,35 @@
 The Cacti Group | spine
 
-1.2.31
--issue: Bound PHP script-server shutdown and use width-safe pipe capacity arithmetic
--issue#365: Removed Backtrace Support due to lack of OS support
--issue#366: Prevent polling from stopping when sysDescr OID returns noSuchObject
--issue#370: Increase buffer sizes to handle large OID numbers
--issue#373: Spine cannot generate SNMPv3 Ku for SHA-384/SHA-512
--issue#374: Improve depreciated DES support
--issue#383: Improve Spine buffer handling #383
--issue#384: Buffer overflow in ping_icmp() causes Spine crash
--issue: Clear up some minor memory leaks
+1.3.0
+-issue#360: If a Remote Data Collector has not devices, spine does not properly register itself
+-issue#423: Reinitialize fd_set before each select() call in ping_icmp() to prevent instant retry expiry after first timeout
+-issue#424: Correct inverted spike_kill condition for PHP script server (IS_UNDEFINED -> !IS_UNDEFINED)
+-issue#425: Mark all OIDs undefined when snmp_get_multi() receives errindex==0 from agent
+-issue#426: Add NULL check after malloc in host_errors insert path to prevent UB on memory pressure
+-issue#438: Resolve stale content in spine.c (--help search path), configure.ac (AC_PREREQ, obsolete macros), spine.conf.dist (missing settings), and Copilot instructions
+-issue#441: Update copyright year to 2026 in 12 source files
+-issue#445: Replace vfork/execv with posix_spawn in php_init; fix stack-local return in regex_replace
+-issue#447: Correct off-by-one OOB write in strncopy() when src fills buffer; remove suppressing pragma
+-issue#561: Reserve room for the terminator in php_readpipe() so a full script server result cannot write past result_string
+-feature#362: Report the number of data collection errors during data collection in host table
+-feature#439: Add idiomatic RPM spec for cacti-spine (%autosetup, %config(noreplace), man1)
+-feature#442: Add GitHub Actions CI: build matrix (gcc/clang), cppcheck, flawfinder, CodeQL
+-feature#443: Add make targets for Docker build and verification (docker, docker-dev, verify, cppcheck)
+-feature#444: Add multi-stage Dockerfile and Dockerfile.dev with ASan/cppcheck/scan-build
+-feature#3740: Ability to disable a site
+-feature#5090: Enhance number recognition within Spine
+-feature#6001: Extend SYSTEM STATS
+-feature: Make spine work with Stream feature
 
-1.2.30
--no changes
+1.2.31
+-issue#365: Removing Backtrace Support
+-issue#366: Failing to actually a poll device that returns "NoSuchObject"
+-issue#370: Errors experienced with very long OIDs
+-issue#373: Spine SNMPv3 SHA-512 auth doesn't work
+-issue#374: Error DES is no longer supported on this system
+-issue#383: Spine returns Segmentation fault
+-issue#384: ICMP Buffer overflows on Debian/Unbuntu related recvfrom() calls
+-issue: Clear up a few very minor leaks in spine
 
 1.2.29
 -no changes
@@ -655,4 +672,4 @@ The Cacti Group | spine
 -bug: small log file reformatting
 
 -----------------------------------------------
-Copyright (c) 2004-2024 - The Cacti Group, Inc.
+Copyright (c) 2004-2026 - The Cacti Group, Inc.

--- a/common.h
+++ b/common.h
@@ -84,6 +84,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <math.h>
 #include <mysql.h>
 #include <netdb.h>

--- a/error.c
+++ b/error.c
@@ -73,7 +73,7 @@ static void spine_signal_handler(int spine_signal) {
 			break;
 		case SIGSEGV:
 			fprintf(stderr, "%s FATAL: Spine Encountered a Segmentation Fault\n", logtime);
-			exit(1);
+			_exit(1);
 			break;
 		case SIGBUS:
 			fprintf(stderr, "%s FATAL: Spine Encountered a Bus Error\n", logtime);

--- a/nft_popen.c
+++ b/nft_popen.c
@@ -129,7 +129,13 @@ static int reap_child_bounded(pid_t pid, int *pstat, int attempts) {
 			waited = waitpid(pid, pstat, WNOHANG);
 		} while (waited < 0 && errno == EINTR);
 
-		if (waited == pid || (waited < 0 && errno == ECHILD)) {
+		if (waited == pid) {
+			return 0;
+		}
+
+		if (waited < 0 && errno == ECHILD) {
+			/* someone else reaped it, so no status is available */
+			*pstat = 0;
 			return 0;
 		}
 

--- a/nft_popen.c
+++ b/nft_popen.c
@@ -101,6 +101,52 @@ static pthread_mutex_t ListMutex = PTHREAD_MUTEX_INITIALIZER;
 
 static void	close_cleanup(void *);
 
+#define NFT_PCLOSE_REAP_USEC 50000
+#define NFT_PCLOSE_TERM_ATTEMPTS 100
+#define NFT_PCLOSE_KILL_ATTEMPTS 20
+
+static int set_cloexec(int fd) {
+	int flags;
+
+	flags = fcntl(fd, F_GETFD);
+	if (flags < 0) {
+		return -1;
+	}
+
+	return fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
+
+static int set_pipe_cloexec(int pdes[2]) {
+	return set_cloexec(pdes[0]) == 0 && set_cloexec(pdes[1]) == 0;
+}
+
+static int reap_child_bounded(pid_t pid, int *pstat, int attempts) {
+	int attempt;
+	pid_t waited;
+
+	for (attempt = 0; attempt < attempts; attempt++) {
+		do {
+			waited = waitpid(pid, pstat, WNOHANG);
+		} while (waited < 0 && errno == EINTR);
+
+		if (waited == pid || (waited < 0 && errno == ECHILD)) {
+			return 0;
+		}
+
+		if (waited < 0) {
+			return -1;
+		}
+
+		#ifndef SOLAR_THREAD
+		usleep(NFT_PCLOSE_REAP_USEC);
+		#else
+		sleep(1);
+		#endif
+	}
+
+	return 1;
+}
+
 /*! ------------------------------------------------------------------------------
  *
  *  nft_popen
@@ -156,6 +202,12 @@ int nft_popen(const char * command, const char * type) {
 
 	if (pipe(pdes) < 0)
 		return -1;
+
+	if (!set_pipe_cloexec(pdes)) {
+		(void)close(pdes[0]);
+		(void)close(pdes[1]);
+		return -1;
+	}
 
 	/* Disable thread cancellation from this point forward. */
 	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cancel_state);
@@ -354,8 +406,23 @@ nft_pclose(int fd)
 
 	cur->fd = -1;		/* Prevent the fd being closed twice. */
 
-	do { pid = waitpid(cur->pid, &pstat, 0);
-	} while (pid == -1 && errno == EINTR);
+	switch (reap_child_bounded(cur->pid, &pstat, NFT_PCLOSE_TERM_ATTEMPTS)) {
+	case 0:
+		pid = cur->pid;
+		break;
+	case 1:
+		(void)kill(cur->pid, SIGKILL);
+		if (reap_child_bounded(cur->pid, &pstat, NFT_PCLOSE_KILL_ATTEMPTS) == 0) {
+			pid = cur->pid;
+		} else {
+			errno = ETIMEDOUT;
+			pid = -1;
+		}
+		break;
+	default:
+		pid = -1;
+		break;
+	}
 
 	pthread_cleanup_pop(1);	/* Execute the cleanup handler. */
 

--- a/php.c
+++ b/php.c
@@ -72,6 +72,21 @@ static int php_reap_child(pid_t pid, int *wstatus, int attempts) {
 	return (waited == pid || (waited < 0 && errno == ECHILD));
 }
 
+static int php_set_cloexec(int fd) {
+	int flags;
+
+	flags = fcntl(fd, F_GETFD);
+	if (flags < 0) {
+		return FALSE;
+	}
+
+	return fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == 0;
+}
+
+static int php_set_pipe_cloexec(int pdes[2]) {
+	return php_set_cloexec(pdes[0]) && php_set_cloexec(pdes[1]);
+}
+
 /*! \fn char *php_cmd(const char *php_command, int php_process)
  *  \brief calls the script server and executes a script command
  *  \param php_command the formatted php script server command
@@ -362,17 +377,33 @@ int php_init(int php_process) {
 	for (i=0; i < num_processes; i++) {
 		SPINE_LOG_DEBUG(("DEBUG: SS[%i] PHP Script Server Routine Starting", i));
 
-		/* create the output pipes from Spine to php*/
-		if (pipe(cacti2php_pdes) < 0) {
-			SPINE_LOG(("ERROR: SS[%i] Could not allocate php server pipes", i));
-			return FALSE;
-		}
+			/* create the output pipes from Spine to php*/
+			if (pipe(cacti2php_pdes) < 0) {
+				SPINE_LOG(("ERROR: SS[%i] Could not allocate php server pipes", i));
+				return FALSE;
+			}
+			if (!php_set_pipe_cloexec(cacti2php_pdes)) {
+				close(cacti2php_pdes[0]);
+				close(cacti2php_pdes[1]);
+				SPINE_LOG(("ERROR: SS[%i] Could not set close-on-exec on php server pipes", i));
+				return FALSE;
+			}
 
-		/* create the input pipes from php to Spine */
-		if (pipe(php2cacti_pdes) < 0) {
-			SPINE_LOG(("ERROR: SS[%i] Could not allocate php server pipes", i));
-			return FALSE;
-		}
+			/* create the input pipes from php to Spine */
+			if (pipe(php2cacti_pdes) < 0) {
+				close(cacti2php_pdes[0]);
+				close(cacti2php_pdes[1]);
+				SPINE_LOG(("ERROR: SS[%i] Could not allocate php server pipes", i));
+				return FALSE;
+			}
+			if (!php_set_pipe_cloexec(php2cacti_pdes)) {
+				close(php2cacti_pdes[0]);
+				close(php2cacti_pdes[1]);
+				close(cacti2php_pdes[0]);
+				close(cacti2php_pdes[1]);
+				SPINE_LOG(("ERROR: SS[%i] Could not set close-on-exec on php server pipes", i));
+				return FALSE;
+			}
 
 		/* disable thread cancellation from this point forward. */
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cancel_state);

--- a/php.c
+++ b/php.c
@@ -590,6 +590,7 @@ void php_close(int php_process) {
 	int i;
 	int num_processes;
 	int len;
+	int wstatus;
 
 	if (php_process == PHP_INIT) {
 		num_processes = set.php_servers;

--- a/php.c
+++ b/php.c
@@ -37,6 +37,41 @@
 
 extern char **environ;
 
+#define PHP_CLOSE_REAP_USEC 50000
+#define PHP_CLOSE_TERM_ATTEMPTS 100
+#define PHP_CLOSE_KILL_ATTEMPTS 20
+
+static int php_reap_child(pid_t pid, int *wstatus, int attempts) {
+	int attempt;
+	pid_t waited;
+
+	for (attempt = 0; attempt < attempts; attempt++) {
+		do {
+			waited = waitpid(pid, wstatus, WNOHANG);
+		} while (waited < 0 && errno == EINTR);
+
+		if (waited == pid || (waited < 0 && errno == ECHILD)) {
+			return TRUE;
+		}
+
+		if (waited < 0) {
+			return FALSE;
+		}
+
+		#ifndef SOLAR_THREAD
+		usleep(PHP_CLOSE_REAP_USEC);
+		#else
+		sleep(1);
+		#endif
+	}
+
+	do {
+		waited = waitpid(pid, wstatus, WNOHANG);
+	} while (waited < 0 && errno == EINTR);
+
+	return (waited == pid || (waited < 0 && errno == ECHILD));
+}
+
 /*! \fn char *php_cmd(const char *php_command, int php_process)
  *  \brief calls the script server and executes a script command
  *  \param php_command the formatted php script server command
@@ -514,10 +549,7 @@ int php_init(int php_process) {
  *  information is will close and/or terminate the child PHP Script Server
  *  process and then return to the calling function.
  *
- *  TODO: Make ending of the child process not be reliant on SIG_TERM in cases
- *  where the child process is hung for one reason or another.
- *
- */
+	 */
 void php_close(int php_process) {
 	int i;
 	int num_processes;
@@ -572,7 +604,16 @@ void php_close(int php_process) {
 			/* end the php script server process */
 			kill(phpp->php_pid, SIGTERM);
 
-			/* reset this PID variable? */
+			if (!php_reap_child(phpp->php_pid, &wstatus, PHP_CLOSE_TERM_ATTEMPTS)) {
+				SPINE_LOG(("WARNING: SS[%i] PHP Script Server did not exit after SIGTERM; sending SIGKILL", i));
+				kill(phpp->php_pid, SIGKILL);
+
+				if (!php_reap_child(phpp->php_pid, &wstatus, PHP_CLOSE_KILL_ATTEMPTS)) {
+					SPINE_LOG(("WARNING: SS[%i] PHP Script Server could not be reaped after SIGKILL", i));
+				}
+			}
+
+			phpp->php_pid = -1;
 		}
 
 		/* close file descriptors */

--- a/php.c
+++ b/php.c
@@ -65,11 +65,7 @@ static int php_reap_child(pid_t pid, int *wstatus, int attempts) {
 		#endif
 	}
 
-	do {
-		waited = waitpid(pid, wstatus, WNOHANG);
-	} while (waited < 0 && errno == EINTR);
-
-	return (waited == pid || (waited < 0 && errno == ECHILD));
+	return FALSE;
 }
 
 static int php_set_cloexec(int fd) {

--- a/php.c
+++ b/php.c
@@ -216,7 +216,7 @@ char *php_readpipe(int php_process, char *command) {
 	double remaining_usec = 0;
 	char *result_string;
 
-	int  i;
+	ssize_t i;
 	char *cp;
 	char *bptr;
 
@@ -304,22 +304,15 @@ char *php_readpipe(int php_process, char *command) {
 			bptr = result_string;
 
 			while (1) {
-				ptrdiff_t avail = RESULTS_BUFFER - 1 - (bptr - result_string);
+				size_t used = (size_t)(bptr - result_string);
 
-				if (avail <= 0) {
+				if (used >= RESULTS_BUFFER - 1) {
 					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
 					SET_UNDEFINED(result_string);
 					break;
 				}
 
-				ptrdiff_t avail = RESULTS_BUFFER - 1 - (bptr - result_string);
-
-				if (avail <= 0) {
-					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
-					SET_UNDEFINED(result_string);
-					break;
-				}
-
+				size_t avail = (size_t)RESULTS_BUFFER - 1 - used;
 				i = read(php_processes[php_process].php_read_fd, bptr, avail);
 
 				if (i <= 0) {

--- a/php.c
+++ b/php.c
@@ -304,7 +304,23 @@ char *php_readpipe(int php_process, char *command) {
 			bptr = result_string;
 
 			while (1) {
-				i = read(php_processes[php_process].php_read_fd, bptr, RESULTS_BUFFER-(bptr-result_string));
+				ptrdiff_t avail = RESULTS_BUFFER - 1 - (bptr - result_string);
+
+				if (avail <= 0) {
+					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
+					SET_UNDEFINED(result_string);
+					break;
+				}
+
+				ptrdiff_t avail = RESULTS_BUFFER - 1 - (bptr - result_string);
+
+				if (avail <= 0) {
+					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
+					SET_UNDEFINED(result_string);
+					break;
+				}
+
+				i = read(php_processes[php_process].php_read_fd, bptr, avail);
 
 				if (i <= 0) {
 					SET_UNDEFINED(result_string);

--- a/ping.c
+++ b/ping.c
@@ -268,6 +268,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 	struct sockaddr_in fromname;
 	char   socket_reply[BUFSIZE];
 	int    retry_count;
+	int    ihl;
 	const char *cacti_msg = "cacti-monitoring-system\0";
 	int    packet_len;
 	socklen_t    fromlen;
@@ -440,8 +441,18 @@ int ping_icmp(host_t *host, ping_t *ping) {
 							goto keep_listening;
 						}
 					} else {
+						if (return_code < (ssize_t) sizeof(struct ip)) {
+							goto keep_listening;
+						}
+
 						ip  = (struct ip *) socket_reply;
-						pkt = (struct icmp *) (socket_reply + (ip->ip_hl << 2));
+						ihl = ip->ip_hl << 2;
+
+						if (ihl < (int) sizeof(struct ip) || return_code < (ssize_t) (ihl + ICMP_HDR_SIZE)) {
+							goto keep_listening;
+						}
+
+						pkt = (struct icmp *) (socket_reply + ihl);
 
 						if (fromname.sin_addr.s_addr == recvname.sin_addr.s_addr) {
 							if (pkt->icmp_type == ICMP_ECHOREPLY) {

--- a/poller.c
+++ b/poller.c
@@ -1279,7 +1279,10 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 
 	if (num_rows > 0) {
 		/* retrieve each hosts polling items from poller cache and load into array */
-		poller_items = (target_t *) calloc(num_rows, sizeof(target_t));
+		/* retreive each hosts polling items from poller cache and load into array */
+		if (!(poller_items = (target_t *) calloc(num_rows, sizeof(target_t)))) {
+			die("ERROR: Fatal calloc error: poller.c poller_items!");
+		}
 
 		i = 0;
 		while ((row = mysql_fetch_row(result))) {
@@ -1353,7 +1356,9 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 		db_free_result(result);
 
 		/* create an array for snmp oids */
-		snmp_oids = (snmp_oids_t *) calloc(host->max_oids, sizeof(snmp_oids_t));
+		if (!(snmp_oids = (snmp_oids_t *) calloc(host->max_oids, sizeof(snmp_oids_t)))) {
+			die("ERROR: Fatal calloc error: poller.c snmp_oids!");
+		}
 
 		/* initialize all the memory to insure we don't get issues */
 		memset(snmp_oids, 0, sizeof(snmp_oids_t)*host->max_oids);

--- a/snmp.c
+++ b/snmp.c
@@ -889,7 +889,11 @@ int snmp_count(host_t *current_host, const char *snmp_oid) {
 			//SPINE_LOG_DEBUG(("TRACE: Status %i Response %i", status, response->errstat));
 
 			if (status == STAT_SUCCESS) {
-				if (response->errstat == SNMP_ERR_NOERROR) {
+				if (response == NULL) {
+					SPINE_LOG(("ERROR: An internal Net-Snmp error condition detected in Cacti snmp_count"));
+					ok = 0;
+					error_occurred = 1;
+				} else if (response->errstat == SNMP_ERR_NOERROR) {
 					/* check resulting variables */
 					for (vars = response->variables; vars; vars	= vars->next_variable) {
 						if ((vars->name_length < rootlen) || (memcmp(root, vars->name, rootlen * sizeof(oid)) != 0)) {

--- a/snmp.c
+++ b/snmp.c
@@ -891,6 +891,7 @@ int snmp_count(host_t *current_host, const char *snmp_oid) {
 			if (status == STAT_SUCCESS) {
 				if (response == NULL) {
 					SPINE_LOG(("ERROR: An internal Net-Snmp error condition detected in Cacti snmp_count"));
+					status = STAT_ERROR;
 					ok = 0;
 					error_occurred = 1;
 				} else if (response->errstat == SNMP_ERR_NOERROR) {

--- a/spine.c
+++ b/spine.c
@@ -419,11 +419,11 @@ int main(int argc, char *argv[]) {
 			char *setting = getarg(opt, &argv);
 			char *value   = strchr(setting, ':');
 
-			if (*value) {
-				*value++ = '\0';
-			} else {
+			if (value == NULL) {
 				die("ERROR: -O requires setting:value");
 			}
+
+			*value++ = '\0';
 
 			set_option(setting, value);
 		}
@@ -766,6 +766,11 @@ int main(int argc, char *argv[]) {
 
 		if (change_host) {
 			mysql_row       = mysql_fetch_row(result);
+
+			if (mysql_row == NULL) {
+				break;
+			}
+
 			host_id         = atoi(mysql_row[0]);
 			device_threads  = atoi(mysql_row[1]);
 			current_thread  = 1;
@@ -788,7 +793,7 @@ int main(int argc, char *argv[]) {
 			tresult   = db_query(&mysql, LOCAL, querybuf);
 			mysql_row = mysql_fetch_row(tresult);
 
-			total_items = atoi(mysql_row[0]);
+			total_items = (mysql_row != NULL) ? atoi(mysql_row[0]) : 0;
 			db_free_result(tresult);
 
 			if (total_items && total_items < device_threads) {
@@ -812,7 +817,7 @@ int main(int argc, char *argv[]) {
 				tresult   = db_query(&mysql, LOCAL, querybuf);
 				mysql_row = mysql_fetch_row(tresult);
 
-				items_per_thread = atoi(mysql_row[0]);
+				items_per_thread = (mysql_row != NULL) ? atoi(mysql_row[0]) : 0;
 
 				db_free_result(tresult);
 
@@ -827,7 +832,7 @@ int main(int argc, char *argv[]) {
 			tresult   = db_query(&mysql, LOCAL, querybuf);
 			mysql_row = mysql_fetch_row(tresult);
 
-			items_per_thread = atoi(mysql_row[0]);
+			items_per_thread = (mysql_row != NULL) ? atoi(mysql_row[0]) : 0;
 
 			db_free_result(tresult);
 

--- a/tests/regression/test_child_process_safety.sh
+++ b/tests/regression/test_child_process_safety.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+grep -q '#include <fcntl.h>' common.h ||
+	fail "common.h must include fcntl.h for FD_CLOEXEC helpers"
+
+grep -q 'FD_CLOEXEC' php.c ||
+	fail "php.c must set close-on-exec on script-server pipe fds"
+
+grep -q 'FD_CLOEXEC' nft_popen.c ||
+	fail "nft_popen.c must set close-on-exec on popen pipe fds"
+
+grep -q 'php_set_pipe_cloexec(cacti2php_pdes)' php.c ||
+	fail "php.c must protect cacti-to-php pipe fds with close-on-exec"
+
+grep -q 'php_set_pipe_cloexec(php2cacti_pdes)' php.c ||
+	fail "php.c must protect php-to-cacti pipe fds with close-on-exec"
+
+grep -q 'set_pipe_cloexec(pdes)' nft_popen.c ||
+	fail "nft_popen.c must protect popen pipe fds with close-on-exec"
+
+grep -q 'waitpid(pid, pstat, WNOHANG)' nft_popen.c ||
+	fail "nft_popen.c must reap child processes with WNOHANG"
+
+grep -q 'kill(cur->pid, SIGKILL)' nft_popen.c ||
+	fail "nft_popen.c must escalate timed-out child reaping to SIGKILL"
+
+if grep -q 'waitpid(cur->pid, &pstat, 0)' nft_popen.c; then
+	fail "nft_popen.c must not use blocking waitpid() in nft_pclose"
+fi
+
+if grep -q 'waitpid(phpp->php_pid, &wstatus, 0)' php.c; then
+	fail "php.c must not use blocking waitpid() in php_close"
+fi
+
+echo "PASS: child process safety invariants"

--- a/util.c
+++ b/util.c
@@ -447,8 +447,13 @@ void read_config_options(void) {
 		set.log_datetime_separator = atoi(res);
 		free(res);
 
-		if (set.log_datetime_separator < GDC_MIN || set.log_datetime_separator > GDC_MAX) {
-			set.log_datetime_separator = GDC_DEFAULT;
+	/* get log date format */
+	if ((res = getsetting(&mysql, LOCAL, "default_dateformat")) != 0) {
+		set.log_datetime_format = atoi(res);
+		free((char *)res);
+
+		if (set.log_datetime_format < GD_MIN || set.log_datetime_format > GD_MAX) {
+			set.log_datetime_format = GD_DEFAULT;
 		}
 	}
 
@@ -1282,18 +1287,25 @@ char *get_date_format(void) {
 	switch (set.log_datetime_format) {
 		case GD_MO_D_Y:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%m%c%%d%c%%Y %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_MN_D_Y:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%b%c%%d%c%%Y %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_D_MO_Y:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%d%c%%m%c%%Y %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_D_MN_Y:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%d%c%%b%c%%Y %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_Y_MO_D:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%Y%c%%m%c%%d %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		case GD_Y_MN_D:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%Y%c%%b%c%%d %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 		default:
 			snprintf(log_fmt, GD_FMT_SIZE, "%%Y%c%%m%c%%d %%H:%%M:%%S - ", log_sep, log_sep);
+			break;
 	}
 
 	return (log_fmt);

--- a/util.c
+++ b/util.c
@@ -442,11 +442,6 @@ void read_config_options(void) {
 		}
 	}
 
-	/* get log separator */
-	if ((res = getsetting(&mysql, LOCAL, "default_datechar")) != 0) {
-		set.log_datetime_separator = atoi(res);
-		free(res);
-
 	/* get log date format */
 	if ((res = getsetting(&mysql, LOCAL, "default_date_format")) != 0) {
 		set.log_datetime_format = atoi(res);

--- a/util.c
+++ b/util.c
@@ -448,7 +448,7 @@ void read_config_options(void) {
 		free(res);
 
 	/* get log date format */
-	if ((res = getsetting(&mysql, LOCAL, "default_dateformat")) != 0) {
+	if ((res = getsetting(&mysql, LOCAL, "default_date_format")) != 0) {
 		set.log_datetime_format = atoi(res);
 		free((char *)res);
 

--- a/util.c
+++ b/util.c
@@ -60,6 +60,10 @@ static struct {
  *
  */
 void set_option(const char *option, const char *value) {
+	if (nopts >= (int)(sizeof(opttable) / sizeof(opttable[0]))) {
+		die("ERROR: Too many command-line options specified");
+	}
+
 	opttable[nopts  ].opt = option;
 	opttable[nopts++].val = value;
 }


### PR DESCRIPTION
Forward-port of the applicable fixes from #544, rebuilt on develop rather than carried across, so the obsolete release and CI history in #544 is left behind. 12 files, +269/-38.

**Out-of-bounds reads and writes**

- `ping.c` (`ping_icmp`): a raw-socket reply was cast to `struct ip` and the ICMP header located at `ip_hl << 2` with no length check, so a short or malformed reply read past `socket_reply`. The reply is now dropped unless it holds a full IP header, the computed header length is at least `sizeof(struct ip)`, and the buffer reaches the end of the ICMP header.
- `php.c` (`php_readpipe`): the read size was `RESULTS_BUFFER - (bptr - result_string)`, so a script server result that exactly fills the buffer puts the terminator one byte past it. The capacity now reserves the terminator, and an over-long result logs and returns undefined instead of truncating into the write. Offset arithmetic moved to `ssize_t`/`size_t` so it stays width-safe on LP64. (issue#561)
- `util.c` (`set_option`): `nopts` indexed `opttable` with no bound, so enough `-O` arguments walked off the end of the table. It now dies with an error.

**NULL dereferences**

- `spine.c`: `-O` parsing dereferenced the result of `strchr(setting, ':')` before testing it, so `spine -O foo` crashed instead of printing the usage error.
- `spine.c`: four `mysql_fetch_row()` results reached `atoi(row[0])` unchecked. The device loop breaks on NULL and the three count queries fall back to 0.
- `snmp.c` (`snmp_count`): `response->errstat` was read whenever the status came back `STAT_SUCCESS`, but Net-SNMP can report success with a NULL response. That case is now logged and the device treated as an error.
- `poller.c` (`poll_host`): the `poller_items` and `snmp_oids` allocations were used without checking `calloc()`. Both `die()` on failure now, matching the rest of the file.

**Shutdown could hang forever**

`php_close()` and `nft_pclose()` both reaped with a blocking `waitpid(pid, &status, 0)`. A wedged script server or command child held the caller in that call with no way out. Both now poll with `WNOHANG` for five seconds after `SIGTERM`, escalate to `SIGKILL`, wait one more second, then give up with a logged warning (`ETIMEDOUT` out of `nft_pclose`). `php_close()` also clears `php_pid` afterwards. This is the TODO that sat in `php.c` describing exactly this problem.

`error.c`: the `SIGSEGV` handler called `exit(1)`, running atexit handlers and stdio flushing inside an already-corrupt process. It calls `_exit(1)` now.

**Descriptors leaking into children**

The script server pipes (both directions) and the `nft_popen` pipe were created without `FD_CLOEXEC`, so every subsequent `exec` inherited them. All four are marked close-on-exec at creation, and the partially-created pipes are closed on the failure paths. `fcntl.h` added to `common.h`.

**The log date format never took effect**

`get_date_format()` was missing `break` in all six `switch` cases, so every configured format fell through to the default and Spine always logged `%Y-%m-%d`. `read_config_options()` was also reading only `default_datechar` into `log_datetime_separator`; it now reads `default_date_format` into `log_datetime_format` with `GD_*` bounds as well. Both were needed before the setting could do anything.

**Tests and CI**

`tests/regression/test_child_process_safety.sh` asserts the close-on-exec and non-blocking-reap invariants, so the blocking `waitpid` cannot come back unnoticed. CI now also runs on `1.2.x`.
