### PR TITLE
test: cover the poller result predicates against the shipped objects

### DIFF
--- a/tests/unit/test_linked.c
+++ b/tests/unit/test_linked.c
@@ -457,6 +457,91 @@ static void test_is_debug_device_matches_only_listed_ids(void **state) {
 	debug_devices = saved;
 }
 
+
+/* poller.c decides here whether a polled value is stored at all. A result that
+ * validate_result() rejects is discarded, so a mistake in either predicate
+ * silently drops data or accepts a malformed multi-value string. poller.c is
+ * the most frequently changed file in the tree and had no coverage of either.
+ */
+static void test_validate_result_accepts_numeric_forms(void **state) {
+	char integer[]  = "42";
+	char negative[] = "-17";
+	char decimal[]  = "3.14159";
+	char zero[]     = "0";
+	(void) state;
+
+	assert_int_equal(validate_result(integer), TRUE);
+	assert_int_equal(validate_result(negative), TRUE);
+	assert_int_equal(validate_result(decimal), TRUE);
+	assert_int_equal(validate_result(zero), TRUE);
+}
+
+static void test_validate_result_rejects_a_null_and_junk(void **state) {
+	char junk[]  = "not a value";
+	char empty[] = "";
+	(void) state;
+
+	assert_int_equal(validate_result(NULL), FALSE);
+	assert_int_equal(validate_result(junk), FALSE);
+	assert_int_equal(validate_result(empty), FALSE);
+}
+
+static void test_validate_result_accepts_multipart_output(void **state) {
+	char one[]  = "field:1";
+	char many[] = "in:100 out:200 errors:0";
+	(void) state;
+
+	assert_int_equal(validate_result(one), TRUE);
+	assert_int_equal(validate_result(many), TRUE);
+}
+
+/* trim() is asymmetric and the caller needs to know it. rtrim() writes a NUL
+ * over the trailing run, so it mutates the caller's buffer; ltrim() only walks
+ * a pointer forward and leaves the leading run in place. validate_result()
+ * therefore edits the buffer it is handed, but not into the string the
+ * predicate actually saw. Its trim set is also wider than whitespace: it
+ * includes quotes and a backslash.
+ */
+static void test_validate_result_trims_the_buffer_asymmetrically(void **state) {
+	char padded[] = "  field:1  ";
+	char quoted[] = "\"field:1\"";
+	(void) state;
+
+	assert_int_equal(validate_result(padded), TRUE);
+	/* rtrim removed the trailing run in place, ltrim did not touch the front */
+	assert_string_equal(padded, "  field:1");
+
+	assert_int_equal(validate_result(quoted), TRUE);
+	assert_string_equal(quoted, "\"field:1");
+}
+
+static void test_is_multipart_output_requires_a_delimiter(void **state) {
+	char colon[]    = "a:1";
+	char bang[]     = "a!1";
+	char no_delim[] = "abc";
+	(void) state;
+
+	assert_int_equal(is_multipart_output(colon), TRUE);
+	assert_int_equal(is_multipart_output(bang), TRUE);
+	assert_int_equal(is_multipart_output(no_delim), FALSE);
+	assert_int_equal(is_multipart_output(NULL), FALSE);
+}
+
+/* With spaces present the pair count has to line up: one more delimiter than
+ * spaces. That is what separates "a:1 b:2" from a value that merely contains
+ * a colon somewhere in free text.
+ */
+static void test_is_multipart_output_balances_spaces_against_delimiters(void **state) {
+	char balanced[]   = "a:1 b:2 c:3";
+	char unbalanced[] = "a:1 b:2 c";
+	char prose[]      = "time is 12:30 today";
+	(void) state;
+
+	assert_int_equal(is_multipart_output(balanced), TRUE);
+	assert_int_equal(is_multipart_output(unbalanced), FALSE);
+	assert_int_equal(is_multipart_output(prose), FALSE);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_strncopy_truncates_within_the_buffer),
@@ -496,6 +581,12 @@ int main(void) {
 		cmocka_unit_test(test_get_date_format_clamps_an_out_of_range_format),
 		cmocka_unit_test(test_get_date_format_covers_each_supported_format),
 		cmocka_unit_test(test_is_debug_device_matches_only_listed_ids),
+		cmocka_unit_test(test_validate_result_accepts_numeric_forms),
+		cmocka_unit_test(test_validate_result_rejects_a_null_and_junk),
+		cmocka_unit_test(test_validate_result_accepts_multipart_output),
+		cmocka_unit_test(test_validate_result_trims_the_buffer_asymmetrically),
+		cmocka_unit_test(test_is_multipart_output_requires_a_delimiter),
+		cmocka_unit_test(test_is_multipart_output_balances_spaces_against_delimiters),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
`poller.c` is the most frequently changed file in the tree, 28 of the last 100 commits, and `validate_result()` is where it decides whether a polled value is stored at all. Neither it nor `is_multipart_output()` had any coverage. A mistake in either silently discards data or accepts a malformed multi-value string, and nothing fails.

Six cases added to `test_linked`, so they run against the real `poller.o` rather than a copy of the logic:

- numeric forms: integer, negative, decimal, zero
- rejection: `NULL`, free text, empty string
- multi-field output, single and several pairs
- the space-to-delimiter balance, which is what separates `in:100 out:200` from prose that merely contains a colon such as `time is 12:30 today`
- the `trim()` contract

## On the trim case
It documents an asymmetry worth knowing about. `rtrim()` writes a NUL over the trailing run, so it edits the caller's buffer. `ltrim()` only advances a pointer, so the leading run survives in the buffer the caller keeps. `validate_result()` therefore mutates what it is handed, but not into the string the predicate actually saw. The trim set is also wider than whitespace: it includes quotes and a backslash.

I wrote that test asserting the tidier behaviour first, `"  field:1  "` becoming `"field:1"`. It failed, and the assertions here describe what the code does.

## Verification
Built and run in an Ubuntu 24.04 container matching `ci.yml`'s dependency list:

```
PASS: tests/unit/test_util_strings
PASS: tests/unit/test_build_fixes
PASS: tests/unit/test_safety_fixes
PASS: tests/unit/test_linked
# TOTAL: 4   # PASS: 4   # FAIL: 0

test_linked: 43 tests run, 43 passed
```

No build change is needed: `Makefile.am` already links `poller.c` into `test_linked`.

Follows the pattern established by #563, which found the suite was certifying copies rather than shipped code.
