### PR TITLE
fix: memory-safety and polling correctness backports for 1.2.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 The Cacti Group | spine
 
+1.2.32
+-issue#447: Correct off-by-one OOB write in strncopy() when src fills the buffer
+-issue#561: Reserve room for the terminator in php_readpipe() so a full script server result cannot write past result_string
+-issue#562: Escalate PHP script server shutdown to SIGKILL after a bounded grace period so a stuck child is not orphaned
+-issue#573: Copy the hostname in get_namebyhost() so transport and port parsing runs, and tokenise reentrantly
+
 1.2.31
 -issue#365: Removed Backtrace Support due to lack of OS support
 -issue#366: Prevent polling from stopping when sysDescr OID returns noSuchObject

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,11 +3,13 @@ The Cacti Group | spine
 1.2.32
 -issue#447: Correct off-by-one OOB write in strncopy() when src fills the buffer
 -issue#561: Reserve room for the terminator in php_readpipe() so a full script server result cannot write past result_string
--issue#562: Escalate PHP script server shutdown to SIGKILL after a bounded grace period so a stuck child is not orphaned
--issue#573: Copy the hostname in get_namebyhost() so transport and port parsing runs, and tokenise reentrantly
+-issue#562: Batch PHP script server shutdown and retain unreaped child PIDs for later cleanup
+-issue#573: Preserve complete hostnames, including bare IPv6 literals, instead of running dead host:port parsing
 -issue#564: Check the remaining calloc() results in spine.c before they are dereferenced
 -issue#565: Keep the appended newline inside flogmessage when the log line fills LOGSIZE
 -issue#566: Free the result set when the settings helpers fetch no row
+-issue: Validate ICMP packet bounds and correlate echo replies before reporting a host up
+-issue: Stop snmp_count() after an internal Net-SNMP error instead of repeating GETNEXT indefinitely
 
 1.2.31
 -issue#365: Removed Backtrace Support due to lack of OS support

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ The Cacti Group | spine
 -issue#561: Reserve room for the terminator in php_readpipe() so a full script server result cannot write past result_string
 -issue#562: Escalate PHP script server shutdown to SIGKILL after a bounded grace period so a stuck child is not orphaned
 -issue#573: Copy the hostname in get_namebyhost() so transport and port parsing runs, and tokenise reentrantly
+-issue#564: Check the remaining calloc() results in spine.c before they are dereferenced
+-issue#565: Keep the appended newline inside flogmessage when the log line fills LOGSIZE
+-issue#566: Free the result set when the settings helpers fetch no row
 
 1.2.31
 -issue#365: Removed Backtrace Support due to lack of OS support

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,8 @@ AC_CONFIG_SRCDIR(spine.c)
 AC_PREFIX_DEFAULT(/usr/local/spine)
 AC_LANG(C)
 AC_PROG_CC
