### PR TITLE
fix: restore the SNMPv3 noAuthNoPriv and authNoPriv security levels

### DIFF
--- a/snmp.c
+++ b/snmp.c
@@ -41,6 +41,62 @@
 
 #define OIDSIZE(p) (sizeof(p)/sizeof(oid))
 
+/*! \fn int spine_snmpv3_value_is_set(const char *value)
+ *  \brief Whether a Cacti-supplied SNMPv3 field selects anything.
+ *
+ *  Cacti stores the literal "[None]" when the user picks no protocol, and an
+ *  empty string when a passphrase is absent. Both mean "not selected".
+ */
+int spine_snmpv3_value_is_set(const char *value) {
+	if (value == NULL) {
+		return FALSE;
+	}
+
+	if (value[0] == '\0') {
+		return FALSE;
+	}
+
+	if (strcmp(value, "[None]") == 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/*! \fn int spine_snmpv3_security_level(...)
+ *  \brief Pick the SNMPv3 security level from the values Cacti stores.
+ *
+ *  Authentication needs both a protocol and a password; privacy additionally
+ *  needs a privacy protocol and passphrase, and is only meaningful on top of
+ *  authentication. Anything not selected leaves the level lower rather than
+ *  making the device an error, which is what Cacti's own poller does.
+ *
+ *  \return SNMP_SEC_LEVEL_NOAUTH, SNMP_SEC_LEVEL_AUTHNOPRIV or
+ *          SNMP_SEC_LEVEL_AUTHPRIV
+ */
+int spine_snmpv3_security_level(const char *auth_protocol, const char *auth_password,
+		const char *priv_protocol, const char *priv_passphrase) {
+	int authenticates;
+	int encrypts;
+
+	authenticates = spine_snmpv3_value_is_set(auth_protocol) &&
+		spine_snmpv3_value_is_set(auth_password);
+
+	encrypts = authenticates &&
+		spine_snmpv3_value_is_set(priv_protocol) &&
+		spine_snmpv3_value_is_set(priv_passphrase);
+
+	if (encrypts) {
+		return SNMP_SEC_LEVEL_AUTHPRIV;
+	}
+
+	if (authenticates) {
+		return SNMP_SEC_LEVEL_AUTHNOPRIV;
+	}
+
+	return SNMP_SEC_LEVEL_NOAUTH;
+}
+
 /*! \fn void snmp_spine_init()
  *  \brief wrapper function for init_snmp
  *
@@ -226,18 +282,31 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		/* set the authentication protocol */
 		{
 		int auth_type;
+		int security_level;
 		const oid *auth_proto;
 
-		auth_type = usm_lookup_auth_type(snmp_auth_protocol);
-		if (auth_type > 0) {
-            auth_proto = sc_get_auth_oid(auth_type, &session.securityAuthProtoLen);
-            free(session.securityAuthProto);
-            session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
+		/* Cacti stores "[None]" when no protocol is selected, and an absent
+		 * passphrase means the same thing. Neither is an error: the device is
+		 * simply noAuthNoPriv, which is what cmd.php does with the same values.
+		 * Only a protocol that is set and unrecognised is invalid. */
+		security_level = spine_snmpv3_security_level(snmp_auth_protocol, snmp_password,
+			snmp_priv_protocol, snmp_priv_passphrase);
+
+		if (security_level == SNMP_SEC_LEVEL_NOAUTH) {
+			session.securityLevel = SNMP_SEC_LEVEL_NOAUTH;
 		} else {
-			SPINE_LOG(("SNMP: Device[%i] Error auth protocol %s is invalid.", host_id, snmp_auth_protocol));
-			free(session.peername);
-			free(session.localname);
-			return 0;
+			auth_type = usm_lookup_auth_type(snmp_auth_protocol);
+
+			if (auth_type > 0) {
+				auth_proto = sc_get_auth_oid(auth_type, &session.securityAuthProtoLen);
+				free(session.securityAuthProto);
+				session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
+			} else {
+				SPINE_LOG(("SNMP: Device[%i] Error auth protocol %s is invalid.", host_id, snmp_auth_protocol));
+				free(session.peername);
+				free(session.localname);
+				return 0;
+			}
 		}
 
 		/* set the privacy protocol to none */
@@ -247,10 +316,39 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			session.securityPrivKeyLen   = USM_PRIV_KU_LEN;
 
 			/* set the security level to authenticate, but not encrypted */
-			if (strlen(snmp_password)) {
-				session.securityLevel = SNMP_SEC_LEVEL_AUTHNOPRIV;
-			} else {
-				session.securityLevel = SNMP_SEC_LEVEL_NOAUTH;
+			session.securityLevel = security_level;
+
+			/* The authentication key was only ever derived on the privacy path,
+			 * so authNoPriv sessions authenticated with an empty key and every
+			 * such device failed with a USM authentication error. */
+			if (security_level == SNMP_SEC_LEVEL_AUTHNOPRIV) {
+				if (Apsz && zero_sensitive) {
+					memset(Apsz, 0x0, strlen(Apsz));
+				}
+
+				free(Apsz);
+				Apsz = strdup(snmp_password);
+
+				if (zero_sensitive) {
+					memset(snmp_password, 0x0, strlen(snmp_password));
+				}
+
+				session.securityAuthKeyLen = USM_AUTH_KU_LEN;
+
+				if (Apsz == NULL || generate_Ku(session.securityAuthProto,
+					session.securityAuthProtoLen,
+					(u_char *) Apsz, strlen(Apsz),
+					session.securityAuthKey,
+					&session.securityAuthKeyLen) != SNMPERR_SUCCESS) {
+					SPINE_LOG(("SNMP: Device[%i] Error generating SNMPv3 Ku from authentication passphrase.", host_id));
+					free(session.peername);
+					free(session.securityAuthProto);
+					free(session.securityPrivProto);
+					free(Apsz);
+					free(Xpsz);
+					free(session.localname);
+					return 0;
+				}
 			}
 		} else {
 			const oid *priv_proto;

--- a/spine.h
+++ b/spine.h
@@ -626,6 +626,10 @@ typedef struct db_connection {
 #include "error.h"
 
 /* Globals */
+extern int spine_snmpv3_value_is_set(const char *value);
+extern int spine_snmpv3_security_level(const char *auth_protocol, const char *auth_password,
+	const char *priv_protocol, const char *priv_passphrase);
+
 extern config_t set;
 extern php_t  *php_processes;
 extern char   start_datetime[20];

--- a/tests/unit/test_linked.c
+++ b/tests/unit/test_linked.c
@@ -457,6 +457,77 @@ static void test_is_debug_device_matches_only_listed_ids(void **state) {
 	debug_devices = saved;
 }
 
+
+/* Cacti stores the literal "[None]" when no SNMPv3 protocol is selected, and an
+ * empty string for an absent passphrase. Treating either as an error made two
+ * of the three security levels unusable: noAuthNoPriv was refused before the
+ * session opened, and authNoPriv authenticated with a key that was never
+ * derived. cmd.php accepts both, so a device that polls under the PHP poller
+ * has to poll under spine.
+ */
+static void test_snmpv3_value_is_set_treats_none_as_unset(void **state) {
+	(void) state;
+
+	assert_int_equal(spine_snmpv3_value_is_set(NULL), FALSE);
+	assert_int_equal(spine_snmpv3_value_is_set(""), FALSE);
+	assert_int_equal(spine_snmpv3_value_is_set("[None]"), FALSE);
+
+	assert_int_equal(spine_snmpv3_value_is_set("SHA"), TRUE);
+	assert_int_equal(spine_snmpv3_value_is_set("secret"), TRUE);
+	/* only the exact sentinel is unset */
+	assert_int_equal(spine_snmpv3_value_is_set("[None] "), TRUE);
+	assert_int_equal(spine_snmpv3_value_is_set("none"), TRUE);
+}
+
+static void test_snmpv3_level_is_noauth_without_a_protocol(void **state) {
+	(void) state;
+
+	assert_int_equal(spine_snmpv3_security_level("[None]", "", "[None]", ""),
+		SNMP_SEC_LEVEL_NOAUTH);
+	assert_int_equal(spine_snmpv3_security_level(NULL, NULL, NULL, NULL),
+		SNMP_SEC_LEVEL_NOAUTH);
+	/* a protocol with no password cannot authenticate */
+	assert_int_equal(spine_snmpv3_security_level("SHA", "", "[None]", ""),
+		SNMP_SEC_LEVEL_NOAUTH);
+	/* nor a password with no protocol */
+	assert_int_equal(spine_snmpv3_security_level("[None]", "secret", "[None]", ""),
+		SNMP_SEC_LEVEL_NOAUTH);
+}
+
+static void test_snmpv3_level_is_authnopriv_without_privacy(void **state) {
+	(void) state;
+
+	assert_int_equal(spine_snmpv3_security_level("SHA", "secret", "[None]", ""),
+		SNMP_SEC_LEVEL_AUTHNOPRIV);
+	assert_int_equal(spine_snmpv3_security_level("MD5", "secret", "", ""),
+		SNMP_SEC_LEVEL_AUTHNOPRIV);
+	assert_int_equal(spine_snmpv3_security_level("SHA-512", "secret", NULL, NULL),
+		SNMP_SEC_LEVEL_AUTHNOPRIV);
+	/* a privacy protocol without its passphrase is not privacy */
+	assert_int_equal(spine_snmpv3_security_level("SHA", "secret", "AES", ""),
+		SNMP_SEC_LEVEL_AUTHNOPRIV);
+}
+
+static void test_snmpv3_level_is_authpriv_when_both_are_set(void **state) {
+	(void) state;
+
+	assert_int_equal(spine_snmpv3_security_level("SHA", "secret", "AES", "privpass"),
+		SNMP_SEC_LEVEL_AUTHPRIV);
+	assert_int_equal(spine_snmpv3_security_level("SHA-256", "secret", "AES-192", "privpass"),
+		SNMP_SEC_LEVEL_AUTHPRIV);
+}
+
+/* Privacy without authentication is not a level SNMPv3 offers, so a privacy
+ * selection alone must not raise the level above noAuthNoPriv. */
+static void test_snmpv3_privacy_alone_does_not_raise_the_level(void **state) {
+	(void) state;
+
+	assert_int_equal(spine_snmpv3_security_level("[None]", "", "AES", "privpass"),
+		SNMP_SEC_LEVEL_NOAUTH);
+	assert_int_equal(spine_snmpv3_security_level("SHA", "", "AES", "privpass"),
+		SNMP_SEC_LEVEL_NOAUTH);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_strncopy_truncates_within_the_buffer),
@@ -496,6 +567,11 @@ int main(void) {
 		cmocka_unit_test(test_get_date_format_clamps_an_out_of_range_format),
 		cmocka_unit_test(test_get_date_format_covers_each_supported_format),
 		cmocka_unit_test(test_is_debug_device_matches_only_listed_ids),
+		cmocka_unit_test(test_snmpv3_value_is_set_treats_none_as_unset),
+		cmocka_unit_test(test_snmpv3_level_is_noauth_without_a_protocol),
+		cmocka_unit_test(test_snmpv3_level_is_authnopriv_without_privacy),
+		cmocka_unit_test(test_snmpv3_level_is_authpriv_when_both_are_set),
+		cmocka_unit_test(test_snmpv3_privacy_alone_does_not_raise_the_level),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Fixes #582.

Cacti stores the literal `[None]` when no SNMPv3 protocol is selected, and an empty string for an absent passphrase. Since #373 spine treated both as errors, so two of the three security levels stopped working while `cmd.php` kept accepting them. A device that polls fine under the PHP poller fails under spine.

Measured against real net-snmp, replicating the shipped predicates:

```
level          | old: session opens? | old: derives auth key?
noAuthNoPriv   | NO  <-- broken      | n/a
authNoPriv     | yes                 | NO  <-- broken
authPriv       | yes                 | yes
```

**noAuthNoPriv** — `usm_lookup_auth_type("[None]")` returns `-1`, and `snmp.c` returned 0 from the session setup on any non-positive result, so the session was never opened.

**authNoPriv** — the authentication key was derived only on the privacy path, so the session authenticated with `securityAuthKeyLen` still 0 and the agent answered with a USM authentication failure. That points an operator at their credentials rather than at spine.

## The change
Decide the level first, from the four values Cacti supplies, and only require a recognised protocol when authentication is actually in use. Derive the key whenever the level authenticates rather than only when it also encrypts.

The decision is extracted as `spine_snmpv3_security_level()`, which is pure and therefore testable without a live session. That is deliberate: the logic that was wrong is now the part that has coverage.

## Tests
Five cases in `test_linked`, against the shipped `snmp.o`:

- `[None]`, empty and `NULL` are unset; `none` and `[None] ` are not the sentinel
- noAuthNoPriv for no protocol, and for a protocol without a password
- authNoPriv for auth without privacy, including a privacy protocol whose passphrase is missing
- authPriv when both are set
- privacy selected without authentication does not raise the level, since SNMPv3 has no privNoAuth

42 of 42 pass in an Ubuntu 24.04 container matching `ci.yml`, and `snmp.c` compiles warning-clean under `--enable-warnings`.

## Not covered here
The integration fixture still exercises authPriv only. Adding noAuthNoPriv and authNoPriv devices to it would have caught this and is worth doing separately.
