### PR TITLE
build: run the unit tests under make check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get install -y \
           mysql-server libmysqlclient-dev \
           libsnmp-dev libssl-dev build-essential \
-          help2man autoconf automake libtool dos2unix
+          help2man autoconf automake libtool dos2unix libcmocka-dev
 
       - name: Prepare for Spine Build
         run: |
@@ -42,6 +42,11 @@ jobs:
       - name: Build Spine
         run: |
           make -j"$(nproc)"
+
+      - name: Run the unit tests
+        run: |
+          set -euo pipefail
+          make check
 
 #  cppcheck:
 #    runs-on: ubuntu-latest
@@ -114,7 +119,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y clang mysql-server libmysqlclient-dev libsnmp-dev \
-            libssl-dev build-essential help2man autoconf automake libtool dos2unix
+            libssl-dev build-essential help2man autoconf automake libtool dos2unix libcmocka-dev
 
       - name: Build with ASan and UBSan
         env:
@@ -148,7 +153,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y mysql-server libmysqlclient-dev libsnmp-dev \
-            libssl-dev build-essential help2man autoconf automake libtool dos2unix
+            libssl-dev build-essential help2man autoconf automake libtool dos2unix libcmocka-dev
 
       - name: make distcheck
         run: |

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,3 +55,27 @@ cppcheck: docker-dev
 		"cppcheck --enable=all --std=c11 --error-exitcode=1 \
 		--suppress=missingIncludeSystem --suppress=unusedFunction \
 		--suppress=checkersReport --suppress=toomanyconfigs $(spine_SOURCES)"
+
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)
+
+check_PROGRAMS =
+
+if HAVE_CMOCKA
+check_PROGRAMS += \
+	tests/unit/test_util_strings \
+	tests/unit/test_build_fixes \
+	tests/unit/test_safety_fixes
+endif
+
+# test_util_strings pulls in common.h and the sources under test, so it needs
+# the same libraries spine links against.  The other two are self-contained.
+tests_unit_test_util_strings_SOURCES = tests/unit/test_util_strings.c
+tests_unit_test_util_strings_LDADD   = $(CMOCKA_LIBS) $(LIBS)
+
+tests_unit_test_build_fixes_SOURCES  = tests/unit/test_build_fixes.c
+tests_unit_test_build_fixes_LDADD    = $(CMOCKA_LIBS)
+
+tests_unit_test_safety_fixes_SOURCES = tests/unit/test_safety_fixes.c
+tests_unit_test_safety_fixes_LDADD   = $(CMOCKA_LIBS)
+
+TESTS = $(check_PROGRAMS)

--- a/configure.ac
+++ b/configure.ac
@@ -505,5 +505,24 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   ],[AC_MSG_RESULT(no)
 ])
 
+# cmocka is only used by the unit tests under "make check".  Absence is not
+# fatal; the tests are dropped from check_PROGRAMS instead.
+have_cmocka=no
+AC_CHECK_LIB([cmocka], [_cmocka_run_group_tests], [have_cmocka=yes])
+if test "x$have_cmocka" = xyes; then
+  AC_CHECK_HEADER([cmocka.h], [], [have_cmocka=no], [[
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+  ]])
+fi
+
+CMOCKA_LIBS=
+if test "x$have_cmocka" = xyes; then
+  CMOCKA_LIBS=-lcmocka
+fi
+AC_SUBST(CMOCKA_LIBS)
+AM_CONDITIONAL([HAVE_CMOCKA], [test "x$have_cmocka" = xyes])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
The suite that landed in #563 is built by its own `tests/unit/Makefile` and executed by nothing. `Makefile.am` has no `check_PROGRAMS`, `configure.ac` has no cmocka detection, and no workflow invokes it. So `make check` is a no-op today, and `make distcheck` from #556 validates only that the tarball builds.

This wires the three binaries in:

- `configure.ac` probes for `-lcmocka` and `cmocka.h` and defines `HAVE_CMOCKA`
- `Makefile.am` lists the three as `check_PROGRAMS` and sets `TESTS`
- the `build` job runs `make check`, and `libcmocka-dev` is added where the workflow needs it

Verified in a clean `ubuntu:24.04` container.

```
PASS: tests/unit/test_util_strings
PASS: tests/unit/test_build_fixes
PASS: tests/unit/test_safety_fixes
# TOTAL: 3   # PASS: 3   # FAIL: 0
```

`make distcheck` still passes, so the test sources are distributed correctly.

Absence of cmocka is not fatal. Building without `libcmocka-dev` installed:

```
configure OK without cmocka
build OK without cmocka
# TOTAL: 0   # PASS: 0   # FAIL: 0
make check exit: 0
```

The tests drop out of `check_PROGRAMS` rather than breaking the build, which matters for platforms where cmocka is not packaged.