+AC_CHECK_FUNCS([pipe2])
+AC_CHECK_DECLS([SOCK_CLOEXEC], [], [], [[#include <sys/socket.h>]])
 
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_HEADERS(config/config.h)

--- a/error.c
+++ b/error.c
@@ -105,6 +105,9 @@ static int spine_fatal_signals[] = {
 	0
 };
 
+static struct sigaction previous_sigchld;
+static int previous_sigchld_saved = FALSE;
+
 /*! \fn void install_spine_signal_handler(void)
  *  \brief installs the spine signal handler to stop certain calls from
  *         abending Spine.
@@ -115,6 +118,17 @@ void install_spine_signal_handler(void) {
 	int i;
 	struct sigaction sa;
 	void (*ohandler)(int);
+
+	/* Child lifecycle code retains PIDs until waitpid() reaps them.  Normalize
+	 * an inherited SIG_IGN disposition so children remain zombies and their
+	 * PIDs cannot be recycled before Spine observes their exit. */
+	if (sigaction(SIGCHLD, NULL, &previous_sigchld) == 0) {
+		previous_sigchld_saved = TRUE;
+	}
+	sa.sa_handler = SIG_DFL;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sigaction(SIGCHLD, &sa, NULL);
 
 	for (i=0; spine_fatal_signals[i]; ++i) {
 		sigaction(spine_fatal_signals[i], NULL, &sa);
@@ -145,6 +159,11 @@ void uninstall_spine_signal_handler(void) {
 	int i;
 	struct sigaction sa;
 	void (*ohandler)(int);
+
+	if (previous_sigchld_saved) {
+		sigaction(SIGCHLD, &previous_sigchld, NULL);
+		previous_sigchld_saved = FALSE;
+	}
 
 	for (i=0; spine_fatal_signals[i]; ++i) {
 		sigaction(spine_fatal_signals[i], NULL, &sa);

--- a/locks.c
+++ b/locks.c
@@ -71,6 +71,7 @@ DEFINE_SPINE_LOCK(php_proc_13)
 DEFINE_SPINE_LOCK(php_proc_14)
 DEFINE_SPINE_LOCK(thdet)
 DEFINE_SPINE_LOCK(host_time)
+DEFINE_SPINE_LOCK(fork)
 
 void init_mutexes() {
 	pthread_once((pthread_once_t*) get_attr(LOCK_SNMP_O),        init_snmp_lock);
@@ -95,6 +96,7 @@ void init_mutexes() {
 	pthread_once((pthread_once_t*) get_attr(LOCK_PHP_PROC_14_O), init_php_proc_14_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_THDET_O),       init_thdet_lock);
 	pthread_once((pthread_once_t*) get_attr(LOCK_HOST_TIME_O),   init_host_time_lock);
+	pthread_once((pthread_once_t*) get_attr(LOCK_FORK_O),        init_fork_lock);
 }
 
 const char* get_name(int lock) {
@@ -121,6 +123,7 @@ const char* get_name(int lock) {
 		case LOCK_PHP_PROC_14: return "php_proc_14";
 		case LOCK_THDET:       return "thdet";
 		case LOCK_HOST_TIME:   return "host_time";
+		case LOCK_FORK:        return "fork";
 	}
 
 	return "Unknown lock";
@@ -152,6 +155,7 @@ pthread_cond_t* get_cond(int lock) {
 		case LOCK_PHP_PROC_14: ret_val = &php_proc_14_cond; break;
 		case LOCK_THDET:       ret_val = &thdet_cond;       break;
 		case LOCK_HOST_TIME:   ret_val = &host_time_cond;   break;
+		case LOCK_FORK:        ret_val = &fork_cond;        break;
 	}
 
 	SPINE_LOG_DEVDBG(("LOCKS: [RET]   Returning cond for %s", get_name(lock)));
@@ -185,6 +189,7 @@ pthread_mutex_t* get_lock(int lock) {
 		case LOCK_PHP_PROC_14: ret_val = &php_proc_14_lock; break;
 		case LOCK_THDET:       ret_val = &thdet_lock;       break;
 		case LOCK_HOST_TIME:   ret_val = &host_time_lock;   break;
+		case LOCK_FORK:        ret_val = &fork_lock;        break;
 	}
 
 	SPINE_LOG_DEVDBG(("LOCKS: [RET]   Returning lock for %s", get_name(lock)));
@@ -218,6 +223,7 @@ pthread_once_t* get_attr(int locko) {
 		case LOCK_PHP_PROC_14_O: ret_val = &php_proc_14_lock_o; break;
 		case LOCK_THDET_O:       ret_val = &thdet_lock_o;       break;
 		case LOCK_HOST_TIME_O:   ret_val = &host_time_lock_o;   break;
+		case LOCK_FORK_O:        ret_val = &fork_lock_o;        break;
 	}
 
 	SPINE_LOG_DEVDBG(("LOCKS: [RET]   Returning attr for %s", get_name(locko)));
@@ -243,4 +249,3 @@ int thread_mutex_trylock(int mutex) {
 	SPINE_LOG_DEVDBG(("LOCKS: [END]   Mutex try lock for %s, result = %d", get_name(mutex), ret_val));
 	return ret_val;
 }
-

--- a/nft_popen.c
+++ b/nft_popen.c
@@ -84,8 +84,42 @@
  * SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
 #include "common.h"
 #include "spine.h"
+#include <fcntl.h>
+
+static int nft_pipe_cloexec(int pipe_fds[2]) {
+	#ifdef HAVE_PIPE2
+	return pipe2(pipe_fds, O_CLOEXEC);
+	#else
+	int flags;
+
+	thread_mutex_lock(LOCK_FORK);
+	if (pipe(pipe_fds) < 0) {
+		thread_mutex_unlock(LOCK_FORK);
+		return -1;
+	}
+	flags = fcntl(pipe_fds[0], F_GETFD);
+	if (flags < 0 || fcntl(pipe_fds[0], F_SETFD, flags | FD_CLOEXEC) < 0) {
+		goto failure;
+	}
+	flags = fcntl(pipe_fds[1], F_GETFD);
+	if (flags < 0 || fcntl(pipe_fds[1], F_SETFD, flags | FD_CLOEXEC) < 0) {
+		goto failure;
+	}
+	thread_mutex_unlock(LOCK_FORK);
+	return 0;
+
+	failure:
+	flags = errno;
+	close(pipe_fds[0]);
+	close(pipe_fds[1]);
+	thread_mutex_unlock(LOCK_FORK);
+	errno = flags;
+	return -1;
+	#endif
+}
 
 /* An instance of this struct is created for each popen() fd. */
 static struct pid
@@ -146,7 +180,7 @@ int nft_popen(const char * command, const char * type) {
 		}
 	}
 
-	if (pipe(pdes) < 0)
+	if (nft_pipe_cloexec(pdes) < 0)
 		return -1;
 
 	/* Disable thread cancellation from this point forward. */
@@ -171,7 +205,12 @@ int nft_popen(const char * command, const char * type) {
 
 	/* Fork. */
 	retry:
-	switch (pid = vfork()) {
+	thread_mutex_lock(LOCK_FORK);
+	pid = vfork();
+	if (pid != 0) {
+		thread_mutex_unlock(LOCK_FORK);
+	}
+	switch (pid) {
 	case -1:		/* Error. */
 		switch (errno) {
 		case EAGAIN:
@@ -185,6 +224,7 @@ int nft_popen(const char * command, const char * type) {
 			}else{
 				SPINE_LOG(("ERROR: SCRIPT: Cound not fork. Out of Resources nft_popen.c"));
 			}
+			break;
 		case ENOMEM:
 			if (retry_count < 3) {
 				retry_count++;
@@ -196,6 +236,7 @@ int nft_popen(const char * command, const char * type) {
 			}else{
 				SPINE_LOG(("ERROR: SCRIPT Cound not fork. Out of Memory nft_popen.c"));
 			}
+			break;
 		default:
 			SPINE_LOG(("ERROR: SCRIPT Cound not fork. Unknown Reason nft_popen.c"));
 		}
@@ -237,6 +278,8 @@ int nft_popen(const char * command, const char * type) {
 		 */
 		for (p = PidList; p; p = p->next)
 			(void)close(p->fd);
+		(void)fcntl(STDIN_FILENO, F_SETFD, 0);
+		(void)fcntl(STDOUT_FILENO, F_SETFD, 0);
 
 		/* Execute the command. */
 		#if defined(__CYGWIN__)
@@ -398,4 +441,3 @@ close_cleanup(void * arg)
 
 	free(cur);
 }
-

--- a/php.c
+++ b/php.c
@@ -503,6 +503,44 @@ int php_init(int php_process) {
 	return TRUE;
 }
 
+static void php_terminate_and_reap(pid_t pid) {
+	int attempts;
+	int phase;
+	int status;
+	int signal_number = SIGTERM;
+	pid_t waited;
+
+	for (phase = 0; phase < 2; phase++) {
+		if (kill(pid, signal_number) < 0 && errno != ESRCH) {
+			SPINE_LOG(("WARNING: Unable to signal PHP Script Server PID[%ld]: %s", (long)pid, strerror(errno)));
+		}
+
+		for (attempts = 0; attempts < 20; attempts++) {
+			do {
+				waited = waitpid(pid, &status, WNOHANG);
+			} while (waited < 0 && errno == EINTR);
+
+			if (waited == pid || (waited < 0 && errno == ECHILD)) {
+				return;
+			}
+
+			if (waited < 0) {
+				SPINE_LOG(("WARNING: Unable to reap PHP Script Server PID[%ld]: %s", (long)pid, strerror(errno)));
+				return;
+			}
+
+			/* The delay is load-bearing: without it both phases burn twenty
+			 * WNOHANG polls in nanoseconds, so SIGKILL lands immediately and
+			 * the child is never reaped. */
+			usleep(50000);
+		}
+
+		signal_number = SIGKILL;
+	}
+
+	SPINE_LOG(("WARNING: PHP Script Server PID[%ld] did not exit after SIGKILL", (long)pid));
+}
+
 /*! \fn void php_close(int php_process)
  *  \brief close the php script server process
  *  \param php_process the process to close or PHP_INIT
@@ -567,10 +605,10 @@ void php_close(int php_process) {
 	 	 * a process group leader), and PID 1 is "init".
 	  	 */
 		if (phpp->php_pid > 1) {
-			/* end the php script server process */
-			kill(phpp->php_pid, SIGTERM);
-
-			/* reset this PID variable? */
+			/* end the php script server process, escalating if it ignores
+			 * SIGTERM, and reap it so it cannot linger as an orphan */
+			php_terminate_and_reap(phpp->php_pid);
+			phpp->php_pid = -1;
 		}
 
 		/* close file descriptors */

--- a/php.c
+++ b/php.c
@@ -527,7 +527,9 @@ static void php_terminate_and_reap(pid_t pid) {
 			/* The delay is load-bearing: without it both phases burn twenty
 			 * WNOHANG polls in nanoseconds, so SIGKILL lands immediately and
 			 * the child is never reaped. */
+			#ifndef SOLAR_THREAD
 			usleep(50000);
+			#endif
 		}
 
 		signal_number = SIGKILL;

--- a/php.c
+++ b/php.c
@@ -255,7 +255,17 @@ char *php_readpipe(int php_process, char *command) {
 			bptr = result_string;
 
 			while (1) {
-				i = read(php_processes[php_process].php_read_fd, bptr, RESULTS_BUFFER-(bptr-result_string));
+				/* reserve one byte for the trailing '\0' written below */
+				size_t used = (size_t)(bptr - result_string);
+
+				if (used >= RESULTS_BUFFER - 1) {
+					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
+					SET_UNDEFINED(result_string);
+					break;
+				}
+
+				size_t avail = (size_t)RESULTS_BUFFER - 1 - used;
+				i = read(php_processes[php_process].php_read_fd, bptr, avail);
 
 				if (i <= 0) {
 					SET_UNDEFINED(result_string);

--- a/php.c
+++ b/php.c
@@ -31,8 +31,105 @@
  +-------------------------------------------------------------------------+
 */
 
+#define _GNU_SOURCE
 #include "common.h"
 #include "spine.h"
+#include <fcntl.h>
+
+static pid_t php_orphan_pids[MAX_PHP_SERVERS];
+static time_t php_retry_after[MAX_PHP_SERVERS];
+static void php_drain_orphans(void);
+static void php_close_internal(int php_process, int send_quit);
+static pid_t php_get_pid(int server);
+static char *php_readpipe_until(int php_process, char *command, double deadline);
+
+static ssize_t php_write_no_sigpipe(int fd, const void *buffer, size_t length) {
+	const char *cursor = buffer;
+	int saved_errno = errno;
+	int sigpipe_was_pending;
+	sigset_t blocked;
+	sigset_t old_mask;
+	sigset_t pending;
+	ssize_t total = 0;
+	ssize_t written = 0;
+
+	sigemptyset(&blocked);
+	sigaddset(&blocked, SIGPIPE);
+	pthread_sigmask(SIG_BLOCK, &blocked, &old_mask);
+	sigpending(&pending);
+	sigpipe_was_pending = sigismember(&pending, SIGPIPE);
+
+	while ((size_t)total < length) {
+		written = write(fd, cursor + total, length - (size_t)total);
+		if (written > 0) {
+			total += written;
+			continue;
+		}
+		if (written < 0 && errno == EINTR) {
+			continue;
+		}
+
+		saved_errno = written == 0 ? EIO : errno;
+		total = -1;
+		break;
+	}
+
+	if (total < 0 && saved_errno == EPIPE && !sigpipe_was_pending) {
+		int received_signal;
+
+		/* Some platforms discard an ignored SIGPIPE instead of queuing it.
+		 * Consume the signal only when the failed write actually made it
+		 * pending, so this cleanup can never block. */
+		sigpending(&pending);
+		if (sigismember(&pending, SIGPIPE)) {
+			sigwait(&blocked, &received_signal);
+		}
+	}
+
+	pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
+	errno = saved_errno;
+
+	return total;
+}
+
+static int php_set_cloexec(int fd) {
+	int flags = fcntl(fd, F_GETFD);
+
+	return flags >= 0 && fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == 0;
+}
+
+static int php_pipe_cloexec(int pipe_fds[2]) {
+	#ifdef HAVE_PIPE2
+	return pipe2(pipe_fds, O_CLOEXEC);
+	#else
+	thread_mutex_lock(LOCK_FORK);
+	if (pipe(pipe_fds) < 0) {
+		thread_mutex_unlock(LOCK_FORK);
+		return -1;
+	}
+	if (!php_set_cloexec(pipe_fds[0]) || !php_set_cloexec(pipe_fds[1])) {
+		int saved_errno = errno;
+		close(pipe_fds[0]);
+		close(pipe_fds[1]);
+		thread_mutex_unlock(LOCK_FORK);
+		errno = saved_errno;
+		return -1;
+	}
+	thread_mutex_unlock(LOCK_FORK);
+	return 0;
+	#endif
+}
+
+static void php_set_state(int php_process, int state) {
+	thread_mutex_lock(LOCK_PHP);
+	php_processes[php_process].php_state = state;
+	if (state == PHP_READY) {
+		php_retry_after[php_process] = 0;
+	} else {
+		php_retry_after[php_process] = time(NULL) + 30;
+	}
+	thread_mutex_unlock(LOCK_PHP);
+}
 
 /*! \fn char *php_cmd(const char *php_command, int php_process)
  *  \brief calls the script server and executes a script command
@@ -51,6 +148,7 @@ char *php_cmd(const char *php_command, int php_process) {
 	char *result_string;
 	char command[BUFSIZE];
 	ssize_t bytes;
+	int write_fd;
 	int retries = 0;
 
 	assert(php_command != 0);
@@ -79,18 +177,24 @@ char *php_cmd(const char *php_command, int php_process) {
 
 	/* send command to the script server */
 	retry:
-	bytes = write(php_processes[php_process].php_write_fd, command, strlen(command));
+	thread_mutex_lock(LOCK_PHP);
+	write_fd = php_processes[php_process].php_write_fd;
+	thread_mutex_unlock(LOCK_PHP);
+	bytes = php_write_no_sigpipe(write_fd, command, strlen(command));
 
 	/* if write status is <= 0 then the script server may be hung */
 	if (bytes <= 0) {
-		result_string = strdup("U");
+		STRDUP_OR_DIE(result_string, "U", "php_cmd result");
 		SPINE_LOG(("ERROR: SS[%i] PHP Script Server communications lost sending Command[%s].  Restarting PHP Script Server", php_process, command));
 
 		php_close(php_process);
-		php_init(php_process);
+		if (!php_init(php_process)) {
+			retries = 3;
+		}
 		/* increment and retry a few times on the next item */
 		retries++;
 		if (retries < 3) {
+			SPINE_FREE(result_string);
 			goto retry;
 		}
 	} else {
@@ -128,21 +232,47 @@ char *php_cmd(const char *php_command, int php_process) {
 /*!  \fn in php_get_process()
  *  \brief returns the next php script server process to utilize
  *
- *  This very simple function simply returns the next PHP Script Server
- *  process id to poll using a round robin algorithm.
+ *  Returns the next ready PHP Script Server using round robin. Busy slots are
+ *  skipped while another ready server is available.
  *
- *  \return the integer number of the next script server to use
+ *  \return the next ready script server, or -1 when the pool is unavailable
  *
  */
 int php_get_process(void) {
-	int i;
+	int attempts;
+	int i = -1;
+	time_t now = time(NULL);
 
 	thread_mutex_lock(LOCK_PHP);
-	if (set.php_current_server >= set.php_servers) {
-		set.php_current_server = 0;
+	for (attempts = 0; attempts < set.php_servers; attempts++) {
+		if (set.php_current_server >= set.php_servers) {
+			set.php_current_server = 0;
+		}
+
+		i = set.php_current_server++;
+		if (php_processes[i].php_state == PHP_READY) {
+			break;
+		}
+		i = -1;
 	}
-	i = set.php_current_server;
-	set.php_current_server++;
+
+	/* Give unavailable slots a bounded route back without attempting a
+	 * fork/exec for every script-server item in the cycle.  php_cmd() will
+	 * exercise the established close/restart path for the selected slot. */
+	if (i < 0 && set.php_initialized) {
+		for (attempts = 0; attempts < set.php_servers; attempts++) {
+			if (set.php_current_server >= set.php_servers) {
+				set.php_current_server = 0;
+			}
+
+			i = set.php_current_server++;
+			if (php_retry_after[i] <= now) {
+				php_retry_after[i] = now + 30;
+				break;
+			}
+			i = -1;
+		}
+	}
 	thread_mutex_unlock(LOCK_PHP);
 
 	return i;
@@ -160,6 +290,10 @@ int php_get_process(void) {
  *  \return a string pointer to the PHP Script Server response
  */
 char *php_readpipe(int php_process, char *command) {
+	return php_readpipe_until(php_process, command, get_time_as_double() + set.script_timeout);
+}
+
+static char *php_readpipe_until(int php_process, char *command, double deadline) {
 	fd_set fds;
 	struct timeval timeout;
 	double begin_time = 0;
@@ -168,6 +302,9 @@ char *php_readpipe(int php_process, char *command) {
 	char *result_string;
 
 	int  i;
+	int  read_fd;
+	int  reset_server = FALSE;
+	int  send_quit = TRUE;
 	char *cp;
 	char *bptr;
 
@@ -176,12 +313,28 @@ char *php_readpipe(int php_process, char *command) {
 	}
 	result_string[0] = '\0';
 
+	thread_mutex_lock(LOCK_PHP);
+	read_fd = php_processes[php_process].php_read_fd;
+	thread_mutex_unlock(LOCK_PHP);
+	if (read_fd < 0) {
+		SET_UNDEFINED(result_string);
+		php_close_internal(php_process, FALSE);
+		if (strcmp(command, "INIT") != 0) {
+			php_init(php_process);
+		}
+		return result_string;
+	}
+
 	/* record start time */
 	begin_time = get_time_as_double();
 
 	/* establish timeout value for the PHP script server to respond */
-	timeout.tv_sec = set.script_timeout;
-	timeout.tv_usec = 0;
+	remaining_usec = deadline - begin_time;
+	if (remaining_usec < 0) {
+		remaining_usec = 0;
+	}
+	timeout.tv_sec = (int)remaining_usec;
+	timeout.tv_usec = (int)((remaining_usec - timeout.tv_sec) * 1000000);
 
 	/* check to see which pipe talked and take action
 	 * should only be the READ pipe */
@@ -189,9 +342,9 @@ char *php_readpipe(int php_process, char *command) {
 
 	/* initialize file descriptors to review for input/output */
 	FD_ZERO(&fds);
-	FD_SET(php_processes[php_process].php_read_fd,&fds);
+	FD_SET(read_fd,&fds);
 
-	switch (select(php_processes[php_process].php_read_fd+1, &fds, NULL, NULL, &timeout)) {
+	switch (select(read_fd+1, &fds, NULL, NULL, &timeout)) {
 	case -1:
 		switch (errno) {
 			case EBADF:
@@ -207,14 +360,12 @@ char *php_readpipe(int php_process, char *command) {
 				end_time = get_time_as_double();
 
 				/* re-establish new timeout value */
-				timeout.tv_sec  = rint(floor(set.script_timeout-(end_time-begin_time)));
-				remaining_usec  = set.script_timeout - timeout.tv_sec - (end_time - begin_time);
-
-				if (remaining_usec > 0) {
-					timeout.tv_usec = rint(remaining_usec * 1000000);
-				} else {
-					timeout.tv_usec = 0;
+				remaining_usec = deadline - end_time;
+				if (remaining_usec < 0) {
+					remaining_usec = 0;
 				}
+				timeout.tv_sec = (int)remaining_usec;
+				timeout.tv_usec = (int)((remaining_usec - timeout.tv_sec) * 1000000);
 
 				if (timeout.tv_sec + timeout.tv_usec > 0) {
 					goto retry;
@@ -238,7 +389,9 @@ char *php_readpipe(int php_process, char *command) {
 
 		/* kill script server because it is misbehaving */
 		php_close(php_process);
-		php_init(php_process);
+		if (strcmp(command, "INIT") != 0) {
+			php_init(php_process);
+		}
 		break;
 	case 0:
 		/* record end time */
@@ -248,27 +401,68 @@ char *php_readpipe(int php_process, char *command) {
 
 		/* kill script server because it is misbehaving */
 		php_close(php_process);
-		php_init(php_process);
+		if (strcmp(command, "INIT") != 0) {
+			php_init(php_process);
+		}
 		break;
 	default:
-		if (FD_ISSET(php_processes[php_process].php_read_fd, &fds)) {
+		if (FD_ISSET(read_fd, &fds)) {
 			bptr = result_string;
 
 			while (1) {
+				size_t avail;
+				size_t used;
+
 				/* reserve one byte for the trailing '\0' written below */
-				size_t used = (size_t)(bptr - result_string);
+				used = (size_t)(bptr - result_string);
 
 				if (used >= RESULTS_BUFFER - 1) {
 					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
 					SET_UNDEFINED(result_string);
+					reset_server = TRUE;
 					break;
 				}
 
-				size_t avail = (size_t)RESULTS_BUFFER - 1 - used;
-				i = read(php_processes[php_process].php_read_fd, bptr, avail);
+				/* A newline may require multiple reads.  Re-check readability
+				 * against the original command deadline before every one so a
+				 * partial line cannot hold this worker indefinitely. */
+				end_time = get_time_as_double();
+				remaining_usec = deadline - end_time;
+				if (remaining_usec <= 0) {
+					SPINE_LOG(("WARNING: SS[%i] The PHP Script Server stalled during a partial response", php_process));
+					SET_UNDEFINED(result_string);
+					reset_server = TRUE;
+					break;
+				}
+
+				timeout.tv_sec = (int)remaining_usec;
+				timeout.tv_usec = (int)((remaining_usec - timeout.tv_sec) * 1000000);
+				FD_ZERO(&fds);
+				FD_SET(read_fd, &fds);
+				i = select(read_fd + 1, &fds, NULL, NULL, &timeout);
+				if (i < 0 && errno == EINTR) {
+					continue;
+				}
+				if (i <= 0 || !FD_ISSET(read_fd, &fds)) {
+					SPINE_LOG(("WARNING: SS[%i] The PHP Script Server did not complete its response", php_process));
+					SET_UNDEFINED(result_string);
+					reset_server = TRUE;
+					break;
+				}
+
+				avail = (size_t)RESULTS_BUFFER - 1 - used;
+				i = read(read_fd, bptr, avail);
+
+				if (i < 0 && errno == EINTR) {
+					continue;
+				}
 
 				if (i <= 0) {
 					SET_UNDEFINED(result_string);
+					reset_server = TRUE;
+					if (i == 0) {
+						send_quit = FALSE;
+					}
 					break;
 				}
 
@@ -282,9 +476,20 @@ char *php_readpipe(int php_process, char *command) {
 		} else {
 			SPINE_LOG(("ERROR: SS[%i] The FD was not set as expected", php_process));
 			SET_UNDEFINED(result_string);
+			reset_server = TRUE;
 		}
 
-		php_processes[php_process].php_state = PHP_READY;
+		if (reset_server) {
+			/* The unread tail belongs to this response.  Reusing the pipe would
+			 * return it as the next command's result, so discard the process and
+			 * start with a fresh protocol stream. */
+			php_close_internal(php_process, send_quit);
+			if (strcmp(command, "INIT") != 0) {
+				php_init(php_process);
+			}
+		} else if (strcmp(command, "INIT") != 0) {
+			php_set_state(php_process, PHP_READY);
+		}
 	}
 
 	return result_string;
@@ -312,8 +517,19 @@ int php_init(int php_process) {
 	char *result_string = 0;
 	int num_processes;
 	int i;
+	int ready_count = 0;
 	int retry_count = 0;
-	char *command = strdup("INIT");
+	char *command;
+
+	/* php_init(PHP_INIT) runs before the main initialization block.  The
+	 * pthread_once-backed initializer is idempotent and makes the orphan-list
+	 * lock available both here and in later per-server restarts. */
+	init_mutexes();
+	command = strdup("INIT");
+	if (command == NULL) {
+		die("ERROR: Fatal malloc error: php.c php_init command!");
+	}
+	php_drain_orphans();
 
 	/* special code to start all PHP Servers */
 	if (php_process == PHP_INIT) {
@@ -323,17 +539,41 @@ int php_init(int php_process) {
 	}
 
 	for (i=0; i < num_processes; i++) {
-		SPINE_LOG_DEBUG(("DEBUG: SS[%i] PHP Script Server Routine Starting", i));
+		double handshake_deadline;
+		int handshake_lines;
+		int server = (php_process == PHP_INIT) ? i : php_process;
+		retry_count = 0;
+		if (php_get_pid(server) > 1) {
+			SPINE_LOG(("WARNING: SS[%i] Refusing to replace an unreaped PHP Script Server", server));
+			php_set_state(server, PHP_BUSY);
+			if (php_process == PHP_INIT) {
+				continue;
+			}
+			SPINE_FREE(command);
+			return FALSE;
+		}
+
+		SPINE_LOG_DEBUG(("DEBUG: SS[%i] PHP Script Server Routine Starting", server));
 
 		/* create the output pipes from Spine to php*/
-		if (pipe(cacti2php_pdes) < 0) {
-			SPINE_LOG(("ERROR: SS[%i] Could not allocate php server pipes", i));
+		if (php_pipe_cloexec(cacti2php_pdes) < 0) {
+			SPINE_LOG(("ERROR: SS[%i] Could not allocate php server pipes", server));
+			if (php_process == PHP_INIT) {
+				continue;
+			}
+			SPINE_FREE(command);
 			return FALSE;
 		}
 
 		/* create the input pipes from php to Spine */
-		if (pipe(php2cacti_pdes) < 0) {
-			SPINE_LOG(("ERROR: SS[%i] Could not allocate php server pipes", i));
+		if (php_pipe_cloexec(php2cacti_pdes) < 0) {
+			SPINE_LOG(("ERROR: SS[%i] Could not allocate php server pipes", server));
+			close(cacti2php_pdes[0]);
+			close(cacti2php_pdes[1]);
+			if (php_process == PHP_INIT) {
+				continue;
+			}
+			SPINE_FREE(command);
 			return FALSE;
 		}
 
@@ -378,11 +618,15 @@ int php_init(int php_process) {
 		}
 
 		/* fork a child process */
-		SPINE_LOG_DEBUG(("DEBUG: SS[%i] PHP Script Server About to FORK Child Process", i));
+		SPINE_LOG_DEBUG(("DEBUG: SS[%i] PHP Script Server About to FORK Child Process", server));
 
 		retry:
 
+		thread_mutex_lock(LOCK_FORK);
 		pid = vfork();
+		if (pid != 0) {
+			thread_mutex_unlock(LOCK_FORK);
+		}
 
 		/* check the pid status and process as required */
 		switch (pid) {
@@ -397,8 +641,9 @@ int php_init(int php_process) {
 						#endif
 						goto retry;
 					} else {
-						SPINE_LOG(("ERROR: SS[%i] Could not fork PHP Script Server Out of Resources", i));
+						SPINE_LOG(("ERROR: SS[%i] Could not fork PHP Script Server Out of Resources", server));
 					}
+					break;
 				case ENOMEM:
 					if (retry_count < 3) {
 						retry_count++;
@@ -408,10 +653,11 @@ int php_init(int php_process) {
 						#endif
 						goto retry;
 					} else {
-						SPINE_LOG(("ERROR: SS[%i] Could not fork PHP Script Server Out of Memory", i));
+						SPINE_LOG(("ERROR: SS[%i] Could not fork PHP Script Server Out of Memory", server));
 					}
+					break;
 				default:
-					SPINE_LOG(("ERROR: SS[%i] Could not fork PHP Script Server Unknown Reason", i));
+					SPINE_LOG(("ERROR: SS[%i] Could not fork PHP Script Server Unknown Reason", server));
 				}
 
 				close(php2cacti_pdes[0]);
@@ -419,8 +665,12 @@ int php_init(int php_process) {
 				close(cacti2php_pdes[0]);
 				close(cacti2php_pdes[1]);
 
-				SPINE_LOG(("ERROR: SS[%i] Could not fork PHP Script Server", i));
+				SPINE_LOG(("ERROR: SS[%i] Could not fork PHP Script Server", server));
 				pthread_setcancelstate(cancel_state, NULL);
+				if (php_process == PHP_INIT) {
+					continue;
+				}
+				SPINE_FREE(command);
 
 				return FALSE;
 				/* NOTREACHED */
@@ -428,6 +678,8 @@ int php_init(int php_process) {
 				/* set the standard input/output channels of the new process.  */
 				dup2(cacti2php_pdes[0], STDIN_FILENO);
 				dup2(php2cacti_pdes[1], STDOUT_FILENO);
+				fcntl(STDIN_FILENO, F_SETFD, 0);
+				fcntl(STDOUT_FILENO, F_SETFD, 0);
 
 				/* close unneeded Pipes */
 				(void)close(php2cacti_pdes[0]);
@@ -440,7 +692,7 @@ int php_init(int php_process) {
 				_exit(127);
 				/* NOTREACHED */
 			default: /* I am the parent process */
-				SPINE_LOG_DEBUG(("DEBUG: SS[%i] PHP Script Server Child FORK Success", i));
+				SPINE_LOG_DEBUG(("DEBUG: SS[%i] PHP Script Server Child FORK Success", server));
 		}
 
 		/* Parent */
@@ -448,94 +700,211 @@ int php_init(int php_process) {
 		close(cacti2php_pdes[0]);
 		close(php2cacti_pdes[1]);
 
-		if (php_process == PHP_INIT) {
-			php_processes[i].php_pid = pid;
-			php_processes[i].php_write_fd = cacti2php_pdes[1];
-			php_processes[i].php_read_fd = php2cacti_pdes[0];
-		} else {
-			php_processes[php_process].php_pid = pid;
-			php_processes[php_process].php_write_fd = cacti2php_pdes[1];
-			php_processes[php_process].php_read_fd = php2cacti_pdes[0];
-		}
+		thread_mutex_lock(LOCK_PHP);
+		php_processes[server].php_pid      = pid;
+		php_processes[server].php_write_fd = cacti2php_pdes[1];
+		php_processes[server].php_read_fd  = php2cacti_pdes[0];
+		thread_mutex_unlock(LOCK_PHP);
 
 		/* restore caller's cancellation state. */
 		pthread_setcancelstate(cancel_state, NULL);
 
 		/* check pipe to insure startup took place */
-		if (php_process == PHP_INIT) {
-			result_string = php_readpipe(i, command);
-		} else {
-			result_string = php_readpipe(php_process, command);
+		/* PHP can emit a bounded number of startup notices before the banner.
+		 * Consume complete lines until the handshake arrives, but share one
+		 * script_timeout budget across the entire handshake. */
+		handshake_deadline = get_time_as_double() + set.script_timeout;
+		for (handshake_lines = 0; handshake_lines < 10; handshake_lines++) {
+			result_string = php_readpipe_until(server, command, handshake_deadline);
+
+			if (strstr(result_string, "Started")) {
+				break;
+			}
+
+			if (strcmp(result_string, "U") == 0) {
+				break;
+			}
+
+			SPINE_FREE(result_string);
 		}
 
-		if (strstr(result_string, "Started")) {
-			if (php_process == PHP_INIT) {
-				SPINE_LOG_DEBUG(("DEBUG: SS[%i] Confirmed PHP Script Server running using readfd[%i], writefd[%i]", i, php2cacti_pdes[0], cacti2php_pdes[1]));
-
-				php_processes[i].php_state = PHP_READY;
-			} else {
-				SPINE_LOG_DEBUG(("DEBUG: SS[%i] Confirmed PHP Script Server running using readfd[%i], writefd[%i]", php_process, php2cacti_pdes[0], cacti2php_pdes[1]));
-
-				php_processes[php_process].php_state = PHP_READY;
-			}
+		if (result_string != NULL && strstr(result_string, "Started")) {
+			SPINE_LOG_DEBUG(("DEBUG: SS[%i] Confirmed PHP Script Server running using readfd[%i], writefd[%i]", server, php2cacti_pdes[0], cacti2php_pdes[1]));
+			php_set_state(server, PHP_READY);
+			ready_count++;
 		} else {
-			if (php_process == PHP_INIT) {
-				SPINE_LOG(("ERROR: SS[%i] Script Server did not start properly return message was: '%s'", i, result_string));
-
-				php_processes[i].php_state = PHP_BUSY;
-			} else {
-				SPINE_LOG(("ERROR: SS[%i] Script Server did not start properly return message was: '%s'", php_process, result_string));
-
-				php_processes[php_process].php_state = PHP_BUSY;
-			}
+			SPINE_LOG(("ERROR: SS[%i] Script Server did not start properly return message was: '%s'", server, result_string != NULL ? result_string : "U"));
+			php_close_internal(server, TRUE);
+			php_set_state(server, PHP_BUSY);
 		}
 
-		free(result_string);
+		SPINE_FREE(result_string);
 	}
 
-	free(command);
+	SPINE_FREE(command);
 
-	return TRUE;
+	return ready_count > 0;
 }
 
-static void php_terminate_and_reap(pid_t pid) {
-	int attempts;
-	int phase;
+static void php_reap_delay(void) {
+	struct timeval delay;
+
+	do {
+		delay.tv_sec  = 0;
+		delay.tv_usec = 10000;
+	} while (select(0, NULL, NULL, NULL, &delay) < 0 && errno == EINTR);
+}
+
+static pid_t php_get_pid(int server) {
+	pid_t pid;
+
+	thread_mutex_lock(LOCK_PHP);
+	pid = php_processes[server].php_pid;
+	thread_mutex_unlock(LOCK_PHP);
+
+	return pid;
+}
+
+static int php_try_reap(int server) {
+	int reap_error = 0;
 	int status;
-	int signal_number = SIGTERM;
+	pid_t pid;
 	pid_t waited;
 
-	for (phase = 0; phase < 2; phase++) {
-		if (kill(pid, signal_number) < 0 && errno != ESRCH) {
-			SPINE_LOG(("WARNING: Unable to signal PHP Script Server PID[%ld]: %s", (long)pid, strerror(errno)));
-		}
-
-		for (attempts = 0; attempts < 20; attempts++) {
-			do {
-				waited = waitpid(pid, &status, WNOHANG);
-			} while (waited < 0 && errno == EINTR);
-
-			if (waited == pid || (waited < 0 && errno == ECHILD)) {
-				return;
-			}
-
-			if (waited < 0) {
-				SPINE_LOG(("WARNING: Unable to reap PHP Script Server PID[%ld]: %s", (long)pid, strerror(errno)));
-				return;
-			}
-
-			/* The delay is load-bearing: without it both phases burn twenty
-			 * WNOHANG polls in nanoseconds, so SIGKILL lands immediately and
-			 * the child is never reaped. */
-			#ifndef SOLAR_THREAD
-			usleep(50000);
-			#endif
-		}
-
-		signal_number = SIGKILL;
+	thread_mutex_lock(LOCK_PHP);
+	pid = php_processes[server].php_pid;
+	if (pid <= 1) {
+		thread_mutex_unlock(LOCK_PHP);
+		return TRUE;
 	}
 
-	SPINE_LOG(("WARNING: PHP Script Server PID[%ld] did not exit after SIGKILL", (long)pid));
+	do {
+		waited = waitpid(pid, &status, WNOHANG);
+	} while (waited < 0 && errno == EINTR);
+
+	if (waited == pid || (waited < 0 && errno == ECHILD)) {
+		php_processes[server].php_pid = -1;
+		thread_mutex_unlock(LOCK_PHP);
+		return TRUE;
+	}
+
+	if (waited < 0) {
+		reap_error = errno;
+	}
+	thread_mutex_unlock(LOCK_PHP);
+
+	if (reap_error != 0) {
+		SPINE_LOG(("WARNING: Unable to reap PHP Script Server PID[%ld]: %s", (long)pid, strerror(reap_error)));
+	}
+
+	return FALSE;
+}
+
+static void php_signal_servers(int first_process, int num_processes, int signal_number) {
+	int i;
+
+	for (i = 0; i < num_processes; i++) {
+		int signal_error = 0;
+		int server = first_process + i;
+		pid_t pid;
+
+		thread_mutex_lock(LOCK_PHP);
+		pid = php_processes[server].php_pid;
+		if (pid > 1 && kill(pid, signal_number) < 0 && errno != ESRCH) {
+			signal_error = errno;
+		}
+		thread_mutex_unlock(LOCK_PHP);
+
+		if (signal_error != 0) {
+			SPINE_LOG(("WARNING: Unable to signal PHP Script Server PID[%ld]: %s", (long)pid, strerror(signal_error)));
+		}
+	}
+}
+
+static void php_reap_servers(int first_process, int num_processes) {
+	int attempts;
+	int i;
+
+	/* Poll every child once per round.  All children receive their signal
+	 * before this runs, so the grace period is shared rather than multiplied
+	 * by the number of configured script servers. */
+	for (attempts = 0; attempts < 10; attempts++) {
+		int remaining = 0;
+
+		for (i = 0; i < num_processes; i++) {
+			if (!php_try_reap(first_process + i)) {
+				remaining++;
+			}
+		}
+
+		if (remaining == 0) {
+			return;
+		}
+
+		php_reap_delay();
+	}
+}
+
+static int php_park_orphan(int server, pid_t expected_pid) {
+	int i;
+	int parked = FALSE;
+
+	thread_mutex_lock(LOCK_PHP);
+	if (php_processes[server].php_pid == expected_pid) {
+		for (i = 0; i < MAX_PHP_SERVERS; i++) {
+			if (php_orphan_pids[i] <= 1) {
+				php_orphan_pids[i] = expected_pid;
+				php_processes[server].php_pid = -1;
+				parked = TRUE;
+				break;
+			}
+		}
+	}
+	thread_mutex_unlock(LOCK_PHP);
+
+	return parked;
+}
+
+static void php_drain_orphans(void) {
+	int i;
+	int reap_error = 0;
+	int signal_error = 0;
+	pid_t reap_error_pid = -1;
+	pid_t signal_error_pid = -1;
+
+	thread_mutex_lock(LOCK_PHP);
+	for (i = 0; i < MAX_PHP_SERVERS; i++) {
+		int status;
+		pid_t waited;
+
+		if (php_orphan_pids[i] <= 1) {
+			continue;
+		}
+
+		do {
+			waited = waitpid(php_orphan_pids[i], &status, WNOHANG);
+		} while (waited < 0 && errno == EINTR);
+
+		if (waited == php_orphan_pids[i] || (waited < 0 && errno == ECHILD)) {
+			php_orphan_pids[i] = -1;
+		} else if (waited < 0) {
+			reap_error_pid = php_orphan_pids[i];
+			reap_error = errno;
+		} else if (kill(php_orphan_pids[i], SIGKILL) < 0 && errno != ESRCH) {
+			/* A zero wait result proves this PID is still our live child.  With
+			 * SIGCHLD normalized to SIG_DFL it cannot be recycled until reaped. */
+			signal_error_pid = php_orphan_pids[i];
+			signal_error = errno;
+		}
+	}
+	thread_mutex_unlock(LOCK_PHP);
+
+	if (signal_error_pid > 1) {
+		SPINE_LOG(("WARNING: Unable to re-signal unreaped PHP Script Server PID[%ld]: %s", (long)signal_error_pid, strerror(signal_error)));
+	}
+	if (reap_error_pid > 1) {
+		SPINE_LOG(("WARNING: Unable to retry reap of PHP Script Server PID[%ld]: %s", (long)reap_error_pid, strerror(reap_error)));
+	}
 }
 
 /*! \fn void php_close(int php_process)
@@ -551,65 +920,102 @@ static void php_terminate_and_reap(pid_t pid) {
  *  where the child process is hung for one reason or another.
  *
  */
-void php_close(int php_process) {
+static void php_close_internal(int php_process, int send_quit) {
+	int first_process;
+	int had_write_pipe = FALSE;
 	int i;
 	int num_processes;
 	int len;
 
+	php_drain_orphans();
+
 	if (php_process == PHP_INIT) {
+		first_process = 0;
 		num_processes = set.php_servers;
 	} else {
+		first_process = php_process;
 		num_processes = 1;
 	}
 
-	for(i = 0; i < num_processes; i++) {
-		php_t *phpp;
+	for (i = 0; i < num_processes; i++) {
+		int server = first_process + i;
+		php_t *phpp = &php_processes[server];
+		int write_fd;
 
-		SPINE_LOG_DEBUG(("DEBUG: SS[%i] Script Server Shutdown Started", i));
+		SPINE_LOG_DEBUG(("DEBUG: SS[%i] Script Server Shutdown Started", server));
+
+		thread_mutex_lock(LOCK_PHP);
+		phpp->php_state = PHP_BUSY;
+		php_retry_after[server] = time(NULL) + 30;
+		write_fd = phpp->php_write_fd;
+		phpp->php_write_fd = -1;
+		thread_mutex_unlock(LOCK_PHP);
 
 		/* tell the script server to close */
-		if (php_process == PHP_INIT) {
-			phpp = &php_processes[i];
-		} else {
-			phpp = &php_processes[php_process];
-		}
-
 		/* If we still have a valid write pipe, tell PHP to close down
 		 * by sending a "quit" message, then closing the input channel
-		 * so it gets an EOF.
-		 *
-		 * Then we wait a moment before actually killing it to allow for
-		 * a clean shutdown.
+		 * so it gets an EOF.  Every server receives the request before
+		 * the shared grace period starts.
 		 */
-		if (phpp->php_write_fd >= 0) {
+		if (write_fd >= 0) {
 			static const char quit[] = "quit\r\n";
 
-			len = write(phpp->php_write_fd, quit, strlen(quit));
+			len = send_quit ? php_write_no_sigpipe(write_fd, quit, strlen(quit)) : 0;
 
-			if (len >= 0) {
-				close(phpp->php_write_fd);
-				phpp->php_write_fd = -1;
+			if (len < 0) {
+				SPINE_LOG_DEBUG(("DEBUG: SS[%i] Script Server quit write failed, closing anyway", server));
 			}
 
-			/* wait before killing php */
-			#ifndef SOLAR_THREAD
-			usleep(50000);			/* 50 msec */
-			#endif
+			close(write_fd);
+			had_write_pipe = TRUE;
 		}
+	}
 
-		/* only try to kill the process if the PID looks valid.
-		 * Trying to kill a negative number is bad news (it's
-	 	 * a process group leader), and PID 1 is "init".
-	  	 */
-		if (phpp->php_pid > 1) {
-			/* end the php script server process, escalating if it ignores
-			 * SIGTERM, and reap it so it cannot linger as an orphan */
-			php_terminate_and_reap(phpp->php_pid);
-			phpp->php_pid = -1;
+	if (had_write_pipe) {
+		#ifndef SOLAR_THREAD
+		usleep(50000);			/* 50 msec */
+		#endif
+	}
+
+	/* Signal all children before waiting so shutdown latency is bounded by a
+	 * shared grace period instead of one grace period per server. */
+	php_signal_servers(first_process, num_processes, SIGTERM);
+	php_reap_servers(first_process, num_processes);
+	php_signal_servers(first_process, num_processes, SIGKILL);
+	php_reap_servers(first_process, num_processes);
+
+	for (i = 0; i < num_processes; i++) {
+		int server = first_process + i;
+		int read_fd;
+		pid_t pid = php_get_pid(server);
+
+		if (pid > 1) {
+			/* Move the handle out of the active slot so a replacement can
+			 * start while later closes keep retrying this reap. */
+			SPINE_LOG(("WARNING: PHP Script Server PID[%ld] did not exit after SIGKILL", (long)pid));
+			if (!php_park_orphan(server, pid)) {
+				php_drain_orphans();
+				if (!php_park_orphan(server, pid)) {
+					/* Leave the unreaped PID in its active slot.  php_init() will
+					 * refuse to overwrite it and the cooldown bounds retry churn. */
+					php_set_state(server, PHP_BUSY);
+					SPINE_LOG(("WARNING: Unable to retain PHP Script Server PID[%ld] for a later reap; slot remains unavailable", (long)pid));
+				}
+			}
 		}
 
 		/* close file descriptors */
-		close(phpp->php_read_fd);
-		phpp->php_read_fd  = -1;
+		thread_mutex_lock(LOCK_PHP);
+		read_fd = php_processes[server].php_read_fd;
+		php_processes[server].php_read_fd = -1;
+		thread_mutex_unlock(LOCK_PHP);
+
+		if (read_fd >= 0) {
+			close(read_fd);
+		}
 	}
+}
+
+void php_close(int php_process) {
+	php_close_internal(php_process, TRUE);
 }

--- a/php.c
+++ b/php.c
@@ -278,11 +278,6 @@ char *php_readpipe(int php_process, char *command) {
 				if ((cp = strstr(result_string,"\n")) != 0) {
 					break;
 				}
-
-				if (bptr >= result_string+BUFSIZE) {
-					SPINE_LOG(("ERROR: SS[%i] The Script Server result was longer than the acceptable range", php_process));
-					SET_UNDEFINED(result_string);
-				}
 			}
 		} else {
 			SPINE_LOG(("ERROR: SS[%i] The FD was not set as expected", php_process));

--- a/ping.c
+++ b/ping.c
@@ -987,14 +987,15 @@ name_t *get_namebyhost(char *hostname, name_t *name) {
 	int tokens = 0;
 	char *stack = NULL;
 	char *token = NULL;
+	char *saveptr = NULL;
 
 	if (!(stack = (char *) malloc(strlen(hostname)+1))) {
 		die("ERROR: Fatal malloc error: ping.c get_namebyhost->stack");
 	}
 
 	memset(stack, '\0', strlen(hostname)+1);
-	strncopy(stack, hostname, strlen(stack));
-	token = strtok(stack, ":");
+	strncopy(stack, hostname, strlen(hostname)+1);
+	token = strtok_r(stack, ":", &saveptr);
 
 	if (token == NULL) {
 		SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - No delimiter, assume full hostname", hostname));
@@ -1056,7 +1057,7 @@ name_t *get_namebyhost(char *hostname, name_t *name) {
 		if (tokens > 3) {
 			SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Unexpected token: %i", hostname, tokens));
 		}
-		token = strtok(NULL, ":");
+		token = strtok_r(NULL, ":", &saveptr);
 	}
 
 	if (stack != NULL) {

--- a/ping.c
+++ b/ping.c
@@ -33,6 +33,18 @@
 
 #include "common.h"
 #include "spine.h"
+#include <fcntl.h>
+
+#ifdef __CYGWIN__
+static void icmp_discard_reply(int icmp_socket, char *buffer) {
+	while (recvfrom(icmp_socket, buffer, BUFSIZE, 0, NULL, NULL) < 0 && errno == EINTR) {
+		/* interrupted before the peeked datagram was removed; retry */
+	}
+}
+#define ICMP_DISCARD_PEEKED(sock, buf) icmp_discard_reply((sock), (buf))
+#else
+#define ICMP_DISCARD_PEEKED(sock, buf) ((void)0)
+#endif
 
 /*! \fn int ping_host(host_t *host, ping_t *ping)
  *  \brief ping a host to determine if it is reachable for polling
@@ -268,6 +280,11 @@ int ping_icmp(host_t *host, ping_t *ping) {
 	struct sockaddr_in fromname;
 	char   socket_reply[BUFSIZE];
 	int    retry_count;
+	int    fd_error;
+	int    elevate_euid;
+	int    fork_locked;
+	int    socket_type = SOCK_RAW;
+	int    ihl;
 	char   *cacti_msg = "cacti-monitoring-system\0";
 	int    packet_len;
 	socklen_t    fromlen;
@@ -289,8 +306,30 @@ int ping_icmp(host_t *host, ping_t *ping) {
 	/* get ICMP socket */
 	retry_count = 0;
 	while (TRUE) {
+		fd_error = 0;
+		elevate_euid = FALSE;
+		fork_locked = FALSE;
+		#if defined(HAVE_DECL_SOCK_CLOEXEC) && HAVE_DECL_SOCK_CLOEXEC
+		socket_type = SOCK_RAW | SOCK_CLOEXEC;
+		#else
+		/* Without atomic SOCK_CLOEXEC, serialize socket creation through
+		 * FD_CLOEXEC publication with every process spawn. */
+		fork_locked = TRUE;
+		#endif
 		#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
-		if (hasCaps() != TRUE) {
+		elevate_euid = hasCaps() != TRUE;
+		if (elevate_euid) {
+			fork_locked = TRUE;
+		}
+		#endif
+
+		/* Effective UID changes are process-wide.  Exclude every fork/exec
+		 * from the complete elevated interval. */
+		if (fork_locked) {
+			thread_mutex_lock(LOCK_FORK);
+		}
+		#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
+		if (elevate_euid) {
 			thread_mutex_lock(LOCK_SETEUID);
 			if (seteuid(0) == -1) {
 				SPINE_LOG_DEBUG(("WARNING: Spine unable to obtain root privileges."));
@@ -298,39 +337,50 @@ int ping_icmp(host_t *host, ping_t *ping) {
 		}
 		#endif
 
-		if ((icmp_socket = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP)) == -1) {
-			usleep(500000);
-			retry_count++;
-
-			if (retry_count > 4) {
-				snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Ping unable to create ICMP Socket");
-				snprintf(ping->ping_status, 50, "down");
-				#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
-				if (hasCaps() != TRUE) {
-					if (seteuid(getuid()) == -1) {
-						SPINE_LOG_DEBUG(("WARNING: Spine unable to drop from root to local user."));
-					}
-					thread_mutex_unlock(LOCK_SETEUID);
-				}
-				#endif
-
-				return HOST_DOWN;
-
-				break;
-			}
+		if ((icmp_socket = socket(AF_INET, socket_type, IPPROTO_ICMP)) == -1) {
+			fd_error = errno;
 		} else {
+			int fd_flags = fcntl(icmp_socket, F_GETFD);
+			if (fd_flags < 0 || fcntl(icmp_socket, F_SETFD, fd_flags | FD_CLOEXEC) < 0) {
+				fd_error = errno;
+				close(icmp_socket);
+				icmp_socket = -1;
+			}
+		}
+
+		#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
+		if (elevate_euid) {
+			if (seteuid(getuid()) == -1) {
+				/* Try an irreversible privilege drop before giving up.  Normal
+				 * cleanup is unsafe if both calls fail because it would execute
+				 * complex shutdown code while the process still has euid 0. */
+				if (setuid(getuid()) == -1) {
+					SPINE_LOG(("ERROR: Spine unable to drop root privileges; terminating immediately."));
+					_exit(EXIT_FAILURE);
+				}
+			}
+			thread_mutex_unlock(LOCK_SETEUID);
+		}
+		#endif
+		if (fork_locked) {
+			thread_mutex_unlock(LOCK_FORK);
+		}
+
+		if (icmp_socket != -1) {
 			break;
 		}
-	}
 
-	#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
-	if (hasCaps() != TRUE) {
-		if (seteuid(getuid()) == -1) {
-			SPINE_LOG_DEBUG(("WARNING: Spine unable to drop from root to local user."));
+		if (fd_error != 0) {
+			SPINE_LOG(("WARNING: Unable to create or secure ICMP socket: %s", strerror(fd_error)));
 		}
-		thread_mutex_unlock(LOCK_SETEUID);
+		usleep(500000);
+		retry_count++;
+		if (retry_count > 4) {
+			snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Ping unable to create ICMP Socket");
+			snprintf(ping->ping_status, 50, "down");
+			return HOST_DOWN;
+		}
 	}
-	#endif
 
 	/* convert the host timeout to a double precision number in seconds */
 	host_timeout = host->ping_timeout;
@@ -382,7 +432,7 @@ int ping_icmp(host_t *host, ping_t *ping) {
 				if (retry_count > host->ping_retries) {
 					snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Ping timed out");
 					snprintf(ping->ping_status, 50, "down");
-					free(packet);
+					SPINE_FREE(packet);
 					close(icmp_socket);
 					return HOST_DOWN;
 				}
@@ -436,51 +486,57 @@ int ping_icmp(host_t *host, ping_t *ping) {
 							goto keep_listening;
 						}
 					} else {
-						ip  = (struct ip *) socket_reply;
-						pkt = (struct icmp *) (socket_reply + (ip->ip_hl << 2));
-
-						if (fromname.sin_addr.s_addr == recvname.sin_addr.s_addr) {
-							if (pkt->icmp_type == ICMP_ECHOREPLY) {
-								if (is_debug_device(host->id)) {
-									SPINE_LOG(("Device[%i] INFO: ICMP Device Alive, Try Count:%i, Time:%.4f ms", host->id, retry_count+1, (total_time)));
-								} else {
-									SPINE_LOG_MEDIUM(("Device[%i] INFO: ICMP Device Alive, Try Count:%i, Time:%.4f ms", host->id, retry_count+1, (total_time)));
-								}
-								snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Device is Alive");
-								snprintf(ping->ping_status, 50, "%.5f", total_time);
-								free(packet);
-								#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
-								if (hasCaps() != TRUE) {
-									thread_mutex_lock(LOCK_SETEUID);
-									if (seteuid(0) == -1) {
-										SPINE_LOG_DEBUG(("WARNING: Spine unable to obtain root privileges."));
-									}
-								}
-								#endif
-								close(icmp_socket);
-								#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
-								if (hasCaps() != TRUE) {
-									if (seteuid(getuid()) == -1) {
-										SPINE_LOG_DEBUG(("WARNING: Spine unable to drop from root to local user."));
-									}
-									thread_mutex_unlock(LOCK_SETEUID);
-								}
-								#endif
-
-								return HOST_UP;
-							} else {
-								/* received a response other than an echo reply */
-								if (total_time > host_timeout) {
-									retry_count++;
-									total_time = 0;
-								}
-
-								continue;
-							}
-						} else {
-							/* another host responded */
+						if (return_code < (ssize_t) sizeof(struct ip)) {
+							ICMP_DISCARD_PEEKED(icmp_socket, socket_reply);
 							goto keep_listening;
 						}
+
+						ip  = (struct ip *) socket_reply;
+						ihl = ip->ip_hl << 2;
+						if (ihl < (int) sizeof(struct ip) || return_code < (ssize_t) (ihl + ICMP_HDR_SIZE)) {
+							ICMP_DISCARD_PEEKED(icmp_socket, socket_reply);
+							goto keep_listening;
+						}
+
+						pkt = (struct icmp *) (socket_reply + ihl);
+
+						if (fromname.sin_addr.s_addr != recvname.sin_addr.s_addr) {
+							/* another host responded */
+							ICMP_DISCARD_PEEKED(icmp_socket, socket_reply);
+							goto keep_listening;
+						}
+
+						if (pkt->icmp_type == ICMP_ECHOREPLY) {
+							/* Only echo replies carry our identifier and sequence in
+							 * the outer ICMP header.  Error responses carry the
+							 * triggering packet there instead. */
+							if (pkt->icmp_id != icmp->icmp_id || pkt->icmp_seq != icmp->icmp_seq) {
+								ICMP_DISCARD_PEEKED(icmp_socket, socket_reply);
+								goto keep_listening;
+							}
+
+							if (is_debug_device(host->id)) {
+								SPINE_LOG(("Device[%i] INFO: ICMP Device Alive, Try Count:%i, Time:%.4f ms", host->id, retry_count+1, (total_time)));
+							} else {
+								SPINE_LOG_MEDIUM(("Device[%i] INFO: ICMP Device Alive, Try Count:%i, Time:%.4f ms", host->id, retry_count+1, (total_time)));
+							}
+							snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Device is Alive");
+							snprintf(ping->ping_status, 50, "%.5f", total_time);
+							SPINE_FREE(packet);
+							close(icmp_socket);
+
+							return HOST_UP;
+						}
+
+						/* A correlated ICMP error requires parsing the embedded
+						 * IP packet.  Keep listening until that
+						 * correlation is available; never report the host up. */
+						ICMP_DISCARD_PEEKED(icmp_socket, socket_reply);
+						if (total_time > host_timeout) {
+							retry_count++;
+							total_time = 0;
+						}
+						continue;
 					}
 				} else {
 					if (is_debug_device(host->id)) {
@@ -499,48 +555,16 @@ int ping_icmp(host_t *host, ping_t *ping) {
 		} else {
 			snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Destination hostname invalid");
 			snprintf(ping->ping_status, 50, "down");
-			free(packet);
-			#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
-			if (hasCaps() != TRUE) {
-				thread_mutex_lock(LOCK_SETEUID);
-				if (seteuid(0) == -1) {
-					SPINE_LOG_DEBUG(("WARNING: Spine unable to obtain root privileges."));
-				}
-			}
-			#endif
+			SPINE_FREE(packet);
 			close(icmp_socket);
-			#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
-			if (hasCaps() != TRUE) {
-				if (seteuid(getuid()) == -1) {
-					SPINE_LOG_DEBUG(("WARNING: Spine unable to drop from root to local user."));
-				}
-				thread_mutex_unlock(LOCK_SETEUID);
-			}
-			#endif
 			return HOST_DOWN;
 		}
 	} else {
 		snprintf(ping->ping_response, SMALL_BUFSIZE, "ICMP: Destination address not specified");
 		snprintf(ping->ping_status, 50, "down");
-		free(packet);
+		SPINE_FREE(packet);
 		if (icmp_socket != -1) {
-			#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
-			if (hasCaps() != TRUE) {
-				thread_mutex_lock(LOCK_SETEUID);
-				if (seteuid(0) == -1) {
-					SPINE_LOG_DEBUG(("WARNING: Spine unable to obtain root privileges."));
-				}
-			}
-			#endif
 			close(icmp_socket);
-			#if !(defined(__CYGWIN__) && !defined(SOLAR_PRIV))
-			if (hasCaps() != TRUE) {
-				if (seteuid(getuid()) == -1) {
-					SPINE_LOG_DEBUG(("WARNING: Spine unable to drop from root to local user."));
-				}
-				thread_mutex_unlock(LOCK_SETEUID);
-			}
-			#endif
 		}
 		return HOST_DOWN;
 	}
@@ -968,9 +992,9 @@ int init_sockaddr(struct sockaddr_in *name, const char *hostname, unsigned short
 }
 
 /*! \fn name_t *get_namebyhost(char *hostname, name_t *name)
- *  \brief splits the hostname into method, name and port
+ *  \brief copies the complete hostname into a name result
  *
- *  \return name_t containing a trimmed hostname, port, and optional method
+ *  \return name_t containing the complete hostname
  *
  */
 name_t *get_namebyhost(char *hostname, name_t *name) {
@@ -984,86 +1008,10 @@ name_t *get_namebyhost(char *hostname, name_t *name) {
 		memset(name, '\0', sizeof(name_t));
 	}
 
-	int tokens = 0;
-	char *stack = NULL;
-	char *token = NULL;
-	char *saveptr = NULL;
-
-	if (!(stack = (char *) malloc(strlen(hostname)+1))) {
-		die("ERROR: Fatal malloc error: ping.c get_namebyhost->stack");
-	}
-
-	memset(stack, '\0', strlen(hostname)+1);
-	strncopy(stack, hostname, strlen(hostname)+1);
-	token = strtok_r(stack, ":", &saveptr);
-
-	if (token == NULL) {
-		SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - No delimiter, assume full hostname", hostname));
-		strncopy(name->hostname, hostname, SMALL_BUFSIZE);
-	}
-
-	while (token != NULL && tokens <= 3) {
-		tokens++;
-		SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Token #%i - %s", hostname, tokens, token));
-		if (tokens == 1) {
-			if (strlen(token) && token[0] == '[') {
-				SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Have TCPv6 method", hostname));
-				strncpy(name->hostname, hostname, sizeof(name->hostname)-1);
-				break;
-			} else if (strlen(token) == 3) {
-				if (strncasecmp(token, "TCP", 3)) {
-					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Have TCPv4 method", hostname));
-					name->method = 1;
-				} else if (strncasecmp(hostname, "UDP", 3)) {
-					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Have UDPv4 method", hostname));
-					name->method = 2;
-				} else {
-					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - No matching method for 3 chars: %s", hostname, token));
-					// assume we have had a method
-					tokens++;
-				}
-			} else if (strlen(token) == 4) {
-				if (strncasecmp(token, "TCP6", 3)) {
-					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Have TCPv6 method", hostname));
-					name->method = 3;
-				} else if (strncasecmp(hostname, "UDP6", 3)) {
-					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Have UDPv6 method", hostname));
-					name->method = 4;
-				} else {
-					SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - No matching method for 4 chars: %s", hostname, token));
-
-					// assume we have had a method
-					tokens++;
-				}
-			} else {
-				SPINE_LOG_DEBUG(("DEBUG: get_hostbyname(%s) - No matching method for %li chars: %s", hostname, strlen(token), token));
-
-				// assume we have had a method
-				tokens++;
-			}
-		}
-
-		if (tokens == 2) {
-			SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Setting hostname: %s", hostname, token));
-			strncpy(name->hostname, token, sizeof(name->hostname)-1);
-			name->hostname[strlen(token)] = '\0';
-		}
-
-		if (tokens == 3 && strlen(token)) {
-			SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Setting port: %s", hostname, token));
-			name->port = atoi(token);
-		}
-
-		if (tokens > 3) {
-			SPINE_LOG_DEBUG(("DEBUG: get_namebyhost(%s) - Unexpected token: %i", hostname, tokens));
-		}
-		token = strtok_r(NULL, ":", &saveptr);
-	}
-
-	if (stack != NULL) {
-		free(stack);
-		stack = NULL;
-	}
+	/* The database supplies ping method and port in separate columns, and the
+	 * caller overwrites both parsed values immediately.  Preserve the complete
+	 * hostname here; splitting on ':' silently truncates bare IPv6 literals. */
+	STRNCOPY(name->hostname, hostname);
 
 	return name;
 }

--- a/poller.c
+++ b/poller.c
@@ -178,6 +178,7 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 	int    php_process;
 
 	char *poll_result = NULL;
+	char *command_result = NULL;
 	char update_sql[BIG_BUFSIZE];
 	char temp_poll_result[BUFSIZE];
 	char temp_arg1[BUFSIZE];
@@ -992,7 +993,14 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 
 							break;
 						case POLLER_ACTION_SCRIPT: /* script (popen) */
-							poll_result = trim(exec_poll(host, reindex->arg1, reindex->data_query_id, "DQ"));
+							poll_result = exec_poll(host, reindex->arg1, reindex->data_query_id, "DQ");
+							if (poll_result == NULL) {
+								die("ERROR: Script command returned no allocated result");
+							}
+							command_result = trim(poll_result);
+							if (command_result != poll_result) {
+								memmove(poll_result, command_result, strlen(command_result) + 1);
+							}
 
 							if (is_debug_device(host->id)) {
 								SPINE_LOG(("Device[%i] HT[%i] DQ[%i] RECACHE CMD: %s, output: %s", host->id, host_thread, reindex->data_query_id, reindex->arg1, poll_result));
@@ -1004,7 +1012,18 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 						case POLLER_ACTION_PHP_SCRIPT_SERVER: /* script (php script server) */
 							php_process = php_get_process();
 
-							poll_result = trim(php_cmd(reindex->arg1, php_process));
+							if (php_process >= 0) {
+								poll_result = php_cmd(reindex->arg1, php_process);
+							} else {
+								STRDUP_OR_DIE(poll_result, "U", "unavailable PHP Script Server pool");
+							}
+							if (poll_result == NULL) {
+								die("ERROR: PHP Script Server returned no allocated result");
+							}
+							command_result = trim(poll_result);
+							if (command_result != poll_result) {
+								memmove(poll_result, command_result, strlen(command_result) + 1);
+							}
 
 							if (is_debug_device(host->id)) {
 								SPINE_LOG(("Device[%i] HT[%i] DQ[%i] RECACHE SERVER: %s, output: %s", host->id, host_thread, reindex->data_query_id, reindex->arg1, poll_result));
@@ -1013,13 +1032,20 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 							}
 
 							break;
-						case POLLER_ACTION_SNMP_COUNT: /* snmp; count items */
+						case POLLER_ACTION_SNMP_COUNT: { /* snmp; count items */
+							int snmp_items;
+
 							if (!(poll_result = (char *) malloc(BUFSIZE))) {
 								die("ERROR: Fatal malloc error: poller.c poll_result");
 							}
 							poll_result[0] = '\0';
 
-							snprintf(poll_result, BUFSIZE, "%d", snmp_count(host, reindex->arg1));
+							snmp_items = snmp_count(host, reindex->arg1);
+							if (snmp_items < 0) {
+								SET_UNDEFINED(poll_result);
+							} else {
+								snprintf(poll_result, BUFSIZE, "%d", snmp_items);
+							}
 
 							if (is_debug_device(host->id)) {
 								SPINE_LOG(("Device[%i] HT[%i] DQ[%i] RECACHE OID COUNT: %s, output: %s", host->id, host_thread, reindex->data_query_id, reindex->arg1, poll_result));
@@ -1028,13 +1054,20 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 							}
 
 							break;
+						}
 						case POLLER_ACTION_SCRIPT_COUNT: /* script (popen); count items by counting line feeds */
 							if (!(poll_result = (char *) malloc(BUFSIZE))) {
 								die("ERROR: Fatal malloc error: poller.c poll_result");
 							}
 							poll_result[0] = '\0';
 
-							snprintf(poll_result, BUFSIZE, "%d", char_count(exec_poll(host, reindex->arg1, reindex->data_query_id, "DQ"), '\n'));
+							command_result = exec_poll(host, reindex->arg1, reindex->data_query_id, "DQ");
+							if (command_result == NULL || IS_UNDEFINED(command_result)) {
+								SET_UNDEFINED(poll_result);
+							} else {
+								snprintf(poll_result, BUFSIZE, "%d", char_count(command_result, '\n'));
+							}
+							SPINE_FREE(command_result);
 
 							if (is_debug_device(host->id)) {
 								SPINE_LOG(("Device[%i] HT[%i] DQ[%i] RECACHE CMD COUNT: %s, output: %s", host->id, host_thread, reindex->data_query_id, reindex->arg1, poll_result));
@@ -1051,7 +1084,17 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 
 							php_process = php_get_process();
 
-							sprintf(poll_result, "%d", char_count(php_cmd(reindex->arg1, php_process), '\n'));
+							if (php_process < 0) {
+								SET_UNDEFINED(poll_result);
+							} else {
+								command_result = php_cmd(reindex->arg1, php_process);
+								if (command_result == NULL || IS_UNDEFINED(command_result)) {
+									SET_UNDEFINED(poll_result);
+								} else {
+									snprintf(poll_result, BUFSIZE, "%d", char_count(command_result, '\n'));
+								}
+								SPINE_FREE(command_result);
+							}
 
 							if (is_debug_device(host->id)) {
 								SPINE_LOG(("Device[%i] HT[%i] DQ[%i] RECACHE SERVER COUNT: %s, output: %s", host->id, host_thread, reindex->data_query_id, reindex->arg1, poll_result));
@@ -1164,7 +1207,8 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 							 * 1) the assert fails
 							 * 2) the OP code is > or < meaning the current value could have changed without causing
 							 *     the assert to fail */
-							if ((assert_fail) || (!strcmp(reindex->op, ">")) || (!strcmp(reindex->op, "<"))) {
+							if (poll_result != NULL && !IS_UNDEFINED(poll_result) &&
+								((assert_fail) || (!strcmp(reindex->op, ">")) || (!strcmp(reindex->op, "<")))) {
 								if (host_thread == 1) {
 									db_escape(&mysql, temp_poll_result, sizeof(temp_poll_result), poll_result);
 									db_escape(&mysql, temp_arg1, sizeof(temp_arg1), reindex->arg1);
@@ -1622,7 +1666,11 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 			case POLLER_ACTION_PHP_SCRIPT_SERVER: /* execute script server */
 				php_process = php_get_process();
 
-				poll_result = php_cmd(poller_items[i].arg1, php_process);
+				if (php_process >= 0) {
+					poll_result = php_cmd(poller_items[i].arg1, php_process);
+				} else {
+					STRDUP_OR_DIE(poll_result, "U", "unavailable PHP Script Server pool");
+				}
 
 				/* process the output */
 				if (IS_UNDEFINED(poll_result)) {
@@ -2185,7 +2233,9 @@ int validate_result(char *result) {
  */
 char *exec_poll(host_t *current_host, char *command, int id, char *type) {
 	int cmd_fd;
+	#ifndef USING_TPOPEN
 	int pid;
+	#endif
 
 	#ifdef USING_TPOPEN
 	int close_fd = TRUE;
@@ -2280,8 +2330,12 @@ char *exec_poll(host_t *current_host, char *command, int id, char *type) {
 
 		if (access(executable, X_OK | F_OK) != -1) {
 			#ifdef USING_TPOPEN
+			/* libc popen() forks internally.  Serialize that fork with every
+			 * process-wide effective-UID elevation. */
+			thread_mutex_lock(LOCK_FORK);
 			fd = popen((char *)proc_command, "r");
-			cmd_fd = fileno(fd);
+			thread_mutex_unlock(LOCK_FORK);
+			cmd_fd = fd != NULL ? fileno(fd) : -1;
 			if (is_debug_device(current_host->id)) {
 				SPINE_LOG(("DEBUG: Device[%i] DEBUG: The POPEN returned the following File Descriptor %i", current_host->id, cmd_fd));
 			} else {

--- a/snmp.c
+++ b/snmp.c
@@ -627,7 +627,7 @@ char *snmp_getnext(host_t *current_host, char *snmp_oid) {
  *	This function will poll a specific snmp OID for a host.  The host snmp
  *  session must already be established.
  *
- *  \return returns count of table entries
+ *  \return count of table entries, or -1 when the walk is incomplete
  *
  */
 int snmp_count(host_t *current_host, char *snmp_oid) {
@@ -656,7 +656,9 @@ int snmp_count(host_t *current_host, char *snmp_oid) {
 		/* parse input parm to an array for use with snmp functions */
 		if (!snmp_parse_oid(snmp_oid, root, &rootlen)) {
 			SPINE_LOG(("Device[%i] ERROR: SNMP Count Problems parsing SNMP OID %s", current_host->id, snmp_oid));
-			return count;
+			/* This is a local configuration error, not evidence that the
+			 * device is unavailable; leave host status unchanged. */
+			return -1;
 		}
 		memmove(anOID, root, rootlen * sizeof(oid));
 		anOID_len = rootlen;
@@ -669,13 +671,21 @@ int snmp_count(host_t *current_host, char *snmp_oid) {
 			/* do the request, use thread safe call */
 			status = snmp_sess_synch_response(current_host->snmp_session, pdu, &response);
 
-			/* add status to host structure */
-			current_host->snmp_status = status;
-
 			//SPINE_LOG_DEBUG(("TRACE: Status %i Response %i", status, response->errstat));
 
 			if (status == STAT_SUCCESS) {
-				if (response->errstat == SNMP_ERR_NOERROR) {
+				if (response == NULL) {
+					SPINE_LOG(("ERROR: An internal Net-Snmp error condition detected in Cacti snmp_count"));
+					status = STAT_ERROR;
+					ok = 0;
+					error_occurred = 1;
+					count = -1;
+				} else if (response->errstat == SNMP_ERR_NOERROR) {
+					if (response->variables == NULL) {
+						SPINE_LOG_DEBUG(("DEBUG: Empty Net-SNMP response ended Cacti snmp_count walk"));
+						ok = 0;
+					}
+
 					/* check resulting variables */
 					for (vars = response->variables; vars; vars	= vars->next_variable) {
 						if ((vars->name_length < rootlen) || (memcmp(root, vars->name, rootlen * sizeof(oid)) != 0)) {
@@ -704,7 +714,17 @@ int snmp_count(host_t *current_host, char *snmp_oid) {
 						}
 					}
 				} else {
-					SPINE_LOG(("ERROR: An internal Net-Snmp error condition detected in Cacti snmp_count"));
+					ok = 0;
+
+					/* SNMPv1 reports the normal end of a GETNEXT walk as
+					 * noSuchName rather than an endOfMibView variable. */
+					if (response->errstat != SNMP_ERR_NOSUCHNAME) {
+						SPINE_LOG(("ERROR: Net-SNMP error %ld detected in Cacti snmp_count", response->errstat));
+						error_occurred = 1;
+						count = -1;
+						/* The walk result is unusable, but a valid SNMP response
+						 * still proves that the device is reachable. */
+					}
 				}
 			} else if (status == STAT_TIMEOUT) {
 				SPINE_LOG(("ERROR: Timeout detected in Cacti snmp_count"));
@@ -718,17 +738,21 @@ int snmp_count(host_t *current_host, char *snmp_oid) {
 
 			if (response) {
 				snmp_free_pdu(response);
+				response = NULL;
 			}
 		}
 	} else {
 		status = STAT_DESCRIP_ERROR;
+		count = -1;
 	}
+
+	current_host->snmp_status = status;
 
 	if (status != STAT_SUCCESS) {
 		current_host->ignore_host = TRUE;
 	}
 
-	return count;
+	return error_occurred ? -1 : count;
 }
 
 /*! \fn void snmp_snprint_value(char *obuf, size_t buf_len, const oid *objid, size_t objidlen, struct variable_list *variable)
@@ -782,7 +806,12 @@ void snmp_get_multi(host_t *current_host, target_t *poller_items, snmp_oids_t *s
 	} *name, *namep;
 
 	/* load up oids */
-	namep = name = (struct nameStruct *) calloc(num_oids, sizeof(*name));
+	if (num_oids <= 0) {
+		return;
+	}
+	if (!(namep = name = (struct nameStruct *) calloc(num_oids, sizeof(*name)))) {
+		die("ERROR: Fatal malloc error: snmp.c snmp_get_multi!");
+	}
 	pdu = snmp_pdu_create(SNMP_MSG_GET);
 	for (i = 0; i < num_oids; i++) {
 		namep->name_len = MAX_OID_LEN;
@@ -804,9 +833,6 @@ void snmp_get_multi(host_t *current_host, target_t *poller_items, snmp_oids_t *s
 	/* execute the multi-get request */
 	retry:
 	status = snmp_sess_synch_response(current_host->snmp_session, pdu, &response);
-
-	/* add status to host structure */
-	current_host->snmp_status = status;
 
 	/* liftoff, successful poll, process it!! */
 	if (status == STAT_SUCCESS) {
@@ -873,6 +899,9 @@ void snmp_get_multi(host_t *current_host, target_t *poller_items, snmp_oids_t *s
 			SET_UNDEFINED(snmp_oids[i].result);
 		}
 	}
+
+	/* Record the final classified result, including response-level errors. */
+	current_host->snmp_status = status;
 
 	if (response != NULL) {
 		snmp_free_pdu(response);

--- a/spine.c
+++ b/spine.c
@@ -249,7 +249,10 @@ int main(int argc, char *argv[]) {
 	}
 
 	for (i = 0; i < MAX_PHP_SERVERS; i++) {
-		php_processes[i].php_state = PHP_BUSY;
+		php_processes[i].php_state    = PHP_BUSY;
+		php_processes[i].php_read_fd  = -1;
+		php_processes[i].php_write_fd = -1;
+		php_processes[i].php_pid      = -1;
 	}
 
 	/* create the array of debug devices */
@@ -629,8 +632,10 @@ int main(int argc, char *argv[]) {
 
 	/* initialize the script server */
 	if (set.php_required && !set.ping_only) {
-		php_init(PHP_INIT);
-		set.php_initialized    = TRUE;
+		set.php_initialized = TRUE;
+		if (!php_init(PHP_INIT)) {
+			SPINE_LOG(("ERROR: Unable to initialize any PHP Script Server; script-server data sources will remain undefined"));
+		}
 		set.php_current_server = 0;
 	}
 
@@ -736,6 +741,9 @@ int main(int argc, char *argv[]) {
 	while (canexit == FALSE && device_counter < num_rows) {
 		if (change_host) {
 			mysql_row       = mysql_fetch_row(result);
+			if (mysql_row == NULL || mysql_row[0] == NULL || mysql_row[1] == NULL) {
+				die("ERROR: Unable to fetch the next device row");
+			}
 			host_id         = atoi(mysql_row[0]);
 			device_threads  = atoi(mysql_row[1]);
 			current_thread  = 1;
@@ -756,10 +764,15 @@ int main(int argc, char *argv[]) {
 			}
 
 			tresult   = db_query(&mysql, LOCAL, querybuf);
-			mysql_row = mysql_fetch_row(tresult);
+			mysql_row = (tresult != NULL) ? mysql_fetch_row(tresult) : NULL;
+
+			if (mysql_row == NULL || mysql_row[0] == NULL) {
+				if (tresult != NULL) db_free_result(tresult);
+				die("ERROR: Device[%i] unable to determine the poller item count", host_id);
+			}
 
 			total_items = atoi(mysql_row[0]);
-			db_free_result(tresult);
+			if (tresult != NULL) db_free_result(tresult);
 
 			if (total_items && total_items < device_threads) {
 				device_threads = total_items;
@@ -780,11 +793,15 @@ int main(int argc, char *argv[]) {
 				}
 
 				tresult   = db_query(&mysql, LOCAL, querybuf);
-				mysql_row = mysql_fetch_row(tresult);
+				mysql_row = (tresult != NULL) ? mysql_fetch_row(tresult) : NULL;
+
+				if (mysql_row == NULL || mysql_row[0] == NULL) {
+					if (tresult != NULL) db_free_result(tresult);
+					die("ERROR: Device[%i] unable to determine the per-thread poller item count", host_id);
+				}
 
 				items_per_thread = atoi(mysql_row[0]);
-
-				db_free_result(tresult);
+				if (tresult != NULL) db_free_result(tresult);
 
 				sprintf(host_time, "%lu", (unsigned long) time(NULL));
 				host_time_double = get_time_as_double();
@@ -795,11 +812,15 @@ int main(int argc, char *argv[]) {
 		} else {
 			snprintf(querybuf, BIG_BUFSIZE, "SELECT SQL_NO_CACHE COUNT(local_data_id) FROM poller_item WHERE host_id=%i AND rrd_next_step <=0", host_id);
 			tresult   = db_query(&mysql, LOCAL, querybuf);
-			mysql_row = mysql_fetch_row(tresult);
+			mysql_row = (tresult != NULL) ? mysql_fetch_row(tresult) : NULL;
+
+			if (mysql_row == NULL || mysql_row[0] == NULL) {
+				if (tresult != NULL) db_free_result(tresult);
+				die("ERROR: Device[%i] unable to determine the poller item count", host_id);
+			}
 
 			items_per_thread = atoi(mysql_row[0]);
-
-			db_free_result(tresult);
+			if (tresult != NULL) db_free_result(tresult);
 
 			sprintf(host_time, "%lu", (unsigned long) time(NULL));
 			host_time_double = get_time_as_double();

--- a/spine.c
+++ b/spine.c
@@ -244,13 +244,18 @@ int main(int argc, char *argv[]) {
 	install_spine_signal_handler();
 
 	/* establish php processes and initialize space */
-	php_processes = (php_t*) calloc(MAX_PHP_SERVERS, sizeof(php_t));
+	if (!(php_processes = (php_t*) calloc(MAX_PHP_SERVERS, sizeof(php_t)))) {
+		die("ERROR: Fatal malloc error: spine.c php_processes!");
+	}
+
 	for (i = 0; i < MAX_PHP_SERVERS; i++) {
 		php_processes[i].php_state = PHP_BUSY;
 	}
 
 	/* create the array of debug devices */
-	debug_devices = calloc(100, sizeof(int));
+	if (!(debug_devices = calloc(100, sizeof(int)))) {
+		die("ERROR: Fatal malloc error: spine.c debug_devices!");
+	}
 
 	/* initialize icmp_avail */
 	set.icmp_avail = TRUE;
@@ -538,7 +543,10 @@ int main(int argc, char *argv[]) {
 	db_connect(LOCAL, &mysql);
 
 	/* setup local connection pool for hosts */
-	db_pool_local = (pool_t *) calloc(set.threads, sizeof(pool_t));
+	if (!(db_pool_local = (pool_t *) calloc(set.threads, sizeof(pool_t)))) {
+		die("ERROR: Fatal malloc error: spine.c db_pool_local!");
+	}
+
 	db_create_connection_pool(LOCAL);
 
 	if (set.poller_id > 1 && set.mode == REMOTE_ONLINE) {
@@ -546,7 +554,10 @@ int main(int argc, char *argv[]) {
 		mode = REMOTE;
 
 		/* setup remote connection pool for hosts */
-		db_pool_remote = (pool_t *) calloc(set.threads, sizeof(pool_t));
+		if (!(db_pool_remote = (pool_t *) calloc(set.threads, sizeof(pool_t)))) {
+			die("ERROR: Fatal malloc error: spine.c db_pool_remote!");
+		}
+
 		db_create_connection_pool(REMOTE);
 	} else {
 		mode = LOCAL;

--- a/spine.h
+++ b/spine.h
@@ -190,6 +190,7 @@
 #define LOCK_PHP_PROC_14 21
 #define LOCK_THDET 40
 #define LOCK_HOST_TIME 41
+#define LOCK_FORK 42
 
 #define LOCK_SNMP_O 0
 #define LOCK_SETEUID_O 2
@@ -213,6 +214,7 @@
 #define LOCK_PHP_PROC_14_O 21
 #define LOCK_THDET_O 40
 #define LOCK_HOST_TIME_O 41
+#define LOCK_FORK_O 42
 
 /* poller actions */
 #define POLLER_ACTION_SNMP 0
@@ -424,9 +426,9 @@ typedef struct config_struct {
 	char   rdb_user[BUFSIZE];
 	char   rdb_pass[BUFSIZE];
 	int    rdb_ssl;
-	char   rdb_ssl_key[BUFSIZE];
-	char   rdb_ssl_cert[BUFSIZE];
-	char   rdb_ssl_ca[BUFSIZE];
+	char   rdb_ssl_key[BIG_BUFSIZE];
+	char   rdb_ssl_cert[BIG_BUFSIZE];
+	char   rdb_ssl_ca[BIG_BUFSIZE];
 	unsigned int rdb_port;
 	char   rdbversion[BUFSIZE];
 	int    rdbonupdate;

--- a/spine.h
+++ b/spine.h
@@ -424,9 +424,9 @@ typedef struct config_struct {
 	char   rdb_user[BUFSIZE];
 	char   rdb_pass[BUFSIZE];
 	int    rdb_ssl;
-	char   rdb_ssl_key[BIG_BUFSIZE];
-	char   rdb_ssl_cert[BIG_BUFSIZE];
-	char   rdb_ssl_ca[BIG_BUFSIZE];
+	char   rdb_ssl_key[BUFSIZE];
+	char   rdb_ssl_cert[BUFSIZE];
+	char   rdb_ssl_ca[BUFSIZE];
 	unsigned int rdb_port;
 	char   rdbversion[BUFSIZE];
 	int    rdbonupdate;

--- a/util.c
+++ b/util.c
@@ -103,7 +103,7 @@ static const char *getsetting(MYSQL *psql, int mode, const char *setting) {
 		if (mysql_num_rows(result) > 0) {
 			mysql_row = mysql_fetch_row(result);
 
-			if (mysql_row != NULL) {
+			if (mysql_row != NULL && mysql_row[0] != NULL) {
 				retval = strdup(mysql_row[0]);
 				db_free_result(result);
 				return retval;
@@ -196,7 +196,7 @@ static const char *getpsetting(MYSQL *psql, int mode, const char *setting) {
 		if (mysql_num_rows(result) > 0) {
 			mysql_row = mysql_fetch_row(result);
 
-			if (mysql_row != NULL) {
+			if (mysql_row != NULL && mysql_row[0] != NULL) {
 				retval = strdup(mysql_row[0]);
 				db_free_result(result);
 				return retval;
@@ -291,7 +291,7 @@ static const char *getglobalvariable(MYSQL *psql, int mode, const char *setting)
 		if (mysql_num_rows(result) > 0) {
 			mysql_row = mysql_fetch_row(result);
 
-			if (mysql_row != NULL) {
+			if (mysql_row != NULL && mysql_row[1] != NULL) {
 				retval = strdup(mysql_row[1]);
 				db_free_result(result);
 				return retval;
@@ -1191,13 +1191,11 @@ void die(const char *format, ...) {
 
 	fprintf(stderr, "%s", flogmessage);
 
-	if (set.parent_fork == SPINE_PARENT) {
-		if (set.php_initialized) {
-			php_close(PHP_INIT);
-		}
+	if (set.parent_fork == SPINE_PARENT && set.php_initialized) {
+		php_close(PHP_INIT);
 	}
 
-	exit(set.exit_code);
+	exit(set.exit_code != 0 ? set.exit_code : EXIT_FAILURE);
 }
 
 char * get_date_format() {
@@ -1320,6 +1318,7 @@ int spine_log(const char *format, ...) {
 	int ulog_len   = strlen(ulogmessage);
 	int flog_len   = 0;
 
+	flogmessage[0] = '\0';
 	if ((flog_len = strftime(flogmessage, 50, log_fmt, now_ptr)) == (int) 0) {
 		#ifdef DISABLE_STDERR
 		fp = stdout;
@@ -1705,9 +1704,12 @@ char *strncopy(char *dst, const char *src, size_t obuf) {
 
 	if (obuf == 0) return dst;
 
-	/* Cap the scan at obuf-1: no need to walk past the usable copy capacity,
-	 * and avoids a full strlen when src is large or unterminated near obuf. */
-	copy_len = strnlen(src, obuf - 1);
+	/* Avoid strnlen here: older supported Solaris environments may not
+	 * provide it, and the bounded loop has the same copy semantics. */
+	copy_len = 0;
+	while (copy_len < obuf - 1 && src[copy_len] != '\0') {
+		copy_len++;
+	}
 
 	if (copy_len) {
 		/* copy_len is the exact byte count and dst is terminated below, so
@@ -2057,7 +2059,7 @@ int get_cacti_version(MYSQL *psql, int mode) {
 		if (mysql_num_rows(result) > 0) {
 			mysql_row = mysql_fetch_row(result);
 
-			if (mysql_row != NULL) {
+			if (mysql_row != NULL && mysql_row[0] != NULL) {
 				retval = strdup(mysql_row[0]);
 				db_free_result(result);
 
@@ -2085,4 +2087,3 @@ int get_cacti_version(MYSQL *psql, int mode) {
 		return 0;
 	}
 }
-

--- a/util.c
+++ b/util.c
@@ -108,6 +108,7 @@ static const char *getsetting(MYSQL *psql, int mode, const char *setting) {
 				db_free_result(result);
 				return retval;
 			}else{
+				db_free_result(result);
 				return strdup("");
 			}
 		}else{
@@ -200,6 +201,7 @@ static const char *getpsetting(MYSQL *psql, int mode, const char *setting) {
 				db_free_result(result);
 				return retval;
 			} else {
+				db_free_result(result);
 				return 0;
 			}
 		} else {
@@ -294,6 +296,7 @@ static const char *getglobalvariable(MYSQL *psql, int mode, const char *setting)
 				db_free_result(result);
 				return retval;
 			} else {
+				db_free_result(result);
 				return 0;
 			}
 		} else {
@@ -1364,9 +1367,20 @@ int spine_log(const char *format, ...) {
 		closelog();
 	}
 
-	/* append a line feed to the log message if needed */
+	/* append a line feed to the log message if needed.  The strncat() calls
+	 * above are allowed to fill flogmessage exactly, so the newline only fits
+	 * when a byte is free; otherwise it replaces the last character rather
+	 * than running past the end. */
 	if (!strstr(flogmessage, "\n")) {
-		strcat(flogmessage, "\n");
+		size_t flog_used = strlen(flogmessage);
+
+		if (flog_used < LOGSIZE - 1) {
+			flogmessage[flog_used]     = '\n';
+			flogmessage[flog_used + 1] = '\0';
+		} else {
+			flogmessage[LOGSIZE - 2] = '\n';
+			flogmessage[LOGSIZE - 1] = '\0';
+		}
 	}
 
 	if ((IS_LOGGING_TO_FILE() &&
@@ -2060,6 +2074,7 @@ int get_cacti_version(MYSQL *psql, int mode) {
 					return cacti_version;
 				}
 			}else{
+				db_free_result(result);
 				return 0;
 			}
 		}else{

--- a/util.c
+++ b/util.c
@@ -1683,26 +1683,27 @@ char *add_slashes(char *string) {
  *  \return pointer to destination string
  *
 */
-#pragma GCC diagnostic push
-#if (defined(__GNUC__) && (__GNUC__ > 7)) || (__GNUC__ == 7 && defined(__GNUC_MINOR__) && __GNUC_MINOR__ > 1)
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
-#endif
 char *strncopy(char *dst, const char *src, size_t obuf) {
+	size_t copy_len;
+
 	assert(dst != 0);
 	assert(src != 0);
 
-	size_t len;
+	if (obuf == 0) return dst;
 
-	len = (strlen(src) < obuf) ? strlen(src) : obuf;
-	if (len) {
-		strncpy(dst, src, len);
+	/* Cap the scan at obuf-1: no need to walk past the usable copy capacity,
+	 * and avoids a full strlen when src is large or unterminated near obuf. */
+	copy_len = strnlen(src, obuf - 1);
+
+	if (copy_len) {
+		/* copy_len is the exact byte count and dst is terminated below, so
+		 * memcpy avoids the strncpy truncation diagnostic. */
+		memcpy(dst, src, copy_len);
 	}
 
-	dst[len] = '\0';
+	dst[copy_len] = '\0';
 	return dst;
 }
-#pragma GCC diagnostic pop
 
 /*! \fn double get_time_as_double()
  *  \brief fetches system time as a double-precison value


### PR DESCRIPTION
Backports the memory-safety, process-lifecycle, and polling-correctness fixes identified in the 1.2.x review.

Memory safety and resource handling:
- fix the `strncopy` one-byte overflow and keep its scan portable to older Solaris
- reserve the `php_readpipe` terminator byte, enforce one aggregate response/startup deadline, and recycle a server whose partial or oversized response leaves unread protocol data
- keep log newline appends inside `flogmessage` and initialize the buffer before `strftime`
- free settings-query results on missing rows and check allocation results before dereference
- preserve allocation ownership when trimming recache command output

Process and privilege lifecycle:
- send quit to every PHP server before a shared grace period, then signal/reap in parallel rounds with bounded SIGTERM-to-SIGKILL escalation
- normalize `SIGCHLD` to `SIG_DFL`, verify retained children with `waitpid` before signaling, and prevent active slots from overwriting unreaped PIDs
- bound failed-server restart churn and make every no-server caller return `U`
- block SIGPIPE only around complete script-server writes and consume only a newly generated pending signal
- create pipe/socket descriptors close-on-exec, using `pipe2`/`SOCK_CLOEXEC` when available and a serialized fallback otherwise
- serialize `vfork`, optional libc `popen`, and the complete process-wide euid-0 raw-socket window so data-input children cannot inherit root
- remove unnecessary privilege elevation when closing raw sockets and fail closed if privileges cannot be dropped

Polling correctness:
- preserve complete database hostnames, including bare IPv6 literals. The removed host:port parser was dead: callers do not consume its method/port outputs and overwrite those fields from the database, while tokenizing the hostname truncated valid IPv6 input.
- validate IPv4 and ICMP header lengths before access, consume rejected peeked datagrams, and correlate echo replies by host, type, identifier, and sequence
- make `snmp_count` stop on internal Net-SNMP errors, distinguish SNMPv1 `noSuchName` walk completion, and avoid turning internal errors into valid zero counts
- fail closed when device/item-count rows cannot be fetched, preventing zero counts from becoming unbounded duplicate polls
- make CLI fatal paths return failure and guard nullable database row fields

Verification:
- `./bootstrap` completes (using Homebrew `glibtoolize`; the initial unavailable GNU `libtoolize` probe is non-fatal)
- default configure/build succeeds against Homebrew mysql-client, net-snmp, and OpenSSL 3
- `--enable-popen` configure/build also succeeds
- both builds use `--enable-warnings` and `make -j4`; remaining warnings are pre-existing macOS deprecations and unrelated unused variables
- `git diff --check` passes
- the blocking pre-push review gate passes all stages (critical/high, secondary scanners, medium, and missing-test review)

Scope notes:
- The new close-on-exec handling covers descriptors created by the changed PHP/script/ICMP paths. Existing MySQL, log, and Net-SNMP descriptors do not yet have comprehensive close-on-exec coverage; that broader descriptor audit should be a separate change rather than implied by this backport.
- In the non-default `--enable-popen` mode, the existing timeout path intentionally skips `pclose` and can retain a child until it exits. This PR secures that mode's fork against the euid window but does not redesign its legacy timeout ownership.
- Spine has no in-tree C test harness. The failure-mode paths were statically reviewed and both supported build variants were compiled, but deployment validation should still exercise PHP restart/orphan handling, partial-response timeouts, SNMPv1 count behavior, and malformed/foreign ICMP replies.
