### PR TITLE
fix: size the escape destination from the caller's buffer

### DIFF
--- a/poller.c
+++ b/poller.c
@@ -1882,7 +1882,9 @@ void poll_host(int device_counter, int host_id, int host_thread, int host_thread
 
 		i = 0;
 		while (i < rows_processed) {
-			char escaped_result[DBL_BUFSIZE];
+			/* escaping can double every byte, so the destination has to be
+			 * twice the source plus the terminator */
+			char escaped_result[(RESULTS_BUFFER * 2) + 1];
 			char escaped_rrd_name[DBL_BUFSIZE];
 
 			db_escape(&mysqlt, escaped_result, sizeof(escaped_result), poller_items[i].result);

--- a/sql.c
+++ b/sql.c
@@ -584,22 +584,32 @@ int append_hostrange(char *obuf, const char *colname) {
  *
  */
 void db_escape(MYSQL *mysql, char *output, int max_size, const char *input) {
-	char input_trimmed[DBL_BUFSIZE];
-	int  max_escaped_input_size;
-	int  trim_limit;
+	size_t input_len;
+	size_t max_input;
 
-	if (input == NULL) return;
+	if (input == NULL || output == NULL) return;
 
-	max_escaped_input_size = (strlen(input) * 2) + 1;
-	trim_limit = (max_size < DBL_BUFSIZE) ? max_size : DBL_BUFSIZE;
+	if (max_size <= 1) {
+		if (max_size == 1) {
+			*output = '\0';
+		}
 
-	if (max_escaped_input_size > max_size) {
-		snprintf(input_trimmed, (trim_limit / 2) - 1, "%s", input);
-	} else {
-		snprintf(input_trimmed, trim_limit, "%s", input);
+		return;
 	}
 
-	mysql_real_escape_string(mysql, output, input_trimmed, strlen(input_trimmed));
+	/* Escaping can double every byte and the result is NUL terminated, so at
+	 * most (max_size - 1) / 2 input bytes fit. The previous implementation
+	 * staged the input through a fixed DBL_BUFSIZE buffer first, which capped
+	 * every caller at 1022 bytes regardless of the destination it supplied, so
+	 * a poller result of 1024 bytes or more was silently truncated. */
+	max_input = ((size_t) max_size - 1) / 2;
+	input_len = strlen(input);
+
+	if (input_len > max_input) {
+		input_len = max_input;
+	}
+
+	mysql_real_escape_string(mysql, output, input, (unsigned long) input_len);
 }
 
 void db_free_result(MYSQL_RES *result) {

--- a/tests/unit/test_linked.c
+++ b/tests/unit/test_linked.c
@@ -457,6 +457,106 @@ static void test_is_debug_device_matches_only_listed_ids(void **state) {
 	debug_devices = saved;
 }
 
+
+/* db_escape() stands between a device-supplied poller result and the SQL text
+ * spine builds: it escapes the metacharacters and must never write past the
+ * destination. It used to stage the input through a fixed DBL_BUFSIZE buffer,
+ * which capped every caller at 1022 input bytes no matter how large a
+ * destination it passed, so poller results were silently truncated.
+ */
+static MYSQL *escape_handle(void) {
+	static MYSQL *handle = NULL;
+
+	if (handle == NULL) {
+		handle = mysql_init(NULL);
+	}
+
+	return handle;
+}
+
+static void test_db_escape_escapes_sql_metacharacters(void **state) {
+	char out[64];
+	(void) state;
+
+	db_escape(escape_handle(), out, sizeof out, "a'b");
+	assert_string_equal(out, "a\\'b");
+
+	db_escape(escape_handle(), out, sizeof out, "back\\slash");
+	assert_string_equal(out, "back\\\\slash");
+
+	db_escape(escape_handle(), out, sizeof out, "plain value");
+	assert_string_equal(out, "plain value");
+}
+
+static void test_db_escape_ignores_a_null_input(void **state) {
+	char out[16];
+	(void) state;
+
+	memcpy(out, "untouched", 10);
+	db_escape(escape_handle(), out, sizeof out, NULL);
+	assert_string_equal(out, "untouched");
+}
+
+/* A result the size of the poller's own buffer has to survive when the
+ * destination is sized 2N+1 for it. This is the case that regressed. */
+static void test_db_escape_keeps_a_full_results_buffer(void **state) {
+	char input[RESULTS_BUFFER];
+	char out[(RESULTS_BUFFER * 2) + 1];
+	(void) state;
+
+	memset(input, 'x', sizeof input - 1);
+	input[sizeof input - 1] = '\0';
+
+	db_escape(escape_handle(), out, sizeof out, input);
+
+	assert_int_equal((int) strlen(out), (int) (sizeof input - 1));
+	assert_string_equal(out, input);
+}
+
+/* Walk across the old staging boundary to prove the cut is gone. */
+static void test_db_escape_survives_the_old_staging_boundary(void **state) {
+	const int sizes[] = { 1022, 1023, 1024, 1100, 2047 };
+	char      input[2048];
+	char      out[(2048 * 2) + 1];
+	size_t    i;
+	(void) state;
+
+	for (i = 0; i < sizeof sizes / sizeof sizes[0]; i++) {
+		memset(input, 'y', (size_t) sizes[i]);
+		input[sizes[i]] = '\0';
+
+		db_escape(escape_handle(), out, sizeof out, input);
+
+		assert_int_equal((int) strlen(out), sizes[i]);
+	}
+}
+
+/* When the destination genuinely cannot hold the escaped form the result is
+ * truncated rather than overflowing, and stays NUL terminated. */
+static void test_db_escape_truncates_into_a_small_destination(void **state) {
+	char out[11];
+	(void) state;
+
+	db_escape(escape_handle(), out, sizeof out, "0123456789abcdef");
+
+	/* (11 - 1) / 2 == 5 input bytes may be represented */
+	assert_int_equal((int) strlen(out), 5);
+	assert_string_equal(out, "01234");
+}
+
+static void test_db_escape_handles_a_degenerate_destination(void **state) {
+	char out[4];
+	(void) state;
+
+	memcpy(out, "abc", 4);
+	db_escape(escape_handle(), out, 1, "anything");
+	assert_string_equal(out, "");
+
+	memcpy(out, "abc", 4);
+	db_escape(escape_handle(), out, 0, "anything");
+	assert_string_equal(out, "abc");
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_strncopy_truncates_within_the_buffer),
@@ -496,6 +596,12 @@ int main(void) {
 		cmocka_unit_test(test_get_date_format_clamps_an_out_of_range_format),
 		cmocka_unit_test(test_get_date_format_covers_each_supported_format),
 		cmocka_unit_test(test_is_debug_device_matches_only_listed_ids),
+		cmocka_unit_test(test_db_escape_escapes_sql_metacharacters),
+		cmocka_unit_test(test_db_escape_ignores_a_null_input),
+		cmocka_unit_test(test_db_escape_keeps_a_full_results_buffer),
+		cmocka_unit_test(test_db_escape_survives_the_old_staging_boundary),
+		cmocka_unit_test(test_db_escape_truncates_into_a_small_destination),
+		cmocka_unit_test(test_db_escape_handles_a_degenerate_destination),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Fixes #583, and the tests written for it turned up something worse than the reported truncation.

## The reported bug
`db_escape()` staged its input through a fixed `DBL_BUFSIZE` buffer before escaping:

```c
trim_limit = (max_size < DBL_BUFSIZE) ? max_size : DBL_BUFSIZE;
if (max_escaped_input_size > max_size) {
    snprintf(input_trimmed, (trim_limit / 2) - 1, "%s", input);
```

Every caller was therefore capped at 1022 input bytes regardless of the destination it passed. A poller result of 1024 bytes or more was silently cut, which matters because `RESULTS_BUFFER` defaults to 2048 and is tunable through `--with-results-buffer` precisely to carry multi-value output. A cut result loses its trailing `field:value` pair, so that data source gets a bad RRD update every cycle.

## What the tests found as well
The same arithmetic is wrong for a small destination. With `max_size` of 1, `(trim_limit / 2) - 1` is `-1`, which `snprintf` takes as an unbounded size, and the escaped result is then written into a destination far smaller than it.

Building the new tests against the **old** implementation does not just fail an assertion:

```
[  FAILED  ] test_db_escape_truncates_into_a_small_destination
[ RUN      ] test_db_escape_handles_a_degenerate_destination
*** buffer overflow detected ***: terminated
```

No in-tree caller passes a destination that small today, so this is a latent overflow rather than a live one, but it is the reason the function needed restructuring rather than a wider staging buffer.

## The change
Derive the limit from the destination and escape straight from the caller's input, dropping the staging buffer entirely. Escaping can double every byte and the result is NUL terminated, so at most `(max_size - 1) / 2` input bytes fit.

`poller.c` sizes `escaped_result` at `(RESULTS_BUFFER * 2) + 1` for its `RESULTS_BUFFER` source, which is what the doubling requires. `escaped_rrd_name` is left alone; its source is `char[30]`.

## Tests
Six cases in `test_linked`, so they run against the shipped `sql.o`:

- metacharacter escaping, quote and backslash
- a `NULL` input leaves the destination untouched
- a full `RESULTS_BUFFER` source round trips with nothing dropped
- the 1022, 1023, 1024, 1100, 2047 boundary the old staging buffer cut at
- truncation into a destination too small for the escaped form, still terminated
- a degenerate `max_size` of 0 and 1

Verified in an Ubuntu 24.04 container matching `ci.yml`: 43 of 43 tests pass with the fix, and the boundary and degenerate cases fail without it.
