### PR TITLE
fix: restore safe SNMPv3 session construction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,7 @@ The Cacti Group | spine
 -issue#552: Terminate die() output so consecutive fatal messages no longer run together
 -issue#561: Reserve room for the terminator in php_readpipe() so a full script server result cannot write past result_string
 -issue#562: Escalate PHP script server shutdown to SIGKILL after a bounded grace period so a stuck child is not orphaned
--issue: Restore SNMPv3 noAuthNoPriv and authNoPriv sessions, validate privacy/authentication combinations, and wipe local passphrase copies
+-issue: Restore SNMPv3 noAuthNoPriv and authNoPriv sessions, validate privacy/authentication combinations, refuse passwords paired with blank protocol fields, and wipe local passphrase copies
 -issue: Correct signed and unsigned printf format specifiers in poller.c, free session.localname on the unknown-version return in snmp.c, and quote shell variables in the build scripts
 -issue: Escape the SNMP result and RRD name before the poller_output INSERT, bound the buffer_output_errors write to the space left in error_string, and validate the --hostlist argument before it reaches SQL
 -issue: Restore the twelve headers and spine.conf.dist missing from the dist tarball so a release tarball can be compiled from

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ The Cacti Group | spine
 -issue#552: Terminate die() output so consecutive fatal messages no longer run together
 -issue#561: Reserve room for the terminator in php_readpipe() so a full script server result cannot write past result_string
 -issue#562: Escalate PHP script server shutdown to SIGKILL after a bounded grace period so a stuck child is not orphaned
+-issue: Restore SNMPv3 noAuthNoPriv and authNoPriv sessions, validate privacy/authentication combinations, and wipe local passphrase copies
 -issue: Correct signed and unsigned printf format specifiers in poller.c, free session.localname on the unknown-version return in snmp.c, and quote shell variables in the build scripts
 -issue: Escape the SNMP result and RRD name before the poller_output INSERT, bound the buffer_output_errors write to the space left in error_string, and validate the --hostlist argument before it reaches SQL
 -issue: Restore the twelve headers and spine.conf.dist missing from the dist tarball so a release tarball can be compiled from

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,8 @@ check_PROGRAMS += \
 	tests/unit/test_util_strings \
 	tests/unit/test_build_fixes \
 	tests/unit/test_safety_fixes \
-	tests/unit/test_linked
+	tests/unit/test_linked \
+	tests/unit/test_snmpv3_session
 endif
 
 # test_util_strings pulls in common.h and the sources under test, so it needs
@@ -85,5 +86,9 @@ tests_unit_test_safety_fixes_LDADD   = $(CMOCKA_LIBS)
 tests_unit_test_linked_SOURCES = tests/unit/test_linked.c tests/fuzz/stubs.c \
 	sql.c util.c snmp.c locks.c poller.c nft_popen.c php.c ping.c keywords.c error.c
 tests_unit_test_linked_LDADD   = $(CMOCKA_LIBS) $(LIBS)
+
+tests_unit_test_snmpv3_session_SOURCES = tests/unit/test_snmpv3_session.c tests/fuzz/stubs.c \
+	sql.c util.c snmp.c locks.c poller.c nft_popen.c php.c ping.c keywords.c error.c
+tests_unit_test_snmpv3_session_LDADD   = $(CMOCKA_LIBS) $(LIBS)
 
 TESTS = $(check_PROGRAMS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,7 @@ tests_unit_test_linked_SOURCES = tests/unit/test_linked.c tests/fuzz/stubs.c \
 tests_unit_test_linked_LDADD   = $(CMOCKA_LIBS) $(LIBS)
 
 tests_unit_test_snmpv3_session_SOURCES = tests/unit/test_snmpv3_session.c tests/fuzz/stubs.c \
-	sql.c util.c snmp.c locks.c poller.c nft_popen.c php.c ping.c keywords.c error.c
+	sql.c util.c locks.c poller.c nft_popen.c php.c ping.c keywords.c error.c
 tests_unit_test_snmpv3_session_LDADD   = $(CMOCKA_LIBS) $(LIBS)
 
 TESTS = $(check_PROGRAMS)

--- a/configure.ac
+++ b/configure.ac
@@ -399,6 +399,23 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   [AC_MSG_RESULT(no)])
 LIBS="$spine_save_LIBS"
 
+# ****************** AES privacy protocol availability **********************
+dnl A DES-disabled net-snmp normally provides AES, but packaging can remove
+dnl both. Probe the symbol before compiling the fallback reference.
+AC_MSG_CHECKING([whether the net-snmp library exports usmAESPrivProtocol])
+spine_save_LIBS="$LIBS"
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+  #include <net-snmp/net-snmp-config.h>
+  #include <net-snmp/net-snmp-includes.h>
+]], [[
+  const oid *p = usmAESPrivProtocol;
+  return p == NULL;
+]])],
+  [AC_DEFINE(HAVE_USM_AES_PRIV_PROTOCOL, 1, [Define if the net-snmp library exports usmAESPrivProtocol.])
+   AC_MSG_RESULT(yes)],
+  [AC_MSG_RESULT(no)])
+LIBS="$spine_save_LIBS"
+
 # ****************** SHA-1 auth protocol availability **********************
 dnl Do not use SNMP_DEFAULT_AUTH_PROTO as a last-resort fallback: on an MD5-
 dnl disabled/FIPS header it may name a symbol the linked library does not

--- a/configure.ac
+++ b/configure.ac
@@ -379,6 +379,26 @@ AC_DEFINE_UNQUOTED(SNMP_LOCALNAME, $havelocalname, If snmp localname session str
 
 AC_CHECK_LIB(netsnmp, snmp_timeout)
 
+# ****************** DES privacy protocol availability **********************
+dnl SNMP_DEFAULT_PRIV_PROTO names usmDESPrivProtocol unless the header sets
+dnl NETSNMP_DISABLE_DES. Fedora once shipped a net-snmp where the header took
+dnl the DES branch while the library exported no such symbol, so spine failed
+dnl to link rather than degrading. Checking the macro is not enough, because
+dnl that packaging did not set it; the symbol itself has to be probed.
+AC_MSG_CHECKING([whether the net-snmp library exports usmDESPrivProtocol])
+spine_save_LIBS="$LIBS"
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+  #include <net-snmp/net-snmp-config.h>
+  #include <net-snmp/net-snmp-includes.h>
+]], [[
+  const oid *p = usmDESPrivProtocol;
+  return p == NULL;
+]])],
+  [AC_DEFINE(HAVE_USM_DES_PRIV_PROTOCOL, 1, [Define if the net-snmp library exports usmDESPrivProtocol.])
+   AC_MSG_RESULT(yes)],
+  [AC_MSG_RESULT(no)])
+LIBS="$spine_save_LIBS"
+
 # ****************** SNMPv3 USM Error Constants Check ***********************
 AC_MSG_CHECKING([for SNMPv3 USM error constants])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[

--- a/configure.ac
+++ b/configure.ac
@@ -379,62 +379,6 @@ AC_DEFINE_UNQUOTED(SNMP_LOCALNAME, $havelocalname, If snmp localname session str
 
 AC_CHECK_LIB(netsnmp, snmp_timeout)
 
-# ****************** DES privacy protocol availability **********************
-dnl SNMP_DEFAULT_PRIV_PROTO names usmDESPrivProtocol unless the header sets
-dnl NETSNMP_DISABLE_DES. Fedora once shipped a net-snmp where the header took
-dnl the DES branch while the library exported no such symbol, so spine failed
-dnl to link rather than degrading. Checking the macro is not enough, because
-dnl that packaging did not set it; the symbol itself has to be probed.
-AC_MSG_CHECKING([whether the net-snmp library exports usmDESPrivProtocol])
-spine_save_LIBS="$LIBS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <net-snmp/net-snmp-config.h>
-  #include <net-snmp/net-snmp-includes.h>
-]], [[
-  const oid *p = usmDESPrivProtocol;
-  return p == NULL;
-]])],
-  [AC_DEFINE(HAVE_USM_DES_PRIV_PROTOCOL, 1, [Define if the net-snmp library exports usmDESPrivProtocol.])
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)])
-LIBS="$spine_save_LIBS"
-
-# ****************** AES privacy protocol availability **********************
-dnl A DES-disabled net-snmp normally provides AES, but packaging can remove
-dnl both. Probe the symbol before compiling the fallback reference.
-AC_MSG_CHECKING([whether the net-snmp library exports usmAESPrivProtocol])
-spine_save_LIBS="$LIBS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <net-snmp/net-snmp-config.h>
-  #include <net-snmp/net-snmp-includes.h>
-]], [[
-  const oid *p = usmAESPrivProtocol;
-  return p == NULL;
-]])],
-  [AC_DEFINE(HAVE_USM_AES_PRIV_PROTOCOL, 1, [Define if the net-snmp library exports usmAESPrivProtocol.])
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)])
-LIBS="$spine_save_LIBS"
-
-# ****************** SHA-1 auth protocol availability **********************
-dnl Do not use SNMP_DEFAULT_AUTH_PROTO as a last-resort fallback: on an MD5-
-dnl disabled/FIPS header it may name a symbol the linked library does not
-dnl export. Probe the explicit SHA-1 symbol, just as the privacy path probes
-dnl DES, and compile the fallback only when it links.
-AC_MSG_CHECKING([whether the net-snmp library exports usmHMACSHA1AuthProtocol])
-spine_save_LIBS="$LIBS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <net-snmp/net-snmp-config.h>
-  #include <net-snmp/net-snmp-includes.h>
-]], [[
-  const oid *p = usmHMACSHA1AuthProtocol;
-  return p == NULL;
-]])],
-  [AC_DEFINE(HAVE_USM_HMACSHA1_AUTH_PROTOCOL, 1, [Define if the net-snmp library exports usmHMACSHA1AuthProtocol.])
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)])
-LIBS="$spine_save_LIBS"
-
 # ****************** SNMPv3 USM Error Constants Check ***********************
 AC_MSG_CHECKING([for SNMPv3 USM error constants])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[

--- a/configure.ac
+++ b/configure.ac
@@ -399,6 +399,25 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   [AC_MSG_RESULT(no)])
 LIBS="$spine_save_LIBS"
 
