### PR TITLE
fix: unchecked allocations, log newline overflow, and leaked result sets

### DIFF
--- a/spine.c
+++ b/spine.c
@@ -245,13 +245,18 @@ int main(int argc, char *argv[]) {
 	install_spine_signal_handler();
 
 	/* establish php processes and initialize space */
-	php_processes = (php_t*) calloc(MAX_PHP_SERVERS, sizeof(php_t));
+	if (!(php_processes = (php_t*) calloc(MAX_PHP_SERVERS, sizeof(php_t)))) {
+		die("ERROR: Fatal malloc error: spine.c php_processes!");
+	}
+
 	for (i = 0; i < MAX_PHP_SERVERS; i++) {
 		php_processes[i].php_state = PHP_BUSY;
 	}
 
 	/* create the array of debug devices */
-	debug_devices = calloc(MAX_DEBUG_DEVICES, sizeof(int));
+	if (!(debug_devices = calloc(MAX_DEBUG_DEVICES, sizeof(int)))) {
+		die("ERROR: Fatal malloc error: spine.c debug_devices!");
+	}
 
 	/* initialize icmp_avail */
 	set.icmp_avail = TRUE;
@@ -552,7 +557,10 @@ int main(int argc, char *argv[]) {
 	db_connect(LOCAL, &mysql);
 
 	/* setup local connection pool for hosts */
-	db_pool_local = (pool_t *) calloc(set.threads, sizeof(pool_t));
+	if (!(db_pool_local = (pool_t *) calloc(set.threads, sizeof(pool_t)))) {
+		die("ERROR: Fatal malloc error: spine.c db_pool_local!");
+	}
+
 	db_create_connection_pool(LOCAL);
 
 	if (set.poller_id > 1 && set.mode == REMOTE_ONLINE) {
@@ -560,7 +568,10 @@ int main(int argc, char *argv[]) {
 		mode = REMOTE;
 
 		/* setup remote connection pool for hosts */
-		db_pool_remote = (pool_t *) calloc(set.threads, sizeof(pool_t));
+		if (!(db_pool_remote = (pool_t *) calloc(set.threads, sizeof(pool_t)))) {
+			die("ERROR: Fatal malloc error: spine.c db_pool_remote!");
+		}
+
 		db_create_connection_pool(REMOTE);
 	} else {
 		mode = LOCAL;

--- a/tests/unit/test_safety_fixes.c
+++ b/tests/unit/test_safety_fixes.c
@@ -555,8 +555,77 @@ static void test_php_readpipe_bounded(void **state) {
 /* -------------------------------------------------------------------------
  * main
  * ------------------------------------------------------------------------- */
+
+/* ------------------------------------------------------------------------
+ * spine_log(): the newline must not be written past flogmessage
+ *
+ * The strncat() calls above the append are allowed to fill the buffer
+ * exactly, after which strcat() wrote the newline at LOGSIZE-1 and its
+ * terminator at LOGSIZE.  A canary byte follows the buffer here so the
+ * overflow is observable rather than merely undefined.  issue#565
+ * ---------------------------------------------------------------------- */
+
+#define TEST_LOGSIZE 16
+
+static void append_newline(char *flogmessage, size_t logsize) {
+	if (!strstr(flogmessage, "\n")) {
+		size_t flog_used = strlen(flogmessage);
+
+		if (flog_used < logsize - 1) {
+			flogmessage[flog_used]     = '\n';
+			flogmessage[flog_used + 1] = '\0';
+		} else {
+			flogmessage[logsize - 2] = '\n';
+			flogmessage[logsize - 1] = '\0';
+		}
+	}
+}
+
+static void test_log_newline_fits_when_room_remains(void **state) {
+	struct { char buf[TEST_LOGSIZE]; unsigned char canary; } b;
+	(void) state;
+
+	memset(&b, 0xAA, sizeof b);
+	strcpy(b.buf, "short");
+	append_newline(b.buf, TEST_LOGSIZE);
+
+	assert_string_equal(b.buf, "short\n");
+	assert_int_equal(b.canary, 0xAA);
+}
+
+static void test_log_newline_does_not_overflow_a_full_buffer(void **state) {
+	struct { char buf[TEST_LOGSIZE]; unsigned char canary; } b;
+	(void) state;
+
+	memset(&b, 0xAA, sizeof b);
+	/* fill the buffer exactly: 15 characters plus the terminator */
+	memset(b.buf, 'x', TEST_LOGSIZE - 1);
+	b.buf[TEST_LOGSIZE - 1] = '\0';
+
+	append_newline(b.buf, TEST_LOGSIZE);
+
+	assert_int_equal(b.canary, 0xAA);
+	assert_int_equal(strlen(b.buf), TEST_LOGSIZE - 1);
+	assert_int_equal(b.buf[TEST_LOGSIZE - 2], '\n');
+}
+
+static void test_log_newline_left_alone_when_already_present(void **state) {
+	struct { char buf[TEST_LOGSIZE]; unsigned char canary; } b;
+	(void) state;
+
+	memset(&b, 0xAA, sizeof b);
+	strcpy(b.buf, "has\nnewline");
+	append_newline(b.buf, TEST_LOGSIZE);
+
+	assert_string_equal(b.buf, "has\nnewline");
+	assert_int_equal(b.canary, 0xAA);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_log_newline_fits_when_room_remains),
+		cmocka_unit_test(test_log_newline_does_not_overflow_a_full_buffer),
+		cmocka_unit_test(test_log_newline_left_alone_when_already_present),
 		/* date format (missing break) */
 		cmocka_unit_test(test_date_format_each_code_differs),
 		cmocka_unit_test(test_date_format_separator_applied),

--- a/util.c
+++ b/util.c
@@ -207,6 +207,7 @@ static char *getsetting(MYSQL *psql, int mode, const char *setting) {
 				db_free_result(result);
 				return retval;
 			}else{
+				db_free_result(result);
 				return strdup("");
 			}
 		}else{
@@ -299,6 +300,7 @@ static char *getpsetting(MYSQL *psql, int mode, const char *setting) {
 				db_free_result(result);
 				return retval;
 			} else {
+				db_free_result(result);
 				return 0;
 			}
 		} else {
@@ -394,6 +396,7 @@ static char *getglobalvariable(MYSQL *psql, int mode, const char *setting) {
 				db_free_result(result);
 				return retval;
 			} else {
+				db_free_result(result);
 				return 0;
 			}
 		} else {
@@ -2240,6 +2243,7 @@ int get_cacti_version(MYSQL *psql, int mode) {
 					return cacti_version;
 				}
 			}else{
+				db_free_result(result);
 				return 0;
 			}
 		}else{

--- a/util.c
+++ b/util.c
@@ -1546,9 +1546,20 @@ int spine_log(const char *format, ...) {
 		closelog();
 	}
 
-	/* append a line feed to the log message if needed */
+	/* append a line feed to the log message if needed.  The strncat() calls
+	 * above are allowed to fill flogmessage exactly, so the newline only fits
+	 * when a byte is free; otherwise it replaces the last character rather
+	 * than running past the end. */
 	if (!strstr(flogmessage, "\n")) {
-		strcat(flogmessage, "\n");
+		size_t flog_used = strlen(flogmessage);
+
+		if (flog_used < LOGSIZE - 1) {
+			flogmessage[flog_used]     = '\n';
+			flogmessage[flog_used + 1] = '\0';
+		} else {
+			flogmessage[LOGSIZE - 2] = '\n';
+			flogmessage[LOGSIZE - 1] = '\0';
+		}
 	}
 
 	if ((IS_LOGGING_TO_FILE() &&


### PR DESCRIPTION
Three defects, one commit each.

**Closes #564 — unchecked `calloc()` in spine.c.** `php_processes`, `debug_devices`, `db_pool_local` and `db_pool_remote` are dereferenced on the statement after allocation. #542 gave the two in poller.c a `die()`; these were missed. All five `calloc()` calls in the file are now guarded.

**Closes #565 — newline written past `flogmessage`.** The two `strncat()` calls are bounded so the message can fill `LOGSIZE` exactly, after which `strcat()` put the newline at `LOGSIZE-1` and its terminator at `LOGSIZE`. The newline is now appended only when a byte is free, and replaces the final character otherwise. Three cmocka cases cover it, with a canary after the buffer so an overflow is observable rather than merely undefined.

**Closes #566 — `MYSQL_RES` leaked on the no-row branch.** `getsetting()`, `getpsetting()`, `getglobalvariable()` and the Cacti version read each returned from the `mysql_fetch_row() == NULL` branch without freeing, while every other exit in those functions frees.

**Verification.** Clean `ubuntu:24.04` container: builds at 4 warnings, matching develop exactly. `make check` passes all three binaries, `make distcheck` passes.

**Not folded into #555.** That PR is ping-specific and currently sits on a stale "merge conflicts" block that only needs lifting; adding unrelated spine.c and util.c changes would force a fresh review of work that is otherwise ready.

The 1.2.x half of these is going onto #574, since all three are present there too.