+# ****************** SHA-1 auth protocol availability **********************
+dnl Do not use SNMP_DEFAULT_AUTH_PROTO as a last-resort fallback: on an MD5-
+dnl disabled/FIPS header it may name a symbol the linked library does not
+dnl export. Probe the explicit SHA-1 symbol, just as the privacy path probes
+dnl DES, and compile the fallback only when it links.
+AC_MSG_CHECKING([whether the net-snmp library exports usmHMACSHA1AuthProtocol])
+spine_save_LIBS="$LIBS"
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+  #include <net-snmp/net-snmp-config.h>
+  #include <net-snmp/net-snmp-includes.h>
+]], [[
+  const oid *p = usmHMACSHA1AuthProtocol;
+  return p == NULL;
+]])],
+  [AC_DEFINE(HAVE_USM_HMACSHA1_AUTH_PROTOCOL, 1, [Define if the net-snmp library exports usmHMACSHA1AuthProtocol.])
+   AC_MSG_RESULT(yes)],
+  [AC_MSG_RESULT(no)])
+LIBS="$spine_save_LIBS"
+
 # ****************** SNMPv3 USM Error Constants Check ***********************
 AC_MSG_CHECKING([for SNMPv3 USM error constants])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[

--- a/snmp.c
+++ b/snmp.c
@@ -292,21 +292,27 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		security_level = spine_snmpv3_security_level(snmp_auth_protocol, snmp_password,
 			snmp_priv_protocol, snmp_priv_passphrase);
 
-		if (security_level == SNMP_SEC_LEVEL_NOAUTH) {
-			session.securityLevel = SNMP_SEC_LEVEL_NOAUTH;
-		} else {
+		/* A protocol that is set but unrecognised is a configuration error at
+		 * any security level. Deciding the level first and only validating on
+		 * the authenticated path would let a typo through as noAuthNoPriv,
+		 * because a device with no passphrase never reaches the check. */
+		if (spine_snmpv3_value_is_set(snmp_auth_protocol)) {
 			auth_type = usm_lookup_auth_type(snmp_auth_protocol);
 
-			if (auth_type > 0) {
-				auth_proto = sc_get_auth_oid(auth_type, &session.securityAuthProtoLen);
-				free(session.securityAuthProto);
-				session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
-			} else {
+			if (auth_type <= 0) {
 				SPINE_LOG(("SNMP: Device[%i] Error auth protocol %s is invalid.", host_id, snmp_auth_protocol));
 				free(session.peername);
 				free(session.localname);
 				return 0;
 			}
+		}
+
+		if (security_level == SNMP_SEC_LEVEL_NOAUTH) {
+			session.securityLevel = SNMP_SEC_LEVEL_NOAUTH;
+		} else {
+			auth_proto = sc_get_auth_oid(auth_type, &session.securityAuthProtoLen);
+			free(session.securityAuthProto);
+			session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
 		}
 
 		/* set the privacy protocol to none */

--- a/snmp.c
+++ b/snmp.c
@@ -378,6 +378,17 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					free(session.localname);
 					return 0;
 				}
+
+				/* The privacy path releases this after deriving its key; this
+				 * one did not, so every authNoPriv session leaked the
+				 * passphrase copy. Zero it first when the setting asks: it is
+				 * the cleartext auth passphrase. */
+				if (zero_sensitive) {
+					memset(Apsz, 0x0, strlen(Apsz));
+				}
+
+				free(Apsz);
+				Apsz = NULL;
 			}
 		} else {
 			const oid *priv_proto;

--- a/snmp.c
+++ b/snmp.c
@@ -41,6 +41,62 @@
 
 #define OIDSIZE(p) (sizeof(p)/sizeof(oid))
 
+/*! \fn int spine_snmpv3_value_is_set(const char *value)
+ *  \brief Whether a Cacti-supplied SNMPv3 field selects anything.
+ *
+ *  Cacti stores the literal "[None]" when the user picks no protocol, and an
+ *  empty string when a passphrase is absent. Both mean "not selected".
+ */
+int spine_snmpv3_value_is_set(const char *value) {
+	if (value == NULL) {
+		return FALSE;
+	}
+
+	if (value[0] == '\0') {
+		return FALSE;
+	}
+
+	if (strcmp(value, "[None]") == 0) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/*! \fn int spine_snmpv3_security_level(...)
+ *  \brief Pick the SNMPv3 security level from the values Cacti stores.
+ *
+ *  Authentication needs both a protocol and a password; privacy additionally
+ *  needs a privacy protocol and passphrase, and is only meaningful on top of
+ *  authentication. Anything not selected leaves the level lower rather than
+ *  making the device an error, which is what Cacti's own poller does.
+ *
+ *  \return SNMP_SEC_LEVEL_NOAUTH, SNMP_SEC_LEVEL_AUTHNOPRIV or
+ *          SNMP_SEC_LEVEL_AUTHPRIV
+ */
+int spine_snmpv3_security_level(const char *auth_protocol, const char *auth_password,
+		const char *priv_protocol, const char *priv_passphrase) {
+	int authenticates;
+	int encrypts;
+
+	authenticates = spine_snmpv3_value_is_set(auth_protocol) &&
+		spine_snmpv3_value_is_set(auth_password);
+
+	encrypts = authenticates &&
+		spine_snmpv3_value_is_set(priv_protocol) &&
+		spine_snmpv3_value_is_set(priv_passphrase);
+
+	if (encrypts) {
+		return SNMP_SEC_LEVEL_AUTHPRIV;
+	}
+
+	if (authenticates) {
+		return SNMP_SEC_LEVEL_AUTHNOPRIV;
+	}
+
+	return SNMP_SEC_LEVEL_NOAUTH;
+}
+
 /*! \fn void snmp_spine_init()
  *  \brief wrapper function for init_snmp
  *
@@ -226,18 +282,31 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		/* set the authentication protocol */
 		{
 		int auth_type;
+		int security_level;
 		const oid *auth_proto;
 
-		auth_type = usm_lookup_auth_type(snmp_auth_protocol);
-		if (auth_type > 0) {
-            auth_proto = sc_get_auth_oid(auth_type, &session.securityAuthProtoLen);
-            free(session.securityAuthProto);
-            session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
+		/* Cacti stores "[None]" when no protocol is selected, and an absent
+		 * passphrase means the same thing. Neither is an error: the device is
+		 * simply noAuthNoPriv, which is what cmd.php does with the same values.
+		 * Only a protocol that is set and unrecognised is invalid. */
+		security_level = spine_snmpv3_security_level(snmp_auth_protocol, snmp_password,
+			snmp_priv_protocol, snmp_priv_passphrase);
+
+		if (security_level == SNMP_SEC_LEVEL_NOAUTH) {
+			session.securityLevel = SNMP_SEC_LEVEL_NOAUTH;
 		} else {
-			SPINE_LOG(("SNMP: Device[%i] Error auth protocol %s is invalid.", host_id, snmp_auth_protocol));
-			free(session.peername);
-			free(session.localname);
-			return 0;
+			auth_type = usm_lookup_auth_type(snmp_auth_protocol);
+
+			if (auth_type > 0) {
+				auth_proto = sc_get_auth_oid(auth_type, &session.securityAuthProtoLen);
+				free(session.securityAuthProto);
+				session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
+			} else {
+				SPINE_LOG(("SNMP: Device[%i] Error auth protocol %s is invalid.", host_id, snmp_auth_protocol));
+				free(session.peername);
+				free(session.localname);
+				return 0;
+			}
 		}
 
 		/* set the privacy protocol to none */
@@ -247,10 +316,39 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			session.securityPrivKeyLen   = USM_PRIV_KU_LEN;
 
 			/* set the security level to authenticate, but not encrypted */
-			if (strlen(snmp_password)) {
-				session.securityLevel = SNMP_SEC_LEVEL_AUTHNOPRIV;
-			} else {
-				session.securityLevel = SNMP_SEC_LEVEL_NOAUTH;
+			session.securityLevel = security_level;
+
+			/* The authentication key was only ever derived on the privacy path,
+			 * so authNoPriv sessions authenticated with an empty key and every
+			 * such device failed with a USM authentication error. */
+			if (security_level == SNMP_SEC_LEVEL_AUTHNOPRIV) {
+				if (Apsz && zero_sensitive) {
+					memset(Apsz, 0x0, strlen(Apsz));
+				}
+
+				free(Apsz);
+				Apsz = strdup(snmp_password);
+
+				if (zero_sensitive) {
+					memset(snmp_password, 0x0, strlen(snmp_password));
+				}
+
+				session.securityAuthKeyLen = USM_AUTH_KU_LEN;
+
+				if (Apsz == NULL || generate_Ku(session.securityAuthProto,
+					session.securityAuthProtoLen,
+					(u_char *) Apsz, strlen(Apsz),
+					session.securityAuthKey,
+					&session.securityAuthKeyLen) != SNMPERR_SUCCESS) {
+					SPINE_LOG(("SNMP: Device[%i] Error generating SNMPv3 Ku from authentication passphrase.", host_id));
+					free(session.peername);
+					free(session.securityAuthProto);
+					free(session.securityPrivProto);
+					free(Apsz);
+					free(Xpsz);
+					free(session.localname);
+					return 0;
+				}
 			}
 		} else {
 			const oid *priv_proto;

--- a/snmp.c
+++ b/snmp.c
@@ -385,8 +385,24 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				Apsz = strdup(snmp_password);
 
 				session.securityAuthKeyLen = USM_AUTH_KU_LEN;
+				if (session.securityAuthProto == NULL) {
+					const oid *def = get_default_authtype(&session.securityAuthProtoLen);
+					if (def != NULL) {
+						session.securityAuthProto = snmp_duplicate_objid(def, session.securityAuthProtoLen);
+					} else {
+						session.securityAuthProtoLen = 0;
+					}
+				}
 
-				if (Apsz == NULL || generate_Ku(session.securityAuthProto,
+				if (session.securityAuthProto == NULL) {
+					#if defined(HAVE_USM_HMACSHA1_AUTH_PROTOCOL)
+					session.securityAuthProto = snmp_duplicate_objid(usmHMACSHA1AuthProtocol, USM_AUTH_PROTO_SHA_LEN);
+					session.securityAuthProtoLen = USM_AUTH_PROTO_SHA_LEN;
+					#endif
+				}
+
+				if (Apsz == NULL || session.securityAuthProto == NULL ||
+					generate_Ku(session.securityAuthProto,
 					session.securityAuthProtoLen,
 					(u_char *) Apsz, strlen(Apsz),
 					session.securityAuthKey,
@@ -443,15 +459,22 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					 * get .conf set default
 					 */
 					const oid *def = get_default_authtype(&session.securityAuthProtoLen);
-					session.securityAuthProto = snmp_duplicate_objid(def, session.securityAuthProtoLen);
+					if (def != NULL) {
+						session.securityAuthProto = snmp_duplicate_objid(def, session.securityAuthProtoLen);
+					} else {
+						session.securityAuthProtoLen = 0;
+					}
 				}
 
 				if (session.securityAuthProto == NULL) {
-					session.securityAuthProto    = snmp_duplicate_objid(SNMP_DEFAULT_AUTH_PROTO, SNMP_DEFAULT_AUTH_PROTOLEN);
-					session.securityAuthProtoLen = SNMP_DEFAULT_AUTH_PROTOLEN;
+					#if defined(HAVE_USM_HMACSHA1_AUTH_PROTOCOL)
+					session.securityAuthProto = snmp_duplicate_objid(usmHMACSHA1AuthProtocol, USM_AUTH_PROTO_SHA_LEN);
+					session.securityAuthProtoLen = USM_AUTH_PROTO_SHA_LEN;
+					#endif
 				}
 
-				if (generate_Ku(session.securityAuthProto,
+				if (session.securityAuthProto == NULL ||
+					generate_Ku(session.securityAuthProto,
 					session.securityAuthProtoLen,
 					(u_char *) Apsz, strlen(Apsz),
 					session.securityAuthKey,
@@ -485,7 +508,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				}
 
 				if (session.securityPrivProto == NULL) {
-#if defined(HAVE_USM_DES_PRIV_PROTOCOL) || defined(NETSNMP_DISABLE_DES)
+#if defined(HAVE_USM_DES_PRIV_PROTOCOL)
 					session.securityPrivProto = snmp_duplicate_objid(SNMP_DEFAULT_PRIV_PROTO, SNMP_DEFAULT_PRIV_PROTOLEN);
 					session.securityPrivProtoLen = SNMP_DEFAULT_PRIV_PROTOLEN;
 #else

--- a/snmp.c
+++ b/snmp.c
@@ -441,8 +441,16 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				}
 
 				if (session.securityPrivProto == NULL) {
+#if defined(HAVE_USM_DES_PRIV_PROTOCOL) || defined(NETSNMP_DISABLE_DES)
 					session.securityPrivProto = snmp_duplicate_objid(SNMP_DEFAULT_PRIV_PROTO, SNMP_DEFAULT_PRIV_PROTOLEN);
 					session.securityPrivProtoLen = SNMP_DEFAULT_PRIV_PROTOLEN;
+#else
+					/* The header names DES as the default but this library does
+					 * not export it, so the macro cannot be referenced. Every
+					 * net-snmp that omits DES provides AES. See #575. */
+					session.securityPrivProto = snmp_duplicate_objid(usmAESPrivProtocol, USM_PRIV_PROTO_AES_LEN);
+					session.securityPrivProtoLen = USM_PRIV_PROTO_AES_LEN;
+#endif
 				}
 
 				if (generate_Ku(session.securityAuthProto,

--- a/snmp.c
+++ b/snmp.c
@@ -97,6 +97,37 @@ int spine_snmpv3_security_level(const char *auth_protocol, const char *auth_pass
 	return SNMP_SEC_LEVEL_NOAUTH;
 }
 
+/*! \fn static void free_passphrase(char *psz)
+ *  \brief Wipes a local passphrase copy, then releases it.
+ *
+ *  Only the copies snmp_host_init() makes are wiped. The caller's
+ *  snmp_password and snmp_priv_passphrase belong to the poller item and have
+ *  to survive the call: poller.c compares them against last_snmp_password and
+ *  last_snmp_priv_passphrase to decide whether the next item can keep the
+ *  open session, so blanking them would tear down the SNMPv3 session and
+ *  re-derive the USM keys for every remaining item on the device.
+ */
+static void free_passphrase(char *psz) {
+	volatile char *wipe;
+	size_t len;
+
+	if (psz != NULL) {
+		/* Written through a volatile pointer on purpose. A plain memset() here
+		   is a dead store into memory that is about to be freed, and gcc -O2
+		   removes it outright, which leaves the passphrase in the heap for
+		   whatever allocates the block next. explicit_bzero() would say this
+		   more clearly but is absent on the Solaris and Cygwin builds. */
+		wipe = (volatile char *) psz;
+		len  = strlen(psz);
+
+		while (len-- > 0) {
+			*wipe++ = '\0';
+		}
+
+		free(psz);
+	}
+}
+
 /*! \fn void snmp_spine_init()
  *  \brief wrapper function for init_snmp
  *
@@ -184,7 +215,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 	char   *Xpsz = NULL;
 	char   *Cpsz = NULL;
 	int    priv_type;
-	int    zero_sensitive = 0;
 
 	/* initialize SNMP */
 	snmp_sess_init(&session);
@@ -351,16 +381,8 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			 * so authNoPriv sessions authenticated with an empty key and every
 			 * such device failed with a USM authentication error. */
 			if (security_level == SNMP_SEC_LEVEL_AUTHNOPRIV) {
-				if (Apsz && zero_sensitive) {
-					memset(Apsz, 0x0, strlen(Apsz));
-				}
-
-				free(Apsz);
+				free_passphrase(Apsz);
 				Apsz = strdup(snmp_password);
-
-				if (zero_sensitive) {
-					memset(snmp_password, 0x0, strlen(snmp_password));
-				}
 
 				session.securityAuthKeyLen = USM_AUTH_KU_LEN;
 
@@ -373,21 +395,16 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					free(session.peername);
 					free(session.securityAuthProto);
 					free(session.securityPrivProto);
-					free(Apsz);
-					free(Xpsz);
+					free_passphrase(Apsz);
+					free_passphrase(Xpsz);
 					free(session.localname);
 					return 0;
 				}
 
 				/* The privacy path releases this after deriving its key; this
 				 * one did not, so every authNoPriv session leaked the
-				 * passphrase copy. Zero it first when the setting asks: it is
-				 * the cleartext auth passphrase. */
-				if (zero_sensitive) {
-					memset(Apsz, 0x0, strlen(Apsz));
-				}
-
-				free(Apsz);
+				 * passphrase copy. */
+				free_passphrase(Apsz);
 				Apsz = NULL;
 			}
 		} else {
@@ -412,28 +429,12 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			session.securityLevel     = security_level;
 
 			// Auth Protocol Setup
-			if (Apsz && zero_sensitive) {
-				memset(Apsz, 0x0, strlen(Apsz));
-			}
-
-			free(Apsz);
+			free_passphrase(Apsz);
 			Apsz = strdup(snmp_password);
 
-			if (zero_sensitive) {
-	            memset(snmp_password, 0x0, strlen(snmp_password));
-			}
-
 			// Privacy Protocol Setup
-			if (Xpsz && zero_sensitive) {
-				memset(Xpsz, 0x0, strlen(Xpsz));
-			}
-
-			free(Xpsz);
+			free_passphrase(Xpsz);
 			Xpsz = strdup(snmp_priv_passphrase);
-
-			if (zero_sensitive) {
-				memset(snmp_priv_passphrase, 0x0, strlen(snmp_priv_passphrase));
-			}
 
 			if (Apsz) {
 				session.securityAuthKeyLen = USM_AUTH_KU_LEN;
@@ -459,8 +460,8 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					free(session.peername);
 					free(session.securityAuthProto);
 					free(session.securityPrivProto);
-					free(Apsz);
-					free(Xpsz);
+					free_passphrase(Apsz);
+					free_passphrase(Xpsz);
 					if (session.localname) {
 						free(session.localname);
 						session.localname = NULL;
@@ -468,7 +469,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					return 0;
 				}
 
-				free(Apsz);
+				free_passphrase(Apsz);
 				Apsz = NULL;
 			}
 
@@ -505,7 +506,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					free(session.peername);
 					free(session.securityAuthProto);
 					free(session.securityPrivProto);
-					free(Xpsz);
+					free_passphrase(Xpsz);
 					if (session.localname) {
 						free(session.localname);
 						session.localname = NULL;
@@ -513,7 +514,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					return 0;
 				}
 
-				free(Xpsz);
+				free_passphrase(Xpsz);
 				Xpsz = NULL;
 			}
 		}

--- a/snmp.c
+++ b/snmp.c
@@ -330,6 +330,11 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; using noAuthNoPriv.", host_id));
 		}
 
+		if (spine_snmpv3_value_is_set(snmp_priv_protocol) !=
+			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
+			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; ignoring privacy and sending SNMP payloads without encryption.", host_id));
+		}
+
 		/* A protocol that is set but unrecognised is a configuration error at
 		 * any security level. Deciding the level first and only validating on
 		 * the authenticated path would let a typo through as noAuthNoPriv,
@@ -361,16 +366,12 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			}
 		}
 
-		/* Privacy requires authentication in USM. A device configured with a
-		 * privacy protocol and passphrase but no auth passphrase cannot have
-		 * what it asked for, and quietly opening it as noAuthNoPriv would
-		 * leave the operator believing the traffic is encrypted. Refuse and
-		 * say why: the old code also refused, but by failing key derivation
-		 * with "passphrase below the length requirements of the USM". */
-		if (security_level != SNMP_SEC_LEVEL_AUTHPRIV &&
-			(spine_snmpv3_value_is_set(snmp_priv_protocol) ||
-			 spine_snmpv3_value_is_set(snmp_priv_passphrase))) {
-			SPINE_LOG(("SNMP: Device[%i] Error privacy requires authentication; set an auth protocol and password, or clear the privacy settings.", host_id));
+		/* A privacy passphrase with no usable authentication cannot be
+		 * honoured by USM. Refuse that case; a stale protocol with no
+		 * passphrase remains compatible with the historical authNoPriv path. */
+		if (security_level == SNMP_SEC_LEVEL_NOAUTH &&
+			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
+			SPINE_LOG(("SNMP: Device[%i] Error privacy passphrase is configured but authentication is unavailable; set an auth protocol and password, or clear the privacy passphrase.", host_id));
 			free(session.peername);
 			free(session.localname);
 			free(session.securityAuthProto);
@@ -398,9 +399,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				return 0;
 			}
 
-			/* set the security level to authenticate, but not encrypted */
-			session.securityLevel = security_level;
-
 			/* The authentication key was only ever derived on the privacy path,
 			 * so authNoPriv sessions authenticated with an empty key and every
 			 * such device failed with a USM authentication error. */
@@ -409,22 +407,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				Apsz = strdup(snmp_password);
 
 				session.securityAuthKeyLen = USM_AUTH_KU_LEN;
-				if (session.securityAuthProto == NULL) {
-					const oid *def = get_default_authtype(&session.securityAuthProtoLen);
-					if (def != NULL) {
-						session.securityAuthProto = snmp_duplicate_objid(def, session.securityAuthProtoLen);
-					} else {
-						session.securityAuthProtoLen = 0;
-					}
-				}
-
-				if (session.securityAuthProto == NULL) {
-					#if defined(HAVE_USM_HMACSHA1_AUTH_PROTOCOL)
-					session.securityAuthProto = snmp_duplicate_objid(usmHMACSHA1AuthProtocol, USM_AUTH_PROTO_SHA_LEN);
-					session.securityAuthProtoLen = USM_AUTH_PROTO_SHA_LEN;
-					#endif
-				}
-
 				if (Apsz == NULL || session.securityAuthProto == NULL ||
 					generate_Ku(session.securityAuthProto,
 					session.securityAuthProtoLen,
@@ -499,25 +481,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 
 			{
 				session.securityAuthKeyLen = USM_AUTH_KU_LEN;
-				if (session.securityAuthProto == NULL) {
-					/*
-					 * get .conf set default
-					 */
-					const oid *def = get_default_authtype(&session.securityAuthProtoLen);
-					if (def != NULL) {
-						session.securityAuthProto = snmp_duplicate_objid(def, session.securityAuthProtoLen);
-					} else {
-						session.securityAuthProtoLen = 0;
-					}
-				}
-
-				if (session.securityAuthProto == NULL) {
-					#if defined(HAVE_USM_HMACSHA1_AUTH_PROTOCOL)
-					session.securityAuthProto = snmp_duplicate_objid(usmHMACSHA1AuthProtocol, USM_AUTH_PROTO_SHA_LEN);
-					session.securityAuthProtoLen = USM_AUTH_PROTO_SHA_LEN;
-					#endif
-				}
-
 				if (session.securityAuthProto == NULL ||
 					generate_Ku(session.securityAuthProto,
 					session.securityAuthProtoLen,
@@ -542,34 +505,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 
 			{
 				session.securityPrivKeyLen = USM_PRIV_KU_LEN;
-				if (session.securityPrivProto == NULL) {
-					/*
-					 * get .conf set default
-					 */
-					const oid *def = get_default_privtype(&session.securityPrivProtoLen);
-					if (def != NULL) {
-						session.securityPrivProto =
-							snmp_duplicate_objid(def, session.securityPrivProtoLen);
-					} else {
-						session.securityPrivProtoLen = 0;
-					}
-				}
-
-				if (session.securityPrivProto == NULL) {
-#if defined(HAVE_USM_DES_PRIV_PROTOCOL)
-					session.securityPrivProto = snmp_duplicate_objid(SNMP_DEFAULT_PRIV_PROTO, SNMP_DEFAULT_PRIV_PROTOLEN);
-					session.securityPrivProtoLen = SNMP_DEFAULT_PRIV_PROTOLEN;
-#elif defined(HAVE_USM_AES_PRIV_PROTOCOL)
-					/* The header names DES as the default but this library does
-					 * not export it, so the macro cannot be referenced. */
-					session.securityPrivProto = snmp_duplicate_objid(usmAESPrivProtocol, USM_PRIV_PROTO_AES_LEN);
-					session.securityPrivProtoLen = USM_PRIV_PROTO_AES_LEN;
-#else
-					SPINE_LOG(("SNMP: Device[%i] Error no supported default privacy protocol is available.", host_id));
-					session.securityPrivProtoLen = 0;
-#endif
-				}
-
 				if (session.securityPrivProto == NULL ||
 					generate_Ku(session.securityAuthProto,
 					session.securityAuthProtoLen,

--- a/snmp.c
+++ b/snmp.c
@@ -364,12 +364,12 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 
 		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_password)) {
-			SPINE_LOG_MEDIUM(("SNMP: Device[%i] WARNING incomplete authentication settings; Cacti's effective security level is noAuthNoPriv.", host_id));
+			SPINE_LOG_LOW(("SNMP: Device[%i] WARNING incomplete authentication settings; Cacti's effective security level is noAuthNoPriv.", host_id));
 		}
 
 		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
-			SPINE_LOG_MEDIUM(("SNMP: Device[%i] WARNING incomplete privacy settings; Cacti's effective security level does not include encryption.", host_id));
+			SPINE_LOG_LOW(("SNMP: Device[%i] WARNING incomplete privacy settings; Cacti's effective security level does not include encryption.", host_id));
 		}
 
 		/* A protocol that is set but unrecognised is a configuration error at

--- a/snmp.c
+++ b/snmp.c
@@ -330,12 +330,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; using noAuthNoPriv.", host_id));
 		}
 
-		if (spine_snmpv3_value_is_set(snmp_priv_protocol) !=
-			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
-			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; using security level %i.",
-				host_id, security_level));
-		}
-
 		/* A protocol that is set but unrecognised is a configuration error at
 		 * any security level. Deciding the level first and only validating on
 		 * the authenticated path would let a typo through as noAuthNoPriv,
@@ -374,8 +368,8 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		 * say why: the old code also refused, but by failing key derivation
 		 * with "passphrase below the length requirements of the USM". */
 		if (security_level != SNMP_SEC_LEVEL_AUTHPRIV &&
-			spine_snmpv3_value_is_set(snmp_priv_protocol) &&
-			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
+			(spine_snmpv3_value_is_set(snmp_priv_protocol) ||
+			 spine_snmpv3_value_is_set(snmp_priv_passphrase))) {
 			SPINE_LOG(("SNMP: Device[%i] Error privacy requires authentication; set an auth protocol and password, or clear the privacy settings.", host_id));
 			free(session.peername);
 			free(session.localname);

--- a/snmp.c
+++ b/snmp.c
@@ -337,10 +337,24 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			spine_snmpv3_passphrase_is_set(snmp_password)) {
 			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; polling at noAuthNoPriv to match Cacti's effective security level.", host_id));
 		}
+		if (spine_snmpv3_passphrase_is_set(snmp_password) &&
+			(snmp_auth_protocol == NULL || snmp_auth_protocol[0] == '\0')) {
+			SPINE_LOG(("SNMP: Device[%i] Error authentication password is set but the authentication protocol is empty.", host_id));
+			free(session.peername);
+			free(session.localname);
+			return 0;
+		}
 
 		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
 			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; polling without encryption to match Cacti's effective security level.", host_id));
+		}
+		if (spine_snmpv3_passphrase_is_set(snmp_priv_passphrase) &&
+			(snmp_priv_protocol == NULL || snmp_priv_protocol[0] == '\0')) {
+			SPINE_LOG(("SNMP: Device[%i] Error privacy passphrase is set but the privacy protocol is empty.", host_id));
+			free(session.peername);
+			free(session.localname);
+			return 0;
 		}
 
 		/* A protocol that is set but unrecognised is a configuration error at

--- a/snmp.c
+++ b/snmp.c
@@ -305,18 +305,41 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				free(session.localname);
 				return 0;
 			}
-		}
 
-		if (security_level == SNMP_SEC_LEVEL_NOAUTH) {
-			session.securityLevel = SNMP_SEC_LEVEL_NOAUTH;
-		} else {
+			/* Install it whenever it is configured, not only when the level
+			 * says the session authenticates. The privacy branch below can
+			 * still raise the level, and leaving this to that branch meant a
+			 * device with a protocol but no passphrase got the library
+			 * default instead of the one it was configured with. */
 			auth_proto = sc_get_auth_oid(auth_type, &session.securityAuthProtoLen);
 			free(session.securityAuthProto);
 			session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
 		}
 
-		/* set the privacy protocol to none */
-		if (strcmp(snmp_priv_protocol, "[None]") == 0 || (strlen(snmp_priv_passphrase) == 0)) {
+		/* Privacy requires authentication in USM. A device configured with a
+		 * privacy protocol and passphrase but no auth passphrase cannot have
+		 * what it asked for, and quietly opening it as noAuthNoPriv would
+		 * leave the operator believing the traffic is encrypted. Refuse and
+		 * say why: the old code also refused, but by failing key derivation
+		 * with "passphrase below the length requirements of the USM". */
+		if (security_level != SNMP_SEC_LEVEL_AUTHPRIV &&
+			spine_snmpv3_value_is_set(snmp_priv_protocol) &&
+			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
+			SPINE_LOG(("SNMP: Device[%i] Error privacy requires authentication; set an auth protocol and password, or clear the privacy settings.", host_id));
+			free(session.peername);
+			free(session.localname);
+			free(session.securityAuthProto);
+			return 0;
+		}
+
+		session.securityLevel = security_level;
+
+		/* Privacy follows the computed level. Selecting it from the privacy
+		 * fields alone disagreed with spine_snmpv3_security_level(), which
+		 * requires authentication before encryption: a device with privacy
+		 * configured but no auth passphrase took this branch's else and was
+		 * built as authPriv with no authentication key. */
+		if (security_level != SNMP_SEC_LEVEL_AUTHPRIV) {
 			session.securityPrivProto    = snmp_duplicate_objid(usmNoPrivProtocol, OID_LENGTH(usmNoPrivProtocol));
 			session.securityPrivProtoLen = OID_LENGTH(usmNoPrivProtocol);
 			session.securityPrivKeyLen   = USM_PRIV_KU_LEN;
@@ -372,7 +395,10 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			priv_proto = sc_get_priv_oid(priv_type, &session.securityPrivProtoLen);
 			free(session.securityPrivProto);
 			session.securityPrivProto = snmp_duplicate_objid(priv_proto, session.securityPrivProtoLen);
-			session.securityLevel     = SNMP_SEC_LEVEL_AUTHPRIV;
+			/* security_level is AUTHPRIV here by construction: this branch is
+			 * only reached when it is. Assigning the computed value keeps one
+			 * predicate authoritative rather than two that can disagree. */
+			session.securityLevel     = security_level;
 
 			// Auth Protocol Setup
 			if (Apsz && zero_sensitive) {

--- a/snmp.c
+++ b/snmp.c
@@ -325,6 +325,17 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		security_level = spine_snmpv3_security_level(snmp_auth_protocol, snmp_password,
 			snmp_priv_protocol, snmp_priv_passphrase);
 
+		if (spine_snmpv3_value_is_set(snmp_auth_protocol) !=
+			spine_snmpv3_value_is_set(snmp_password)) {
+			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; using noAuthNoPriv.", host_id));
+		}
+
+		if (spine_snmpv3_value_is_set(snmp_priv_protocol) !=
+			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
+			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; using security level %i.",
+				host_id, security_level));
+		}
+
 		/* A protocol that is set but unrecognised is a configuration error at
 		 * any security level. Deciding the level first and only validating on
 		 * the authenticated path would let a typo through as noAuthNoPriv,
@@ -383,6 +394,15 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			session.securityPrivProto    = snmp_duplicate_objid(usmNoPrivProtocol, OID_LENGTH(usmNoPrivProtocol));
 			session.securityPrivProtoLen = OID_LENGTH(usmNoPrivProtocol);
 			session.securityPrivKeyLen   = USM_PRIV_KU_LEN;
+
+			if (session.securityPrivProto == NULL) {
+				session.securityPrivProtoLen = 0;
+				SPINE_LOG(("SNMP: Device[%i] Error installing the no-privacy protocol.", host_id));
+				free(session.peername);
+				free(session.securityAuthProto);
+				free(session.localname);
+				return 0;
+			}
 
 			/* set the security level to authenticate, but not encrypted */
 			session.securityLevel = security_level;

--- a/snmp.c
+++ b/snmp.c
@@ -370,6 +370,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		 * honoured by USM. Refuse that case; a stale protocol with no
 		 * passphrase remains compatible with the historical authNoPriv path. */
 		if (security_level == SNMP_SEC_LEVEL_NOAUTH &&
+			spine_snmpv3_value_is_set(snmp_priv_protocol) &&
 			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
 			SPINE_LOG(("SNMP: Device[%i] Error privacy passphrase is configured but authentication is unavailable; set an auth protocol and password, or clear the privacy passphrase.", host_id));
 			free(session.peername);

--- a/snmp.c
+++ b/snmp.c
@@ -346,7 +346,14 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			 * default instead of the one it was configured with. */
 			auth_proto = sc_get_auth_oid(auth_type, &session.securityAuthProtoLen);
 			free(session.securityAuthProto);
-			session.securityAuthProto = snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
+			session.securityAuthProto = auth_proto == NULL ? NULL :
+				snmp_duplicate_objid(auth_proto, session.securityAuthProtoLen);
+			if (session.securityAuthProto == NULL) {
+				SPINE_LOG(("SNMP: Device[%i] Error installing auth protocol %s.", host_id, snmp_auth_protocol));
+				free(session.peername);
+				free(session.localname);
+				return 0;
+			}
 		}
 
 		/* Privacy requires authentication in USM. A device configured with a
@@ -440,7 +447,15 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 
 			priv_proto = sc_get_priv_oid(priv_type, &session.securityPrivProtoLen);
 			free(session.securityPrivProto);
-			session.securityPrivProto = snmp_duplicate_objid(priv_proto, session.securityPrivProtoLen);
+			session.securityPrivProto = priv_proto == NULL ? NULL :
+				snmp_duplicate_objid(priv_proto, session.securityPrivProtoLen);
+			if (session.securityPrivProto == NULL) {
+				SPINE_LOG(("SNMP: Device[%i] Error installing privacy protocol %s.", host_id, snmp_priv_protocol));
+				free(session.peername);
+				free(session.securityAuthProto);
+				free(session.localname);
+				return 0;
+			}
 			/* security_level is AUTHPRIV here by construction: this branch is
 			 * only reached when it is. Assigning the computed value keeps one
 			 * predicate authoritative rather than two that can disagree. */
@@ -454,7 +469,21 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			free_passphrase(&Xpsz);
 			Xpsz = strdup(snmp_priv_passphrase);
 
-			if (Apsz) {
+			/* authPriv cannot be constructed safely without both local copies.
+			 * Treat allocator failure like key-derivation failure instead of
+			 * handing net-snmp an authPriv session with an empty key. */
+			if (Apsz == NULL || Xpsz == NULL) {
+				SPINE_LOG(("SNMP: Device[%i] Error allocating SNMPv3 passphrase storage.", host_id));
+				free(session.peername);
+				free(session.securityAuthProto);
+				free(session.securityPrivProto);
+				free_passphrase(&Apsz);
+				free_passphrase(&Xpsz);
+				free(session.localname);
+				return 0;
+			}
+
+			{
 				session.securityAuthKeyLen = USM_AUTH_KU_LEN;
 				if (session.securityAuthProto == NULL) {
 					/*
@@ -497,15 +526,19 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				free_passphrase(&Apsz);
 			}
 
-			if (Xpsz) {
+			{
 				session.securityPrivKeyLen = USM_PRIV_KU_LEN;
 				if (session.securityPrivProto == NULL) {
 					/*
 					 * get .conf set default
 					 */
 					const oid *def = get_default_privtype(&session.securityPrivProtoLen);
-					session.securityPrivProto =
-					snmp_duplicate_objid(def, session.securityPrivProtoLen);
+					if (def != NULL) {
+						session.securityPrivProto =
+							snmp_duplicate_objid(def, session.securityPrivProtoLen);
+					} else {
+						session.securityPrivProtoLen = 0;
+					}
 				}
 
 				if (session.securityPrivProto == NULL) {

--- a/snmp.c
+++ b/snmp.c
@@ -1207,6 +1207,21 @@ void snmp_get_multi(host_t *current_host, target_t *poller_items, snmp_oids_t *s
 		size_t          name_len;
 	} *name, *namep;
 
+	/* A per-item credential change can fail to rebuild the session after the
+	 * caller's earlier NULL check. Fail the pending group as one host error
+	 * instead of passing NULL into net-snmp. */
+	if (current_host == NULL || current_host->snmp_session == NULL) {
+		if (current_host != NULL) {
+			current_host->ignore_host = TRUE;
+		}
+		if (snmp_oids != NULL) {
+			for (i = 0; i < num_oids; i++) {
+				SET_UNDEFINED(snmp_oids[i].result);
+			}
+		}
+		return;
+	}
+
 	/* load up oids */
 	namep = name = (struct nameStruct *) calloc(num_oids, sizeof(*name));
 	if (name == NULL) {

--- a/snmp.c
+++ b/snmp.c
@@ -327,26 +327,20 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		int security_level;
 		const oid *auth_proto;
 
-		/* Cacti stores "[None]" when no protocol is selected. Complete absent
-		 * pairs mean noAuthNoPriv; half-configured pairs are refused below so
-		 * that an intended security property cannot be silently discarded. */
+		/* Cacti stores "[None]" when no protocol is selected. Match cmd.php's
+		 * effective-level rules for incomplete pairs, but report the downgrade
+		 * explicitly so an operator does not mistake it for auth or privacy. */
 		security_level = spine_snmpv3_security_level(snmp_auth_protocol, snmp_password,
 			snmp_priv_protocol, snmp_priv_passphrase);
 
 		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_password)) {
-			SPINE_LOG(("SNMP: Device[%i] Error incomplete authentication settings; both an authentication protocol and password are required.", host_id));
-			free(session.peername);
-			free(session.localname);
-			return 0;
+			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; polling at noAuthNoPriv to match Cacti's effective security level.", host_id));
 		}
 
 		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
-			SPINE_LOG(("SNMP: Device[%i] Error incomplete privacy settings; both a privacy protocol and passphrase are required.", host_id));
-			free(session.peername);
-			free(session.localname);
-			return 0;
+			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; polling without encryption to match Cacti's effective security level.", host_id));
 		}
 
 		/* A protocol that is set but unrecognised is a configuration error at
@@ -380,9 +374,9 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			}
 		}
 
-		/* A privacy passphrase with no usable authentication cannot be
-		 * honoured by USM. Refuse that case; a stale protocol with no
-		 * passphrase remains compatible with the historical authNoPriv path. */
+		/* Complete privacy credentials with no usable authentication cannot be
+		 * honoured by USM. Refuse that case; incomplete privacy fields follow
+		 * Cacti's lower effective level after the warning above. */
 		if (security_level == SNMP_SEC_LEVEL_NOAUTH &&
 			spine_snmpv3_protocol_is_set(snmp_priv_protocol) &&
 			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {

--- a/snmp.c
+++ b/snmp.c
@@ -364,12 +364,12 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 
 		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_password)) {
-			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; Cacti's effective security level is noAuthNoPriv.", host_id));
+			SPINE_LOG_MEDIUM(("SNMP: Device[%i] WARNING incomplete authentication settings; Cacti's effective security level is noAuthNoPriv.", host_id));
 		}
 
 		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
-			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; Cacti's effective security level does not include encryption.", host_id));
+			SPINE_LOG_MEDIUM(("SNMP: Device[%i] WARNING incomplete privacy settings; Cacti's effective security level does not include encryption.", host_id));
 		}
 
 		/* A protocol that is set but unrecognised is a configuration error at

--- a/snmp.c
+++ b/snmp.c
@@ -362,17 +362,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			return 0;
 		}
 
-		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol)) {
-			priv_type = usm_lookup_priv_type(snmp_priv_protocol);
-
-			if (priv_type < 0) {
-				SPINE_LOG(("SNMP: Device[%i] Error privacy protocol %s is invalid.", host_id, snmp_priv_protocol));
-				free(session.peername);
-				free(session.localname);
-				return 0;
-			}
-		}
-
 		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_password)) {
 			SPINE_LOG_LOW(("SNMP: Device[%i] WARNING incomplete authentication settings; Cacti's effective security level is noAuthNoPriv.", host_id));
@@ -466,6 +455,16 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			}
 		} else {
 			const oid *priv_proto;
+
+			priv_type = usm_lookup_priv_type(snmp_priv_protocol);
+
+			if (priv_type < 0) {
+				SPINE_LOG(("SNMP: Device[%i] Error privacy protocol %s is invalid.", host_id, snmp_priv_protocol));
+				free(session.peername);
+				free(session.securityAuthProto);
+				free(session.localname);
+				return 0;
+			}
 
 			priv_proto = sc_get_priv_oid(priv_type, &session.securityPrivProtoLen);
 			free(session.securityPrivProto);

--- a/snmp.c
+++ b/snmp.c
@@ -226,7 +226,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 	char   *Apsz = NULL;
 	char   *Xpsz = NULL;
 	char   *Cpsz = NULL;
-	int    priv_type;
+	int    priv_type = -1;
 
 	/* initialize SNMP */
 	snmp_sess_init(&session);
@@ -362,6 +362,17 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			return 0;
 		}
 
+		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol)) {
+			priv_type = usm_lookup_priv_type(snmp_priv_protocol);
+
+			if (priv_type < 0) {
+				SPINE_LOG(("SNMP: Device[%i] Error privacy protocol %s is invalid.", host_id, snmp_priv_protocol));
+				free(session.peername);
+				free(session.localname);
+				return 0;
+			}
+		}
+
 		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_password)) {
 			SPINE_LOG_LOW(("SNMP: Device[%i] WARNING incomplete authentication settings; Cacti's effective security level is noAuthNoPriv.", host_id));
@@ -455,16 +466,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			}
 		} else {
 			const oid *priv_proto;
-
-			priv_type = usm_lookup_priv_type(snmp_priv_protocol);
-
-			if (priv_type < 0) {
-				SPINE_LOG(("SNMP: Device[%i] Error privacy protocol %s is invalid.", host_id, snmp_priv_protocol));
-				free(session.peername);
-				free(session.securityAuthProto);
-				free(session.localname);
-				return 0;
-			}
 
 			priv_proto = sc_get_priv_oid(priv_type, &session.securityPrivProtoLen);
 			free(session.securityPrivProto);

--- a/snmp.c
+++ b/snmp.c
@@ -44,13 +44,12 @@
 
 #define OIDSIZE(p) (sizeof(p)/sizeof(oid))
 
-/*! \fn int spine_snmpv3_value_is_set(const char *value)
- *  \brief Whether a Cacti-supplied SNMPv3 field selects anything.
+/*! \fn int spine_snmpv3_protocol_is_set(const char *value)
+ *  \brief Whether a Cacti-supplied SNMPv3 protocol field selects anything.
  *
- *  Cacti stores the literal "[None]" when the user picks no protocol, and an
- *  empty string when a passphrase is absent. Both mean "not selected".
+ *  Cacti stores the literal "[None]" when the user picks no protocol.
  */
-int spine_snmpv3_value_is_set(const char *value) {
+int spine_snmpv3_protocol_is_set(const char *value) {
 	if (value == NULL) {
 		return FALSE;
 	}
@@ -66,13 +65,23 @@ int spine_snmpv3_value_is_set(const char *value) {
 	return TRUE;
 }
 
+/*! \fn int spine_snmpv3_passphrase_is_set(const char *value)
+ *  \brief Whether a Cacti-supplied SNMPv3 passphrase is nonempty.
+ *
+ *  Unlike protocol fields, passphrases do not use the "[None]" sentinel. That
+ *  text is therefore a valid (if weak) passphrase and must not be discarded.
+ */
+int spine_snmpv3_passphrase_is_set(const char *value) {
+	return value != NULL && value[0] != '\0';
+}
+
 /*! \fn int spine_snmpv3_security_level(...)
  *  \brief Pick the SNMPv3 security level from the values Cacti stores.
  *
  *  Authentication needs both a protocol and a password; privacy additionally
  *  needs a privacy protocol and passphrase, and is only meaningful on top of
- *  authentication. Anything not selected leaves the level lower rather than
- *  making the device an error, which is what Cacti's own poller does.
+ *  authentication. The session builder separately refuses half-configured
+ *  credential pairs before using this computed level.
  *
  *  \return SNMP_SEC_LEVEL_NOAUTH, SNMP_SEC_LEVEL_AUTHNOPRIV or
  *          SNMP_SEC_LEVEL_AUTHPRIV
@@ -82,12 +91,12 @@ int spine_snmpv3_security_level(const char *auth_protocol, const char *auth_pass
 	int authenticates;
 	int encrypts;
 
-	authenticates = spine_snmpv3_value_is_set(auth_protocol) &&
-		spine_snmpv3_value_is_set(auth_password);
+	authenticates = spine_snmpv3_protocol_is_set(auth_protocol) &&
+		spine_snmpv3_passphrase_is_set(auth_password);
 
 	encrypts = authenticates &&
-		spine_snmpv3_value_is_set(priv_protocol) &&
-		spine_snmpv3_value_is_set(priv_passphrase);
+		spine_snmpv3_protocol_is_set(priv_protocol) &&
+		spine_snmpv3_passphrase_is_set(priv_passphrase);
 
 	if (encrypts) {
 		return SNMP_SEC_LEVEL_AUTHPRIV;
@@ -318,39 +327,33 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		int security_level;
 		const oid *auth_proto;
 
-		/* Cacti stores "[None]" when no protocol is selected, and an absent
-		 * passphrase means the same thing. Neither is an error: the device is
-		 * simply noAuthNoPriv, which is what cmd.php does with the same values.
-		 * Only a protocol that is set and unrecognised is invalid. */
+		/* Cacti stores "[None]" when no protocol is selected. Complete absent
+		 * pairs mean noAuthNoPriv; half-configured pairs are refused below so
+		 * that an intended security property cannot be silently discarded. */
 		security_level = spine_snmpv3_security_level(snmp_auth_protocol, snmp_password,
 			snmp_priv_protocol, snmp_priv_passphrase);
 
-		if (spine_snmpv3_value_is_set(snmp_auth_protocol) !=
-			spine_snmpv3_value_is_set(snmp_password)) {
-			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; using noAuthNoPriv.", host_id));
-		}
-
-		/* A password with no selected protocol was rejected by the historical
-		 * path. Preserve that fail-closed boundary rather than silently sending
-		 * an unauthenticated request that carries no usable password. */
-		if (!spine_snmpv3_value_is_set(snmp_auth_protocol) &&
-			spine_snmpv3_value_is_set(snmp_password)) {
-			SPINE_LOG(("SNMP: Device[%i] Error authentication password is configured but no authentication protocol is selected.", host_id));
+		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol) !=
+			spine_snmpv3_passphrase_is_set(snmp_password)) {
+			SPINE_LOG(("SNMP: Device[%i] Error incomplete authentication settings; both an authentication protocol and password are required.", host_id));
 			free(session.peername);
 			free(session.localname);
 			return 0;
 		}
 
-		if (spine_snmpv3_value_is_set(snmp_priv_protocol) !=
-			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
-			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; ignoring privacy and sending SNMP payloads without encryption.", host_id));
+		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol) !=
+			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
+			SPINE_LOG(("SNMP: Device[%i] Error incomplete privacy settings; both a privacy protocol and passphrase are required.", host_id));
+			free(session.peername);
+			free(session.localname);
+			return 0;
 		}
 
 		/* A protocol that is set but unrecognised is a configuration error at
 		 * any security level. Deciding the level first and only validating on
 		 * the authenticated path would let a typo through as noAuthNoPriv,
 		 * because a device with no passphrase never reaches the check. */
-		if (spine_snmpv3_value_is_set(snmp_auth_protocol)) {
+		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol)) {
 			auth_type = usm_lookup_auth_type(snmp_auth_protocol);
 
 			if (auth_type <= 0) {
@@ -381,8 +384,8 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		 * honoured by USM. Refuse that case; a stale protocol with no
 		 * passphrase remains compatible with the historical authNoPriv path. */
 		if (security_level == SNMP_SEC_LEVEL_NOAUTH &&
-			spine_snmpv3_value_is_set(snmp_priv_protocol) &&
-			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
+			spine_snmpv3_protocol_is_set(snmp_priv_protocol) &&
+			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
 			SPINE_LOG(("SNMP: Device[%i] Error privacy passphrase is configured but authentication is unavailable; set an auth protocol and password, or clear the privacy passphrase.", host_id));
 			free(session.peername);
 			free(session.localname);

--- a/snmp.c
+++ b/snmp.c
@@ -364,12 +364,12 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 
 		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_password)) {
-			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; polling at noAuthNoPriv to match Cacti's effective security level.", host_id));
+			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; Cacti's effective security level is noAuthNoPriv.", host_id));
 		}
 
 		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol) !=
 			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
-			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; polling without encryption to match Cacti's effective security level.", host_id));
+			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; Cacti's effective security level does not include encryption.", host_id));
 		}
 
 		/* A protocol that is set but unrecognised is a configuration error at

--- a/snmp.c
+++ b/snmp.c
@@ -34,6 +34,9 @@
 #include "common.h"
 #include "spine.h"
 
+#include <net-snmp/library/scapi.h>
+#include <net-snmp/library/snmpusm.h>
+
 /* resolve problems in debian */
 #ifndef NETSNMP_DS_LIB_DONT_PERSIST_STATE
  #define NETSNMP_DS_LIB_DONT_PERSIST_STATE 32
@@ -97,7 +100,7 @@ int spine_snmpv3_security_level(const char *auth_protocol, const char *auth_pass
 	return SNMP_SEC_LEVEL_NOAUTH;
 }
 
-/*! \fn static void free_passphrase(char *psz)
+/*! \fn static void free_passphrase(char **psz)
  *  \brief Wipes a local passphrase copy, then releases it.
  *
  *  Only the copies snmp_host_init() makes are wiped. The caller's
@@ -107,24 +110,24 @@ int spine_snmpv3_security_level(const char *auth_protocol, const char *auth_pass
  *  open session, so blanking them would tear down the SNMPv3 session and
  *  re-derive the USM keys for every remaining item on the device.
  */
-static void free_passphrase(char *psz) {
+static void free_passphrase(char **psz) {
 	volatile char *wipe;
 	size_t len;
 
-	if (psz != NULL) {
+	if (psz != NULL && *psz != NULL) {
 		/* Written through a volatile pointer on purpose. A plain memset() here
 		   is a dead store into memory that is about to be freed, and gcc -O2
 		   removes it outright, which leaves the passphrase in the heap for
 		   whatever allocates the block next. explicit_bzero() would say this
 		   more clearly but is absent on the Solaris and Cygwin builds. */
-		wipe = (volatile char *) psz;
-		len  = strlen(psz);
+		wipe = (volatile char *) *psz;
+		len  = strlen(*psz);
 
 		while (len-- > 0) {
 			*wipe++ = '\0';
 		}
 
-		free(psz);
+		SPINE_FREE(*psz);
 	}
 }
 
@@ -381,7 +384,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			 * so authNoPriv sessions authenticated with an empty key and every
 			 * such device failed with a USM authentication error. */
 			if (security_level == SNMP_SEC_LEVEL_AUTHNOPRIV) {
-				free_passphrase(Apsz);
+				free_passphrase(&Apsz);
 				Apsz = strdup(snmp_password);
 
 				session.securityAuthKeyLen = USM_AUTH_KU_LEN;
@@ -411,8 +414,8 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					free(session.peername);
 					free(session.securityAuthProto);
 					free(session.securityPrivProto);
-					free_passphrase(Apsz);
-					free_passphrase(Xpsz);
+					free_passphrase(&Apsz);
+					free_passphrase(&Xpsz);
 					free(session.localname);
 					return 0;
 				}
@@ -420,8 +423,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				/* The privacy path releases this after deriving its key; this
 				 * one did not, so every authNoPriv session leaked the
 				 * passphrase copy. */
-				free_passphrase(Apsz);
-				Apsz = NULL;
+				free_passphrase(&Apsz);
 			}
 		} else {
 			const oid *priv_proto;
@@ -445,11 +447,11 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			session.securityLevel     = security_level;
 
 			// Auth Protocol Setup
-			free_passphrase(Apsz);
+			free_passphrase(&Apsz);
 			Apsz = strdup(snmp_password);
 
 			// Privacy Protocol Setup
-			free_passphrase(Xpsz);
+			free_passphrase(&Xpsz);
 			Xpsz = strdup(snmp_priv_passphrase);
 
 			if (Apsz) {
@@ -483,8 +485,8 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					free(session.peername);
 					free(session.securityAuthProto);
 					free(session.securityPrivProto);
-					free_passphrase(Apsz);
-					free_passphrase(Xpsz);
+					free_passphrase(&Apsz);
+					free_passphrase(&Xpsz);
 					if (session.localname) {
 						free(session.localname);
 						session.localname = NULL;
@@ -492,8 +494,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					return 0;
 				}
 
-				free_passphrase(Apsz);
-				Apsz = NULL;
+				free_passphrase(&Apsz);
 			}
 
 			if (Xpsz) {
@@ -511,16 +512,19 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 #if defined(HAVE_USM_DES_PRIV_PROTOCOL)
 					session.securityPrivProto = snmp_duplicate_objid(SNMP_DEFAULT_PRIV_PROTO, SNMP_DEFAULT_PRIV_PROTOLEN);
 					session.securityPrivProtoLen = SNMP_DEFAULT_PRIV_PROTOLEN;
-#else
+#elif defined(HAVE_USM_AES_PRIV_PROTOCOL)
 					/* The header names DES as the default but this library does
-					 * not export it, so the macro cannot be referenced. Every
-					 * net-snmp that omits DES provides AES. See #575. */
+					 * not export it, so the macro cannot be referenced. */
 					session.securityPrivProto = snmp_duplicate_objid(usmAESPrivProtocol, USM_PRIV_PROTO_AES_LEN);
 					session.securityPrivProtoLen = USM_PRIV_PROTO_AES_LEN;
+#else
+					SPINE_LOG(("SNMP: Device[%i] Error no supported default privacy protocol is available.", host_id));
+					session.securityPrivProtoLen = 0;
 #endif
 				}
 
-				if (generate_Ku(session.securityAuthProto,
+				if (session.securityPrivProto == NULL ||
+					generate_Ku(session.securityAuthProto,
 					session.securityAuthProtoLen,
 					(u_char *) Xpsz, strlen(Xpsz),
 					session.securityPrivKey,
@@ -529,7 +533,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					free(session.peername);
 					free(session.securityAuthProto);
 					free(session.securityPrivProto);
-					free_passphrase(Xpsz);
+					free_passphrase(&Xpsz);
 					if (session.localname) {
 						free(session.localname);
 						session.localname = NULL;
@@ -537,8 +541,7 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 					return 0;
 				}
 
-				free_passphrase(Xpsz);
-				Xpsz = NULL;
+				free_passphrase(&Xpsz);
 			}
 		}
 

--- a/snmp.c
+++ b/snmp.c
@@ -330,6 +330,17 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; using noAuthNoPriv.", host_id));
 		}
 
+		/* A password with no selected protocol was rejected by the historical
+		 * path. Preserve that fail-closed boundary rather than silently sending
+		 * an unauthenticated request that carries no usable password. */
+		if (!spine_snmpv3_value_is_set(snmp_auth_protocol) &&
+			spine_snmpv3_value_is_set(snmp_password)) {
+			SPINE_LOG(("SNMP: Device[%i] Error authentication password is configured but no authentication protocol is selected.", host_id));
+			free(session.peername);
+			free(session.localname);
+			return 0;
+		}
+
 		if (spine_snmpv3_value_is_set(snmp_priv_protocol) !=
 			spine_snmpv3_value_is_set(snmp_priv_passphrase)) {
 			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; ignoring privacy and sending SNMP payloads without encryption.", host_id));

--- a/snmp.c
+++ b/snmp.c
@@ -333,10 +333,8 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 		security_level = spine_snmpv3_security_level(snmp_auth_protocol, snmp_password,
 			snmp_priv_protocol, snmp_priv_passphrase);
 
-		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol) !=
-			spine_snmpv3_passphrase_is_set(snmp_password)) {
-			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; polling at noAuthNoPriv to match Cacti's effective security level.", host_id));
-		}
+		/* Refusals precede downgrade warnings so the log never promises that a
+		 * device will be polled when this function is about to reject it. */
 		if (spine_snmpv3_passphrase_is_set(snmp_password) &&
 			(snmp_auth_protocol == NULL || snmp_auth_protocol[0] == '\0')) {
 			SPINE_LOG(("SNMP: Device[%i] Error authentication password is set but the authentication protocol is empty.", host_id));
@@ -345,16 +343,33 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 			return 0;
 		}
 
-		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol) !=
-			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
-			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; polling without encryption to match Cacti's effective security level.", host_id));
-		}
 		if (spine_snmpv3_passphrase_is_set(snmp_priv_passphrase) &&
 			(snmp_priv_protocol == NULL || snmp_priv_protocol[0] == '\0')) {
 			SPINE_LOG(("SNMP: Device[%i] Error privacy passphrase is set but the privacy protocol is empty.", host_id));
 			free(session.peername);
 			free(session.localname);
 			return 0;
+		}
+
+		/* Complete privacy credentials with no usable authentication cannot be
+		 * honoured by USM. Refuse that case before describing any downgrade. */
+		if (security_level == SNMP_SEC_LEVEL_NOAUTH &&
+			spine_snmpv3_protocol_is_set(snmp_priv_protocol) &&
+			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
+			SPINE_LOG(("SNMP: Device[%i] Error privacy passphrase is configured but authentication is unavailable; set an auth protocol and password, or clear the privacy passphrase.", host_id));
+			free(session.peername);
+			free(session.localname);
+			return 0;
+		}
+
+		if (spine_snmpv3_protocol_is_set(snmp_auth_protocol) !=
+			spine_snmpv3_passphrase_is_set(snmp_password)) {
+			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete authentication settings; polling at noAuthNoPriv to match Cacti's effective security level.", host_id));
+		}
+
+		if (spine_snmpv3_protocol_is_set(snmp_priv_protocol) !=
+			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
+			SPINE_LOG(("SNMP: Device[%i] WARNING incomplete privacy settings; polling without encryption to match Cacti's effective security level.", host_id));
 		}
 
 		/* A protocol that is set but unrecognised is a configuration error at
@@ -386,19 +401,6 @@ void *snmp_host_init(int host_id, char *hostname, int snmp_version, char *snmp_c
 				free(session.localname);
 				return 0;
 			}
-		}
-
-		/* Complete privacy credentials with no usable authentication cannot be
-		 * honoured by USM. Refuse that case; incomplete privacy fields follow
-		 * Cacti's lower effective level after the warning above. */
-		if (security_level == SNMP_SEC_LEVEL_NOAUTH &&
-			spine_snmpv3_protocol_is_set(snmp_priv_protocol) &&
-			spine_snmpv3_passphrase_is_set(snmp_priv_passphrase)) {
-			SPINE_LOG(("SNMP: Device[%i] Error privacy passphrase is configured but authentication is unavailable; set an auth protocol and password, or clear the privacy passphrase.", host_id));
-			free(session.peername);
-			free(session.localname);
-			free(session.securityAuthProto);
-			return 0;
 		}
 
 		session.securityLevel = security_level;

--- a/spine.h
+++ b/spine.h
@@ -626,6 +626,10 @@ typedef struct db_connection {
 #include "error.h"
 
 /* Globals */
+extern int spine_snmpv3_value_is_set(const char *value);
+extern int spine_snmpv3_security_level(const char *auth_protocol, const char *auth_password,
+	const char *priv_protocol, const char *priv_passphrase);
+
 extern config_t set;
 extern php_t  *php_processes;
 extern char   start_datetime[20];

--- a/spine.h
+++ b/spine.h
@@ -626,7 +626,8 @@ typedef struct db_connection {
 #include "error.h"
 
 /* Globals */
-extern int spine_snmpv3_value_is_set(const char *value);
+extern int spine_snmpv3_protocol_is_set(const char *value);
+extern int spine_snmpv3_passphrase_is_set(const char *value);
 extern int spine_snmpv3_security_level(const char *auth_protocol, const char *auth_password,
 	const char *priv_protocol, const char *priv_passphrase);
 

--- a/tests/unit/test_linked.c
+++ b/tests/unit/test_linked.c
@@ -20,6 +20,10 @@
 #include "util.h"
 #include "ping.h"
 
+#if !defined(ICMP_DEST_UNREACH) && defined(ICMP_UNREACH)
+#define ICMP_DEST_UNREACH ICMP_UNREACH
+#endif
+
 /* provided by tests/fuzz/stubs.c, as spine.c would */
 extern int *debug_devices;
 

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -1,0 +1,137 @@
+/* SNMPv3 session construction.
+ *
+ * spine_snmpv3_security_level() is unit tested elsewhere, but the level it
+ * returns is only half the story: the session also has to install the right
+ * auth protocol and refuse a configuration it cannot honour. Those decisions
+ * live in snmp_host_init(), and until now nothing exercised them.
+ *
+ * snmp_sess_open() builds the session without contacting anything, so this can
+ * assert the resulting securityLevel directly. That is what makes the
+ * difference between pinning what the code does and pinning what it should do.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "common.h"
+#include "spine.h"
+
+static int session_reset(void **state) {
+	(void) state;
+	config_defaults();
+	set.snmp_retries = 1;
+	return 0;
+}
+
+/* Returns the securityLevel of the session spine builds, or -1 when it
+   refuses to build one. */
+static int level_for(char *auth_protocol, char *auth_password,
+	char *priv_protocol, char *priv_passphrase) {
+	char host[] = "127.0.0.1";
+	char user[] = "snmpuser";
+	char ctx[]  = "";
+	char eid[]  = "";
+	struct snmp_session *s;
+	void *sessp;
+	int level;
+
+	sessp = snmp_host_init(1, host, 3, NULL, user, auth_password, auth_protocol,
+		priv_passphrase, priv_protocol, ctx, eid, 161, 500);
+
+	if (sessp == NULL) {
+		return -1;
+	}
+
+	s = snmp_sess_session(sessp);
+	level = s->securityLevel;
+	snmp_sess_close(sessp);
+
+	return level;
+}
+
+/* Cacti writes "[None]" for an unselected protocol. A device with neither
+   authentication nor privacy is noAuthNoPriv, not an error: this is the level
+   that was unusable before #582. */
+static void test_no_credentials_is_noauthnopriv(void **state) {
+	char none[] = "[None]";
+	char empty[] = "";
+
+	(void) state;
+	assert_int_equal(level_for(none, empty, none, empty), SNMP_SEC_LEVEL_NOAUTH);
+}
+
+/* Authentication without privacy is authNoPriv. This was also unusable before
+   #582, because the key was only derived on the privacy path. */
+static void test_auth_without_privacy_is_authnopriv(void **state) {
+	char sha[] = "SHA";
+	char pw[] = "authpass123";
+	char none[] = "[None]";
+	char empty[] = "";
+
+	(void) state;
+	assert_int_equal(level_for(sha, pw, none, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
+}
+
+static void test_auth_with_privacy_is_authpriv(void **state) {
+	char sha[] = "SHA";
+	char pw[] = "authpass123";
+	char aes[] = "AES";
+	char ppass[] = "privpass123";
+
+	(void) state;
+	assert_int_equal(level_for(sha, pw, aes, ppass), SNMP_SEC_LEVEL_AUTHPRIV);
+}
+
+/* USM has no privacy without authentication. Opening this as noAuthNoPriv
+   would leave the operator believing the traffic is encrypted, so it is
+   refused. The old code also refused, but by failing key derivation with a
+   message about passphrase length that named neither cause nor remedy. */
+static void test_privacy_without_auth_is_refused(void **state) {
+	char sha[] = "SHA";
+	char empty[] = "";
+	char aes[] = "AES";
+	char ppass[] = "privpass123";
+
+	(void) state;
+	assert_int_equal(level_for(sha, empty, aes, ppass), -1);
+}
+
+/* An unrecognised protocol is a configuration error at any level. Deciding the
+   level first and validating only on the authenticated path let a typo through
+   as noAuthNoPriv, because a device with no passphrase never reached the check. */
+static void test_unknown_auth_protocol_is_refused_even_without_a_password(void **state) {
+	char bogus[] = "MD6";
+	char empty[] = "";
+	char none[] = "[None]";
+
+	(void) state;
+	assert_int_equal(level_for(bogus, empty, none, empty), -1);
+}
+
+static void test_unknown_auth_protocol_is_refused_with_a_password(void **state) {
+	char bogus[] = "MD6";
+	char pw[] = "authpass123";
+	char none[] = "[None]";
+	char empty[] = "";
+
+	(void) state;
+	assert_int_equal(level_for(bogus, pw, none, empty), -1);
+}
+
+int main(void) {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test_setup(test_no_credentials_is_noauthnopriv, session_reset),
+		cmocka_unit_test_setup(test_auth_without_privacy_is_authnopriv, session_reset),
+		cmocka_unit_test_setup(test_auth_with_privacy_is_authpriv, session_reset),
+		cmocka_unit_test_setup(test_privacy_without_auth_is_refused, session_reset),
+		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_even_without_a_password, session_reset),
+		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_with_a_password, session_reset),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -260,25 +260,25 @@ static void test_unknown_auth_protocol_is_refused_with_a_password(void **state) 
 	assert_int_equal(level_for(bogus, pw, none, empty), -1);
 }
 
-static void test_empty_auth_protocol_with_password_is_refused(void **state) {
+static void test_empty_auth_protocol_with_password_uses_noauth(void **state) {
 	char empty[] = "";
 	char pw[] = "authpass123";
 	char none[] = "[None]";
 
 	(void) state;
-	assert_int_equal(level_for(empty, pw, none, empty), -1);
+	assert_int_equal(level_for(empty, pw, none, empty), SNMP_SEC_LEVEL_NOAUTH);
 }
 
-static void test_none_auth_protocol_with_password_is_refused(void **state) {
+static void test_none_auth_protocol_with_password_uses_noauth(void **state) {
 	char none[] = "[None]";
 	char pw[] = "authpass123";
 	char empty[] = "";
 
 	(void) state;
-	assert_int_equal(level_for(none, pw, none, empty), -1);
+	assert_int_equal(level_for(none, pw, none, empty), SNMP_SEC_LEVEL_NOAUTH);
 }
 
-static void test_auth_protocol_without_password_is_refused(void **state) {
+static void test_auth_protocol_without_password_uses_noauth(void **state) {
 	char *auth = available_auth_protocol();
 	char empty[] = "";
 	char none[] = "[None]";
@@ -287,7 +287,7 @@ static void test_auth_protocol_without_password_is_refused(void **state) {
 	if (auth == NULL) {
 		skip();
 	}
-	assert_int_equal(level_for(auth, empty, none, empty), -1);
+	assert_int_equal(level_for(auth, empty, none, empty), SNMP_SEC_LEVEL_NOAUTH);
 }
 
 static void test_invalid_privacy_protocol_is_refused(void **state) {
@@ -325,7 +325,7 @@ static void test_auth_key_matches_with_and_without_privacy(void **state) {
 	assert_memory_equal(captured_auth_key, authnopriv_key, authnopriv_len);
 }
 
-static void test_privacy_protocol_without_passphrase_is_refused(void **state) {
+static void test_privacy_protocol_without_passphrase_uses_authnopriv(void **state) {
 	char *auth = available_auth_protocol();
 	char pw[] = "authpass123";
 	char *priv = available_priv_protocol();
@@ -335,10 +335,10 @@ static void test_privacy_protocol_without_passphrase_is_refused(void **state) {
 	if (auth == NULL || priv == NULL) {
 		skip();
 	}
-	assert_int_equal(level_for(auth, pw, priv, empty), -1);
+	assert_int_equal(level_for(auth, pw, priv, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
 }
 
-static void test_privacy_passphrase_without_protocol_is_refused(void **state) {
+static void test_privacy_passphrase_without_protocol_uses_authnopriv(void **state) {
 	char *auth = available_auth_protocol();
 	char pw[] = "authpass123";
 	char none[] = "[None]";
@@ -348,10 +348,10 @@ static void test_privacy_passphrase_without_protocol_is_refused(void **state) {
 	if (auth == NULL) {
 		skip();
 	}
-	assert_int_equal(level_for(auth, pw, none, ppass), -1);
+	assert_int_equal(level_for(auth, pw, none, ppass), SNMP_SEC_LEVEL_AUTHNOPRIV);
 }
 
-static void test_privacy_passphrase_without_auth_is_refused(void **state) {
+static void test_stale_privacy_passphrase_without_auth_uses_noauth(void **state) {
 	char *auth = available_auth_protocol();
 	char empty[] = "";
 	char none[] = "[None]";
@@ -361,7 +361,7 @@ static void test_privacy_passphrase_without_auth_is_refused(void **state) {
 	if (auth == NULL) {
 		skip();
 	}
-	assert_int_equal(level_for(auth, empty, none, ppass), -1);
+	assert_int_equal(level_for(auth, empty, none, ppass), SNMP_SEC_LEVEL_NOAUTH);
 }
 
 static void test_session_construction_does_not_modify_caller_passphrases(void **state) {
@@ -389,14 +389,14 @@ int main(void) {
 		cmocka_unit_test_setup(test_privacy_without_auth_is_refused, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_even_without_a_password, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_with_a_password, session_reset),
-		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_is_refused, session_reset),
-		cmocka_unit_test_setup(test_none_auth_protocol_with_password_is_refused, session_reset),
-		cmocka_unit_test_setup(test_auth_protocol_without_password_is_refused, session_reset),
+		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_uses_noauth, session_reset),
+		cmocka_unit_test_setup(test_none_auth_protocol_with_password_uses_noauth, session_reset),
+		cmocka_unit_test_setup(test_auth_protocol_without_password_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_invalid_privacy_protocol_is_refused, session_reset),
 		cmocka_unit_test_setup(test_auth_key_matches_with_and_without_privacy, session_reset),
-		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_is_refused, session_reset),
-		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_is_refused, session_reset),
-		cmocka_unit_test_setup(test_privacy_passphrase_without_auth_is_refused, session_reset),
+		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_uses_authnopriv, session_reset),
+		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_uses_authnopriv, session_reset),
+		cmocka_unit_test_setup(test_stale_privacy_passphrase_without_auth_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_session_construction_does_not_modify_caller_passphrases, session_reset),
 	};
 

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -239,13 +239,76 @@ static void test_unknown_auth_protocol_is_refused_with_a_password(void **state) 
 	assert_int_equal(level_for(bogus, pw, none, empty), -1);
 }
 
-static void test_empty_auth_protocol_with_password_downgrades(void **state) {
+static void test_empty_auth_protocol_with_password_is_refused(void **state) {
 	char empty[] = "";
 	char pw[] = "authpass123";
 	char none[] = "[None]";
 
 	(void) state;
-	assert_int_equal(level_for(empty, pw, none, empty), SNMP_SEC_LEVEL_NOAUTH);
+	assert_int_equal(level_for(empty, pw, none, empty), -1);
+}
+
+static void test_none_auth_protocol_with_password_is_refused(void **state) {
+	char none[] = "[None]";
+	char pw[] = "authpass123";
+	char empty[] = "";
+
+	(void) state;
+	assert_int_equal(level_for(none, pw, none, empty), -1);
+}
+
+static void test_auth_protocol_without_password_installs_selected_oid(void **state) {
+	char *auth = available_auth_protocol();
+	char empty[] = "";
+	char none[] = "[None]";
+	const oid *expected;
+	size_t expected_len;
+
+	(void) state;
+	if (auth == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, empty, none, empty), SNMP_SEC_LEVEL_NOAUTH);
+	expected = sc_get_auth_oid(usm_lookup_auth_type(auth), &expected_len);
+	assert_non_null(expected);
+	assert_int_equal(captured_auth_proto_len, expected_len);
+	assert_int_equal(snmp_oid_compare(captured_auth_proto, captured_auth_proto_len,
+		expected, expected_len), 0);
+}
+
+static void test_invalid_privacy_protocol_is_refused(void **state) {
+	char *auth = available_auth_protocol();
+	char pw[] = "authpass123";
+	char bogus[] = "ROT13";
+	char ppass[] = "privpass123";
+
+	(void) state;
+	if (auth == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, bogus, ppass), -1);
+}
+
+static void test_auth_key_matches_with_and_without_privacy(void **state) {
+	char *auth = available_auth_protocol();
+	char *priv = available_priv_protocol();
+	char pw[] = "authpass123";
+	char none[] = "[None]";
+	char empty[] = "";
+	char ppass[] = "privpass123";
+	unsigned char authnopriv_key[USM_AUTH_KU_LEN];
+	size_t authnopriv_len;
+
+	(void) state;
+	if (auth == NULL || priv == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, none, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
+	authnopriv_len = captured_auth_key_len;
+	memcpy(authnopriv_key, captured_auth_key, authnopriv_len);
+	assert_int_equal(level_for(auth, pw, priv, ppass), SNMP_SEC_LEVEL_AUTHPRIV);
+	assert_int_equal(captured_auth_key_len, authnopriv_len);
+	assert_memory_equal(captured_auth_key, authnopriv_key, authnopriv_len);
 }
 
 static void test_privacy_protocol_without_passphrase_uses_authnopriv(void **state) {
@@ -297,7 +360,11 @@ int main(void) {
 		cmocka_unit_test_setup(test_privacy_without_auth_is_refused, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_even_without_a_password, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_with_a_password, session_reset),
-		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_downgrades, session_reset),
+		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_is_refused, session_reset),
+		cmocka_unit_test_setup(test_none_auth_protocol_with_password_is_refused, session_reset),
+		cmocka_unit_test_setup(test_auth_protocol_without_password_installs_selected_oid, session_reset),
+		cmocka_unit_test_setup(test_invalid_privacy_protocol_is_refused, session_reset),
+		cmocka_unit_test_setup(test_auth_key_matches_with_and_without_privacy, session_reset),
 		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_uses_authnopriv, session_reset),
 		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_uses_authnopriv, session_reset),
 		cmocka_unit_test_setup(test_stale_privacy_passphrase_without_auth_uses_noauth, session_reset),

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -180,8 +180,6 @@ static void test_auth_without_privacy_is_authnopriv(void **state) {
 	char pw[] = "authpass123";
 	char none[] = "[None]";
 	char empty[] = "";
-	const oid *expected;
-	size_t expected_len;
 	const oid *expected_priv;
 	size_t expected_priv_len;
 
@@ -192,16 +190,47 @@ static void test_auth_without_privacy_is_authnopriv(void **state) {
 	assert_int_equal(level_for(auth, pw, none, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
 	assert_true(captured_auth_key_len > 0);
 	assert_true(contains_nonzero(captured_auth_key, captured_auth_key_len));
-	expected = sc_get_auth_oid(usm_lookup_auth_type(auth), &expected_len);
-	assert_non_null(expected);
-	assert_int_equal(captured_auth_proto_len, expected_len);
-	assert_int_equal(snmp_oid_compare(captured_auth_proto, captured_auth_proto_len,
-		expected, expected_len), 0);
 	expected_priv = usmNoPrivProtocol;
 	expected_priv_len = OID_LENGTH(usmNoPrivProtocol);
 	assert_int_equal(captured_priv_proto_len, expected_priv_len);
 	assert_int_equal(snmp_oid_compare(captured_priv_proto, captured_priv_proto_len,
 		expected_priv, expected_priv_len), 0);
+}
+
+static void test_auth_protocol_oids_match_the_selected_algorithms(void **state) {
+	struct auth_case {
+		char *name;
+		const oid *expected;
+		size_t expected_len;
+	};
+	const struct auth_case cases[] = {
+		{ "MD5",    usmHMACMD5AuthProtocol,       OID_LENGTH(usmHMACMD5AuthProtocol) },
+		{ "SHA",    usmHMACSHA1AuthProtocol,      OID_LENGTH(usmHMACSHA1AuthProtocol) },
+		{ "SHA224", usmHMAC128SHA224AuthProtocol, OID_LENGTH(usmHMAC128SHA224AuthProtocol) },
+		{ "SHA256", usmHMAC192SHA256AuthProtocol, OID_LENGTH(usmHMAC192SHA256AuthProtocol) },
+		{ "SHA384", usmHMAC256SHA384AuthProtocol, OID_LENGTH(usmHMAC256SHA384AuthProtocol) },
+		{ "SHA512", usmHMAC384SHA512AuthProtocol, OID_LENGTH(usmHMAC384SHA512AuthProtocol) },
+	};
+	char password[] = "authpass123";
+	char none[] = "[None]";
+	char empty[] = "";
+	size_t i;
+	int exercised = 0;
+
+	(void) state;
+	for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+		if (usm_lookup_auth_type(cases[i].name) <= 0) continue;
+
+		exercised++;
+		assert_int_equal(level_for(cases[i].name, password, none, empty),
+			SNMP_SEC_LEVEL_AUTHNOPRIV);
+		assert_int_equal(captured_auth_proto_len, cases[i].expected_len);
+		assert_int_equal(snmp_oid_compare(captured_auth_proto,
+			captured_auth_proto_len, cases[i].expected,
+			cases[i].expected_len), 0);
+	}
+
+	assert_true(exercised > 0);
 }
 
 static void test_auth_with_privacy_is_authpriv(void **state) {
@@ -412,6 +441,7 @@ int main(void) {
 		cmocka_unit_test_setup(test_security_level_contract, session_reset),
 		cmocka_unit_test_setup(test_no_credentials_is_noauthnopriv, session_reset),
 		cmocka_unit_test_setup(test_auth_without_privacy_is_authnopriv, session_reset),
+		cmocka_unit_test_setup(test_auth_protocol_oids_match_the_selected_algorithms, session_reset),
 		cmocka_unit_test_setup(test_auth_with_privacy_is_authpriv, session_reset),
 		cmocka_unit_test_setup(test_privacy_without_auth_is_refused, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_even_without_a_password, session_reset),

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -84,6 +84,34 @@ static int contains_nonzero(const unsigned char *value, size_t length) {
 	return FALSE;
 }
 
+static char *available_auth_protocol(void) {
+	static char sha[] = "SHA";
+	static char md5[] = "MD5";
+
+	if (usm_lookup_auth_type(sha) > 0) {
+		return sha;
+	}
+	if (usm_lookup_auth_type(md5) > 0) {
+		return md5;
+	}
+
+	return NULL;
+}
+
+static char *available_priv_protocol(void) {
+	static char aes[] = "AES";
+	static char des[] = "DES";
+
+	if (usm_lookup_priv_type(aes) >= 0) {
+		return aes;
+	}
+	if (usm_lookup_priv_type(des) >= 0) {
+		return des;
+	}
+
+	return NULL;
+}
+
 /* Returns the securityLevel of the session spine builds, or -1 when it
    refuses to build one. */
 static int level_for(char *auth_protocol, char *auth_password,
@@ -134,28 +162,38 @@ static void test_no_credentials_is_noauthnopriv(void **state) {
 /* Authentication without privacy is authNoPriv. This was also unusable before
    #582, because the key was only derived on the privacy path. */
 static void test_auth_without_privacy_is_authnopriv(void **state) {
-	char sha[] = "SHA";
+	char *auth = available_auth_protocol();
 	char pw[] = "authpass123";
 	char none[] = "[None]";
 	char empty[] = "";
+	const oid *expected;
+	size_t expected_len;
 
 	(void) state;
-	assert_int_equal(level_for(sha, pw, none, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
+	if (auth == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, none, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
 	assert_true(captured_auth_key_len > 0);
 	assert_true(contains_nonzero(captured_auth_key, captured_auth_key_len));
-	assert_int_equal(captured_auth_proto_len, USM_AUTH_PROTO_SHA_LEN);
+	expected = sc_get_auth_oid(usm_lookup_auth_type(auth), &expected_len);
+	assert_non_null(expected);
+	assert_int_equal(captured_auth_proto_len, expected_len);
 	assert_int_equal(snmp_oid_compare(captured_auth_proto, captured_auth_proto_len,
-		usmHMACSHA1AuthProtocol, USM_AUTH_PROTO_SHA_LEN), 0);
+		expected, expected_len), 0);
 }
 
 static void test_auth_with_privacy_is_authpriv(void **state) {
-	char sha[] = "SHA";
+	char *auth = available_auth_protocol();
 	char pw[] = "authpass123";
-	char aes[] = "AES";
+	char *priv = available_priv_protocol();
 	char ppass[] = "privpass123";
 
 	(void) state;
-	assert_int_equal(level_for(sha, pw, aes, ppass), SNMP_SEC_LEVEL_AUTHPRIV);
+	if (auth == NULL || priv == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, priv, ppass), SNMP_SEC_LEVEL_AUTHPRIV);
 	assert_true(captured_auth_key_len > 0);
 	assert_true(contains_nonzero(captured_auth_key, captured_auth_key_len));
 	assert_true(captured_priv_key_len > 0);
@@ -167,13 +205,16 @@ static void test_auth_with_privacy_is_authpriv(void **state) {
    refused. The old code also refused, but by failing key derivation with a
    message about passphrase length that named neither cause nor remedy. */
 static void test_privacy_without_auth_is_refused(void **state) {
-	char sha[] = "SHA";
+	char *auth = available_auth_protocol();
 	char empty[] = "";
-	char aes[] = "AES";
+	char *priv = available_priv_protocol();
 	char ppass[] = "privpass123";
 
 	(void) state;
-	assert_int_equal(level_for(sha, empty, aes, ppass), -1);
+	if (auth == NULL || priv == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, empty, priv, ppass), -1);
 }
 
 /* An unrecognised protocol is a configuration error at any level. Deciding the
@@ -207,14 +248,30 @@ static void test_empty_auth_protocol_with_password_downgrades(void **state) {
 	assert_int_equal(level_for(empty, pw, none, empty), SNMP_SEC_LEVEL_NOAUTH);
 }
 
-static void test_privacy_protocol_without_passphrase_is_refused(void **state) {
-	char sha[] = "SHA";
+static void test_privacy_protocol_without_passphrase_uses_authnopriv(void **state) {
+	char *auth = available_auth_protocol();
 	char pw[] = "authpass123";
-	char aes[] = "AES";
+	char *priv = available_priv_protocol();
 	char empty[] = "";
 
 	(void) state;
-	assert_int_equal(level_for(sha, pw, aes, empty), -1);
+	if (auth == NULL || priv == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, priv, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
+}
+
+static void test_privacy_passphrase_without_protocol_uses_authnopriv(void **state) {
+	char *auth = available_auth_protocol();
+	char pw[] = "authpass123";
+	char none[] = "[None]";
+	char ppass[] = "privpass123";
+
+	(void) state;
+	if (auth == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, none, ppass), SNMP_SEC_LEVEL_AUTHNOPRIV);
 }
 
 int main(void) {
@@ -228,7 +285,8 @@ int main(void) {
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_even_without_a_password, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_with_a_password, session_reset),
 		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_downgrades, session_reset),
-		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_is_refused, session_reset),
+		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_uses_authnopriv, session_reset),
+		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_uses_authnopriv, session_reset),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -274,6 +274,19 @@ static void test_privacy_passphrase_without_protocol_uses_authnopriv(void **stat
 	assert_int_equal(level_for(auth, pw, none, ppass), SNMP_SEC_LEVEL_AUTHNOPRIV);
 }
 
+static void test_stale_privacy_passphrase_without_auth_uses_noauth(void **state) {
+	char *auth = available_auth_protocol();
+	char empty[] = "";
+	char none[] = "[None]";
+	char ppass[] = "privpass123";
+
+	(void) state;
+	if (auth == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, empty, none, ppass), SNMP_SEC_LEVEL_NOAUTH);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test_setup(test_value_presence_contract, session_reset),
@@ -287,6 +300,7 @@ int main(void) {
 		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_downgrades, session_reset),
 		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_uses_authnopriv, session_reset),
 		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_uses_authnopriv, session_reset),
+		cmocka_unit_test_setup(test_stale_privacy_passphrase_without_auth_uses_noauth, session_reset),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -204,12 +204,18 @@ static void test_auth_protocol_oids_match_the_selected_algorithms(void **state) 
 		size_t expected_len;
 	};
 	const struct auth_case cases[] = {
+		#ifndef NETSNMP_DISABLE_MD5
 		{ "MD5",    usmHMACMD5AuthProtocol,       OID_LENGTH(usmHMACMD5AuthProtocol) },
+		#endif
 		{ "SHA",    usmHMACSHA1AuthProtocol,      OID_LENGTH(usmHMACSHA1AuthProtocol) },
+		#ifdef HAVE_EVP_SHA224
 		{ "SHA224", usmHMAC128SHA224AuthProtocol, OID_LENGTH(usmHMAC128SHA224AuthProtocol) },
 		{ "SHA256", usmHMAC192SHA256AuthProtocol, OID_LENGTH(usmHMAC192SHA256AuthProtocol) },
+		#endif
+		#ifdef HAVE_EVP_SHA384
 		{ "SHA384", usmHMAC256SHA384AuthProtocol, OID_LENGTH(usmHMAC256SHA384AuthProtocol) },
 		{ "SHA512", usmHMAC384SHA512AuthProtocol, OID_LENGTH(usmHMAC384SHA512AuthProtocol) },
+		#endif
 	};
 	char password[] = "authpass123";
 	char none[] = "[None]";

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -25,9 +25,11 @@ static int captured_security_level;
 static size_t captured_auth_key_len;
 static size_t captured_priv_key_len;
 static size_t captured_auth_proto_len;
+static size_t captured_priv_proto_len;
 static unsigned char captured_auth_key[USM_AUTH_KU_LEN];
 static unsigned char captured_priv_key[USM_PRIV_KU_LEN];
 static oid captured_auth_proto[MAX_OID_LEN];
+static oid captured_priv_proto[MAX_OID_LEN];
 
 static void *capture_snmp_sess_open(struct snmp_session *session);
 
@@ -40,9 +42,11 @@ static void *capture_snmp_sess_open(struct snmp_session *session) {
 	captured_auth_key_len = session->securityAuthKeyLen;
 	captured_priv_key_len = session->securityPrivKeyLen;
 	captured_auth_proto_len = session->securityAuthProtoLen;
+	captured_priv_proto_len = session->securityPrivProtoLen;
 	assert_true(captured_auth_key_len <= sizeof(captured_auth_key));
 	assert_true(captured_priv_key_len <= sizeof(captured_priv_key));
 	assert_true(captured_auth_proto_len <= MAX_OID_LEN);
+	assert_true(captured_priv_proto_len <= MAX_OID_LEN);
 	if (captured_auth_key_len > 0) {
 		memcpy(captured_auth_key, session->securityAuthKey, captured_auth_key_len);
 	}
@@ -53,6 +57,11 @@ static void *capture_snmp_sess_open(struct snmp_session *session) {
 		assert_non_null(session->securityAuthProto);
 		memcpy(captured_auth_proto, session->securityAuthProto,
 			captured_auth_proto_len * sizeof(*captured_auth_proto));
+	}
+	if (captured_priv_proto_len > 0) {
+		assert_non_null(session->securityPrivProto);
+		memcpy(captured_priv_proto, session->securityPrivProto,
+			captured_priv_proto_len * sizeof(*captured_priv_proto));
 	}
 	return (void *)(uintptr_t) 1;
 }
@@ -66,9 +75,11 @@ static int session_reset(void **state) {
 	captured_auth_key_len = 0;
 	captured_priv_key_len = 0;
 	captured_auth_proto_len = 0;
+	captured_priv_proto_len = 0;
 	memset(captured_auth_key, 0, sizeof(captured_auth_key));
 	memset(captured_priv_key, 0, sizeof(captured_priv_key));
 	memset(captured_auth_proto, 0, sizeof(captured_auth_proto));
+	memset(captured_priv_proto, 0, sizeof(captured_priv_proto));
 	return 0;
 }
 
@@ -134,10 +145,13 @@ static int level_for(char *auth_protocol, char *auth_password,
 
 static void test_value_presence_contract(void **state) {
 	(void) state;
-	assert_false(spine_snmpv3_value_is_set(NULL));
-	assert_false(spine_snmpv3_value_is_set(""));
-	assert_false(spine_snmpv3_value_is_set("[None]"));
-	assert_true(spine_snmpv3_value_is_set("SHA"));
+	assert_false(spine_snmpv3_protocol_is_set(NULL));
+	assert_false(spine_snmpv3_protocol_is_set(""));
+	assert_false(spine_snmpv3_protocol_is_set("[None]"));
+	assert_true(spine_snmpv3_protocol_is_set("SHA"));
+	assert_false(spine_snmpv3_passphrase_is_set(NULL));
+	assert_false(spine_snmpv3_passphrase_is_set(""));
+	assert_true(spine_snmpv3_passphrase_is_set("[None]"));
 }
 
 static void test_security_level_contract(void **state) {
@@ -168,6 +182,8 @@ static void test_auth_without_privacy_is_authnopriv(void **state) {
 	char empty[] = "";
 	const oid *expected;
 	size_t expected_len;
+	const oid *expected_priv;
+	size_t expected_priv_len;
 
 	(void) state;
 	if (auth == NULL) {
@@ -181,6 +197,11 @@ static void test_auth_without_privacy_is_authnopriv(void **state) {
 	assert_int_equal(captured_auth_proto_len, expected_len);
 	assert_int_equal(snmp_oid_compare(captured_auth_proto, captured_auth_proto_len,
 		expected, expected_len), 0);
+	expected_priv = usmNoPrivProtocol;
+	expected_priv_len = OID_LENGTH(usmNoPrivProtocol);
+	assert_int_equal(captured_priv_proto_len, expected_priv_len);
+	assert_int_equal(snmp_oid_compare(captured_priv_proto, captured_priv_proto_len,
+		expected_priv, expected_priv_len), 0);
 }
 
 static void test_auth_with_privacy_is_authpriv(void **state) {
@@ -257,23 +278,16 @@ static void test_none_auth_protocol_with_password_is_refused(void **state) {
 	assert_int_equal(level_for(none, pw, none, empty), -1);
 }
 
-static void test_auth_protocol_without_password_installs_selected_oid(void **state) {
+static void test_auth_protocol_without_password_is_refused(void **state) {
 	char *auth = available_auth_protocol();
 	char empty[] = "";
 	char none[] = "[None]";
-	const oid *expected;
-	size_t expected_len;
 
 	(void) state;
 	if (auth == NULL) {
 		skip();
 	}
-	assert_int_equal(level_for(auth, empty, none, empty), SNMP_SEC_LEVEL_NOAUTH);
-	expected = sc_get_auth_oid(usm_lookup_auth_type(auth), &expected_len);
-	assert_non_null(expected);
-	assert_int_equal(captured_auth_proto_len, expected_len);
-	assert_int_equal(snmp_oid_compare(captured_auth_proto, captured_auth_proto_len,
-		expected, expected_len), 0);
+	assert_int_equal(level_for(auth, empty, none, empty), -1);
 }
 
 static void test_invalid_privacy_protocol_is_refused(void **state) {
@@ -311,7 +325,7 @@ static void test_auth_key_matches_with_and_without_privacy(void **state) {
 	assert_memory_equal(captured_auth_key, authnopriv_key, authnopriv_len);
 }
 
-static void test_privacy_protocol_without_passphrase_uses_authnopriv(void **state) {
+static void test_privacy_protocol_without_passphrase_is_refused(void **state) {
 	char *auth = available_auth_protocol();
 	char pw[] = "authpass123";
 	char *priv = available_priv_protocol();
@@ -321,10 +335,10 @@ static void test_privacy_protocol_without_passphrase_uses_authnopriv(void **stat
 	if (auth == NULL || priv == NULL) {
 		skip();
 	}
-	assert_int_equal(level_for(auth, pw, priv, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
+	assert_int_equal(level_for(auth, pw, priv, empty), -1);
 }
 
-static void test_privacy_passphrase_without_protocol_uses_authnopriv(void **state) {
+static void test_privacy_passphrase_without_protocol_is_refused(void **state) {
 	char *auth = available_auth_protocol();
 	char pw[] = "authpass123";
 	char none[] = "[None]";
@@ -334,10 +348,10 @@ static void test_privacy_passphrase_without_protocol_uses_authnopriv(void **stat
 	if (auth == NULL) {
 		skip();
 	}
-	assert_int_equal(level_for(auth, pw, none, ppass), SNMP_SEC_LEVEL_AUTHNOPRIV);
+	assert_int_equal(level_for(auth, pw, none, ppass), -1);
 }
 
-static void test_stale_privacy_passphrase_without_auth_uses_noauth(void **state) {
+static void test_privacy_passphrase_without_auth_is_refused(void **state) {
 	char *auth = available_auth_protocol();
 	char empty[] = "";
 	char none[] = "[None]";
@@ -347,7 +361,22 @@ static void test_stale_privacy_passphrase_without_auth_uses_noauth(void **state)
 	if (auth == NULL) {
 		skip();
 	}
-	assert_int_equal(level_for(auth, empty, none, ppass), SNMP_SEC_LEVEL_NOAUTH);
+	assert_int_equal(level_for(auth, empty, none, ppass), -1);
+}
+
+static void test_session_construction_does_not_modify_caller_passphrases(void **state) {
+	char *auth = available_auth_protocol();
+	char *priv = available_priv_protocol();
+	char pw[] = "authpass123";
+	char ppass[] = "privpass123";
+
+	(void) state;
+	if (auth == NULL || priv == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, priv, ppass), SNMP_SEC_LEVEL_AUTHPRIV);
+	assert_string_equal(pw, "authpass123");
+	assert_string_equal(ppass, "privpass123");
 }
 
 int main(void) {
@@ -362,12 +391,13 @@ int main(void) {
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_with_a_password, session_reset),
 		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_is_refused, session_reset),
 		cmocka_unit_test_setup(test_none_auth_protocol_with_password_is_refused, session_reset),
-		cmocka_unit_test_setup(test_auth_protocol_without_password_installs_selected_oid, session_reset),
+		cmocka_unit_test_setup(test_auth_protocol_without_password_is_refused, session_reset),
 		cmocka_unit_test_setup(test_invalid_privacy_protocol_is_refused, session_reset),
 		cmocka_unit_test_setup(test_auth_key_matches_with_and_without_privacy, session_reset),
-		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_uses_authnopriv, session_reset),
-		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_uses_authnopriv, session_reset),
-		cmocka_unit_test_setup(test_stale_privacy_passphrase_without_auth_uses_noauth, session_reset),
+		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_is_refused, session_reset),
+		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_is_refused, session_reset),
+		cmocka_unit_test_setup(test_privacy_passphrase_without_auth_is_refused, session_reset),
+		cmocka_unit_test_setup(test_session_construction_does_not_modify_caller_passphrases, session_reset),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -454,6 +454,23 @@ static void test_authnopriv_does_not_modify_caller_password(void **state) {
 	assert_string_equal(pw, "authpass123");
 }
 
+static void test_multi_get_refuses_a_missing_session(void **state) {
+	host_t host;
+	target_t item;
+	snmp_oids_t request;
+
+	(void) state;
+	memset(&host, 0, sizeof(host));
+	memset(&item, 0, sizeof(item));
+	memset(&request, 0, sizeof(request));
+	strcpy(request.result, "pending");
+
+	snmp_get_multi(&host, &item, &request, 1);
+
+	assert_true(host.ignore_host);
+	assert_true(IS_UNDEFINED(request.result));
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test_setup(test_value_presence_contract, session_reset),
@@ -477,6 +494,7 @@ int main(void) {
 		cmocka_unit_test_setup(test_stale_privacy_passphrase_without_auth_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_session_construction_does_not_modify_caller_passphrases, session_reset),
 		cmocka_unit_test_setup(test_authnopriv_does_not_modify_caller_password, session_reset),
+		cmocka_unit_test_setup(test_multi_get_refuses_a_missing_session, session_reset),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -260,13 +260,13 @@ static void test_unknown_auth_protocol_is_refused_with_a_password(void **state) 
 	assert_int_equal(level_for(bogus, pw, none, empty), -1);
 }
 
-static void test_empty_auth_protocol_with_password_uses_noauth(void **state) {
+static void test_empty_auth_protocol_with_password_is_refused(void **state) {
 	char empty[] = "";
 	char pw[] = "authpass123";
 	char none[] = "[None]";
 
 	(void) state;
-	assert_int_equal(level_for(empty, pw, none, empty), SNMP_SEC_LEVEL_NOAUTH);
+	assert_int_equal(level_for(empty, pw, none, empty), -1);
 }
 
 static void test_none_auth_protocol_with_password_uses_noauth(void **state) {
@@ -351,6 +351,19 @@ static void test_privacy_passphrase_without_protocol_uses_authnopriv(void **stat
 	assert_int_equal(level_for(auth, pw, none, ppass), SNMP_SEC_LEVEL_AUTHNOPRIV);
 }
 
+static void test_privacy_passphrase_with_empty_protocol_is_refused(void **state) {
+	char *auth = available_auth_protocol();
+	char pw[] = "authpass123";
+	char empty[] = "";
+	char ppass[] = "privpass123";
+
+	(void) state;
+	if (auth == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, empty, ppass), -1);
+}
+
 static void test_stale_privacy_passphrase_without_auth_uses_noauth(void **state) {
 	char *auth = available_auth_protocol();
 	char empty[] = "";
@@ -379,6 +392,20 @@ static void test_session_construction_does_not_modify_caller_passphrases(void **
 	assert_string_equal(ppass, "privpass123");
 }
 
+static void test_authnopriv_does_not_modify_caller_password(void **state) {
+	char *auth = available_auth_protocol();
+	char pw[] = "authpass123";
+	char none[] = "[None]";
+	char empty[] = "";
+
+	(void) state;
+	if (auth == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, none, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
+	assert_string_equal(pw, "authpass123");
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test_setup(test_value_presence_contract, session_reset),
@@ -389,15 +416,17 @@ int main(void) {
 		cmocka_unit_test_setup(test_privacy_without_auth_is_refused, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_even_without_a_password, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_with_a_password, session_reset),
-		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_uses_noauth, session_reset),
+		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_is_refused, session_reset),
 		cmocka_unit_test_setup(test_none_auth_protocol_with_password_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_auth_protocol_without_password_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_invalid_privacy_protocol_is_refused, session_reset),
 		cmocka_unit_test_setup(test_auth_key_matches_with_and_without_privacy, session_reset),
 		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_uses_authnopriv, session_reset),
 		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_uses_authnopriv, session_reset),
+		cmocka_unit_test_setup(test_privacy_passphrase_with_empty_protocol_is_refused, session_reset),
 		cmocka_unit_test_setup(test_stale_privacy_passphrase_without_auth_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_session_construction_does_not_modify_caller_passphrases, session_reset),
+		cmocka_unit_test_setup(test_authnopriv_does_not_modify_caller_password, session_reset),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -338,7 +338,7 @@ static void test_invalid_privacy_protocol_is_refused(void **state) {
 	assert_int_equal(level_for(auth, pw, bogus, ppass), -1);
 }
 
-static void test_invalid_privacy_protocol_is_refused_without_a_passphrase(void **state) {
+static void test_unused_privacy_protocol_does_not_block_authnopriv(void **state) {
 	char *auth = available_auth_protocol();
 	char pw[] = "authpass123";
 	char bogus[] = "ROT13";
@@ -348,7 +348,7 @@ static void test_invalid_privacy_protocol_is_refused_without_a_passphrase(void *
 	if (auth == NULL) {
 		skip();
 	}
-	assert_int_equal(level_for(auth, pw, bogus, empty), -1);
+	assert_int_equal(level_for(auth, pw, bogus, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
 }
 
 static void test_auth_key_matches_with_and_without_privacy(void **state) {
@@ -469,7 +469,7 @@ int main(void) {
 		cmocka_unit_test_setup(test_none_auth_protocol_with_password_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_auth_protocol_without_password_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_invalid_privacy_protocol_is_refused, session_reset),
-		cmocka_unit_test_setup(test_invalid_privacy_protocol_is_refused_without_a_passphrase, session_reset),
+		cmocka_unit_test_setup(test_unused_privacy_protocol_does_not_block_authnopriv, session_reset),
 		cmocka_unit_test_setup(test_auth_key_matches_with_and_without_privacy, session_reset),
 		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_uses_authnopriv, session_reset),
 		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_uses_authnopriv, session_reset),

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -463,7 +463,7 @@ static void test_multi_get_refuses_a_missing_session(void **state) {
 	memset(&host, 0, sizeof(host));
 	memset(&item, 0, sizeof(item));
 	memset(&request, 0, sizeof(request));
-	strcpy(request.result, "pending");
+	snprintf(request.result, sizeof(request.result), "pending");
 
 	snmp_get_multi(&host, &item, &request, 1);
 

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -1,13 +1,13 @@
 /* SNMPv3 session construction.
  *
- * spine_snmpv3_security_level() is unit tested elsewhere, but the level it
- * returns is only half the story: the session also has to install the right
+ * The security-level predicates and the session they drive both need coverage:
+ * the session also has to install the right
  * auth protocol and refuse a configuration it cannot honour. Those decisions
  * live in snmp_host_init(), and until now nothing exercised them.
  *
- * snmp_sess_open() builds the session without contacting anything, so this can
- * assert the resulting securityLevel directly. That is what makes the
- * difference between pinning what the code does and pinning what it should do.
+ * The shipped snmp.c is compiled into this test with snmp_sess_open()
+ * intercepted. That captures the completed structure before any engine-ID
+ * discovery or network I/O and keeps the assertions deterministic.
  */
 
 #include <stdarg.h>
@@ -21,10 +21,25 @@
 #include "common.h"
 #include "spine.h"
 
+static int captured_security_level;
+
+static void *capture_snmp_sess_open(struct snmp_session *session);
+
+#define snmp_sess_open capture_snmp_sess_open
+#include "../../snmp.c"
+#undef snmp_sess_open
+
+static void *capture_snmp_sess_open(struct snmp_session *session) {
+	captured_security_level = session->securityLevel;
+	return (void *)(uintptr_t) 1;
+}
+
 static int session_reset(void **state) {
 	(void) state;
 	config_defaults();
+	init_mutexes();
 	set.snmp_retries = 1;
+	captured_security_level = -1;
 	return 0;
 }
 
@@ -36,9 +51,7 @@ static int level_for(char *auth_protocol, char *auth_password,
 	char user[] = "snmpuser";
 	char ctx[]  = "";
 	char eid[]  = "";
-	struct snmp_session *s;
 	void *sessp;
-	int level;
 
 	sessp = snmp_host_init(1, host, 3, NULL, user, auth_password, auth_protocol,
 		priv_passphrase, priv_protocol, ctx, eid, 161, 500);
@@ -47,11 +60,23 @@ static int level_for(char *auth_protocol, char *auth_password,
 		return -1;
 	}
 
-	s = snmp_sess_session(sessp);
-	level = s->securityLevel;
-	snmp_sess_close(sessp);
+	return captured_security_level;
+}
 
-	return level;
+static void test_value_presence_contract(void **state) {
+	(void) state;
+	assert_false(spine_snmpv3_value_is_set(NULL));
+	assert_false(spine_snmpv3_value_is_set(""));
+	assert_false(spine_snmpv3_value_is_set("[None]"));
+	assert_true(spine_snmpv3_value_is_set("SHA"));
+}
+
+static void test_security_level_contract(void **state) {
+	(void) state;
+	assert_int_equal(spine_snmpv3_security_level("[None]", "", "[None]", ""), SNMP_SEC_LEVEL_NOAUTH);
+	assert_int_equal(spine_snmpv3_security_level("SHA", "authpass123", "[None]", ""), SNMP_SEC_LEVEL_AUTHNOPRIV);
+	assert_int_equal(spine_snmpv3_security_level("SHA", "authpass123", "AES", "privpass123"), SNMP_SEC_LEVEL_AUTHPRIV);
+	assert_int_equal(spine_snmpv3_security_level("SHA", "", "AES", "privpass123"), SNMP_SEC_LEVEL_NOAUTH);
 }
 
 /* Cacti writes "[None]" for an unselected protocol. A device with neither
@@ -123,14 +148,37 @@ static void test_unknown_auth_protocol_is_refused_with_a_password(void **state) 
 	assert_int_equal(level_for(bogus, pw, none, empty), -1);
 }
 
+static void test_empty_auth_protocol_with_password_downgrades(void **state) {
+	char empty[] = "";
+	char pw[] = "authpass123";
+	char none[] = "[None]";
+
+	(void) state;
+	assert_int_equal(level_for(empty, pw, none, empty), SNMP_SEC_LEVEL_NOAUTH);
+}
+
+static void test_privacy_protocol_without_passphrase_downgrades(void **state) {
+	char sha[] = "SHA";
+	char pw[] = "authpass123";
+	char aes[] = "AES";
+	char empty[] = "";
+
+	(void) state;
+	assert_int_equal(level_for(sha, pw, aes, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
+		cmocka_unit_test_setup(test_value_presence_contract, session_reset),
+		cmocka_unit_test_setup(test_security_level_contract, session_reset),
 		cmocka_unit_test_setup(test_no_credentials_is_noauthnopriv, session_reset),
 		cmocka_unit_test_setup(test_auth_without_privacy_is_authnopriv, session_reset),
 		cmocka_unit_test_setup(test_auth_with_privacy_is_authpriv, session_reset),
 		cmocka_unit_test_setup(test_privacy_without_auth_is_refused, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_even_without_a_password, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_with_a_password, session_reset),
+		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_downgrades, session_reset),
+		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_downgrades, session_reset),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -338,6 +338,19 @@ static void test_invalid_privacy_protocol_is_refused(void **state) {
 	assert_int_equal(level_for(auth, pw, bogus, ppass), -1);
 }
 
+static void test_invalid_privacy_protocol_is_refused_without_a_passphrase(void **state) {
+	char *auth = available_auth_protocol();
+	char pw[] = "authpass123";
+	char bogus[] = "ROT13";
+	char empty[] = "";
+
+	(void) state;
+	if (auth == NULL) {
+		skip();
+	}
+	assert_int_equal(level_for(auth, pw, bogus, empty), -1);
+}
+
 static void test_auth_key_matches_with_and_without_privacy(void **state) {
 	char *auth = available_auth_protocol();
 	char *priv = available_priv_protocol();
@@ -456,6 +469,7 @@ int main(void) {
 		cmocka_unit_test_setup(test_none_auth_protocol_with_password_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_auth_protocol_without_password_uses_noauth, session_reset),
 		cmocka_unit_test_setup(test_invalid_privacy_protocol_is_refused, session_reset),
+		cmocka_unit_test_setup(test_invalid_privacy_protocol_is_refused_without_a_passphrase, session_reset),
 		cmocka_unit_test_setup(test_auth_key_matches_with_and_without_privacy, session_reset),
 		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_uses_authnopriv, session_reset),
 		cmocka_unit_test_setup(test_privacy_passphrase_without_protocol_uses_authnopriv, session_reset),

--- a/tests/unit/test_snmpv3_session.c
+++ b/tests/unit/test_snmpv3_session.c
@@ -22,6 +22,12 @@
 #include "spine.h"
 
 static int captured_security_level;
+static size_t captured_auth_key_len;
+static size_t captured_priv_key_len;
+static size_t captured_auth_proto_len;
+static unsigned char captured_auth_key[USM_AUTH_KU_LEN];
+static unsigned char captured_priv_key[USM_PRIV_KU_LEN];
+static oid captured_auth_proto[MAX_OID_LEN];
 
 static void *capture_snmp_sess_open(struct snmp_session *session);
 
@@ -31,6 +37,23 @@ static void *capture_snmp_sess_open(struct snmp_session *session);
 
 static void *capture_snmp_sess_open(struct snmp_session *session) {
 	captured_security_level = session->securityLevel;
+	captured_auth_key_len = session->securityAuthKeyLen;
+	captured_priv_key_len = session->securityPrivKeyLen;
+	captured_auth_proto_len = session->securityAuthProtoLen;
+	assert_true(captured_auth_key_len <= sizeof(captured_auth_key));
+	assert_true(captured_priv_key_len <= sizeof(captured_priv_key));
+	assert_true(captured_auth_proto_len <= MAX_OID_LEN);
+	if (captured_auth_key_len > 0) {
+		memcpy(captured_auth_key, session->securityAuthKey, captured_auth_key_len);
+	}
+	if (captured_priv_key_len > 0) {
+		memcpy(captured_priv_key, session->securityPrivKey, captured_priv_key_len);
+	}
+	if (captured_auth_proto_len > 0) {
+		assert_non_null(session->securityAuthProto);
+		memcpy(captured_auth_proto, session->securityAuthProto,
+			captured_auth_proto_len * sizeof(*captured_auth_proto));
+	}
 	return (void *)(uintptr_t) 1;
 }
 
@@ -40,7 +63,25 @@ static int session_reset(void **state) {
 	init_mutexes();
 	set.snmp_retries = 1;
 	captured_security_level = -1;
+	captured_auth_key_len = 0;
+	captured_priv_key_len = 0;
+	captured_auth_proto_len = 0;
+	memset(captured_auth_key, 0, sizeof(captured_auth_key));
+	memset(captured_priv_key, 0, sizeof(captured_priv_key));
+	memset(captured_auth_proto, 0, sizeof(captured_auth_proto));
 	return 0;
+}
+
+static int contains_nonzero(const unsigned char *value, size_t length) {
+	size_t i;
+
+	for (i = 0; i < length; i++) {
+		if (value[i] != 0) {
+			return TRUE;
+		}
+	}
+
+	return FALSE;
 }
 
 /* Returns the securityLevel of the session spine builds, or -1 when it
@@ -100,6 +141,11 @@ static void test_auth_without_privacy_is_authnopriv(void **state) {
 
 	(void) state;
 	assert_int_equal(level_for(sha, pw, none, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
+	assert_true(captured_auth_key_len > 0);
+	assert_true(contains_nonzero(captured_auth_key, captured_auth_key_len));
+	assert_int_equal(captured_auth_proto_len, USM_AUTH_PROTO_SHA_LEN);
+	assert_int_equal(snmp_oid_compare(captured_auth_proto, captured_auth_proto_len,
+		usmHMACSHA1AuthProtocol, USM_AUTH_PROTO_SHA_LEN), 0);
 }
 
 static void test_auth_with_privacy_is_authpriv(void **state) {
@@ -110,6 +156,10 @@ static void test_auth_with_privacy_is_authpriv(void **state) {
 
 	(void) state;
 	assert_int_equal(level_for(sha, pw, aes, ppass), SNMP_SEC_LEVEL_AUTHPRIV);
+	assert_true(captured_auth_key_len > 0);
+	assert_true(contains_nonzero(captured_auth_key, captured_auth_key_len));
+	assert_true(captured_priv_key_len > 0);
+	assert_true(contains_nonzero(captured_priv_key, captured_priv_key_len));
 }
 
 /* USM has no privacy without authentication. Opening this as noAuthNoPriv
@@ -157,14 +207,14 @@ static void test_empty_auth_protocol_with_password_downgrades(void **state) {
 	assert_int_equal(level_for(empty, pw, none, empty), SNMP_SEC_LEVEL_NOAUTH);
 }
 
-static void test_privacy_protocol_without_passphrase_downgrades(void **state) {
+static void test_privacy_protocol_without_passphrase_is_refused(void **state) {
 	char sha[] = "SHA";
 	char pw[] = "authpass123";
 	char aes[] = "AES";
 	char empty[] = "";
 
 	(void) state;
-	assert_int_equal(level_for(sha, pw, aes, empty), SNMP_SEC_LEVEL_AUTHNOPRIV);
+	assert_int_equal(level_for(sha, pw, aes, empty), -1);
 }
 
 int main(void) {
@@ -178,7 +228,7 @@ int main(void) {
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_even_without_a_password, session_reset),
 		cmocka_unit_test_setup(test_unknown_auth_protocol_is_refused_with_a_password, session_reset),
 		cmocka_unit_test_setup(test_empty_auth_protocol_with_password_downgrades, session_reset),
-		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_downgrades, session_reset),
+		cmocka_unit_test_setup(test_privacy_protocol_without_passphrase_is_refused, session_reset),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Extracted from #597 into a focused SNMPv3 correctness and safety change.

This restores noAuthNoPriv and authNoPriv session construction, derives authentication keys on the authNoPriv path, validates configured algorithms when they are used, wipes temporary passphrase copies, and makes the effective security-level decision agree with Cacti. It also prevents a failed mid-loop session rebuild from passing NULL into Net-SNMP multi-get.

Compatibility and failure policy:
- [None] is the explicit no-protocol sentinel; stale passphrases paired with it downgrade with a warning to the Cacti effective level.
- A selected protocol missing its passphrase downgrades with an explicit warning, preserving existing polling behavior.
- A blank protocol field paired with a passphrase is ambiguous and now fails closed with an error.
- Complete privacy credentials without usable authentication fail closed because USM cannot honor privacy without authentication.
- Unknown authentication algorithms fail closed instead of silently substituting a default; unused privacy algorithms do not block authNoPriv.

Verification:
- warning-enabled C99 build on macOS arm64
- make check: all 5 suites passed
- deterministic SNMPv3 session suite: 22/22 pass, including literal OID mapping, effective-level combinations, refusal paths, key derivation, caller-buffer ownership, and NULL multi-get handling
- mandatory independent pre-push review: PASS

Closes #582
Refs #597